### PR TITLE
s/constuct/construct/g

### DIFF
--- a/scanomatic/data_processing/calibration.py
+++ b/scanomatic/data_processing/calibration.py
@@ -1274,7 +1274,7 @@ def add_external_data_to_ccc(identifier, data_file, report):
 
 
 @_validate_ccc_edit_request
-def constuct_polynomial(identifier, poly_name, power):
+def construct_polynomial(identifier, poly_name, power):
 
     ccc = __CCC[identifier]
     data_store = _collect_all_included_data(ccc)

--- a/scanomatic/data_processing/test/test_calibration.py
+++ b/scanomatic/data_processing/test/test_calibration.py
@@ -229,7 +229,7 @@ class TestEditCCC:
         power = 5
         token = 'password'
 
-        response = calibration.constuct_polynomial(
+        response = calibration.construct_polynomial(
             identifier, poly_name, power, access_token=token)
 
         assert (
@@ -245,7 +245,7 @@ class TestEditCCC:
         token = 'password'
         print(identifier)
 
-        response = calibration.constuct_polynomial(
+        response = calibration.construct_polynomial(
             identifier, poly_name, power, access_token=token)
 
         assert (
@@ -323,7 +323,7 @@ class TestActivateCCC:
         poly_name = 'test'
         power = 5
 
-        response = calibration.constuct_polynomial(
+        response = calibration.construct_polynomial(
             identifier, poly_name, power, access_token=token)
 
         assert response is None, "Could edit active CCC but shouldn't have"

--- a/scanomatic/ui_server/calibration_api.py
+++ b/scanomatic/ui_server/calibration_api.py
@@ -840,7 +840,7 @@ def add_routes(app):
                 reason="Name is containing invalid characters"
             )
 
-        response = calibration.constuct_polynomial(
+        response = calibration.construct_polynomial(
             ccc_identifier,
             poly_name,
             power,


### PR DESCRIPTION
Function for constructing (and, as I understand it, adding it to the CCC) a polynomial was misspelled, which causes some confusion and worry. Hopefully this is a remedy to both. (Code for the function probably still needs checking, however, that is outside the scope of this pull request..)