### PR TITLE
removec /data/config/ccc from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ scripts/scan-o-matic_job
 nohup.out
 data/config/rpc.admin
 /htmlcov
-/data/config/ccc


### PR DESCRIPTION
The tests of the calibration didn't previously clean up after themselves, creating files under `/data/config/ccc` that could possibly have conflicted with user data. Sometime before today this was fixed by setting the the `ccc_path` attribute of the `Path` singleton in the tests to a tmp folder. Git blame says that this was accomplished by @local-minimum on 2017-09-06.

This pull request merely updates the `.gitignore` file to acknowledge that his has been resolved.