### PR TITLE
Bug: No or bad signal in grayscale detection mishandled

### DIFF
--- a/scanomatic/image_analysis/first_pass_image.py
+++ b/scanomatic/image_analysis/first_pass_image.py
@@ -1,4 +1,5 @@
 import time
+import traceback
 import itertools
 import numpy as np
 
@@ -402,7 +403,10 @@ class FixtureImage(object):
             current_model.grayscale.values = image_grayscale.get_grayscale(
                 self, current_model.grayscale)[1]
         except TypeError:
-            self._logger.error("Grayscale detection failed / caused TypeError")
+            self._logger.error(
+                "Grayscale detection failed due to: \n{0}".format(
+                    traceback.format_exc()))
+                    
             current_model.grayscale.values = None
 
         if current_model.grayscale.values is None:

--- a/scanomatic/image_analysis/first_pass_image.py
+++ b/scanomatic/image_analysis/first_pass_image.py
@@ -399,13 +399,16 @@ class FixtureImage(object):
             return False
 
         try:
-            current_model.grayscale.values = image_grayscale.get_grayscale(self, current_model.grayscale)[1]
+            current_model.grayscale.values = image_grayscale.get_grayscale(
+                self, current_model.grayscale)[1]
         except TypeError:
+            self._logger.error("Grayscale detection failed / caused TypeError")
             current_model.grayscale.values = None
 
         if current_model.grayscale.values is None:
-            self._logger.error("Grayscale detection failed")
             return False
+
+        return True
 
     def _set_area_relative(self, area, rotation=None, offset=(0, 0), issues={}):
 

--- a/scanomatic/image_analysis/grayscale.py
+++ b/scanomatic/image_analysis/grayscale.py
@@ -6,6 +6,7 @@ import numpy as np
 #
 
 import scanomatic.io.paths as paths
+from scanomatic.io.logger import Logger
 
 #
 # GLOBALS
@@ -34,6 +35,7 @@ _GRAYSCALE_VALUE_TYPES = {
     'length': float,
 }
 
+_logger = Logger("Grayscale settings")
 #
 # METHODS
 #
@@ -44,7 +46,8 @@ def getGrayscales():
     try:
         _GRAYSCALE_CONFIGS.readfp(open(_GRAYSCALE_PATH, 'r'))
     except:
-        pass
+        _logger.critical(
+            "Settings for grayscales not found at: " + _GRAYSCALE_PATH)
     return _GRAYSCALE_CONFIGS.sections()
 
 

--- a/scanomatic/image_analysis/image_grayscale.py
+++ b/scanomatic/image_analysis/image_grayscale.py
@@ -221,6 +221,8 @@ def detect_grayscale(im_trimmed, grayscale):
 
     if gs_l_diff < NEW_GS_ALG_L_DIFF_T:
 
+        _logger.info('Using new method')
+
         deltas, observed_spikes, observed_to_expected_map = signal.get_signal_data(
             para_signal_trimmed_im, up_spikes, grayscale,
             grayscale["length"] * NEW_GS_ALG_L_DIFF_SPIKE_T)
@@ -241,6 +243,10 @@ def detect_grayscale(im_trimmed, grayscale):
                                             grayscale['sections'])
 
             fin_edges = np.isfinite(edges)
+            if not fin_edges.any():
+                _logger.error("No finite edges found")
+                return None, None
+
             where_fin_edges = np.where(fin_edges)[0]
 
             if DEBUG_DETECTION:
@@ -251,13 +257,13 @@ def detect_grayscale(im_trimmed, grayscale):
             frequency = frequency[np.isfinite(frequency)].mean()
 
             if not np.isfinite(frequency):
-                _logger.critical("No frequency was detected, thus no grayscale")
+                _logger.error("No frequency was detected, thus no grayscale")
                 return None, None
 
             edges = signal.extrapolate_edges(edges, frequency, para_signal_trimmed_im.size)
 
             if edges.size != grayscale['sections'] + 1:
-                _logger.critical(
+                _logger.error(
                     "Number of edges doesn't correspond to the grayscale segments ({0}!={1})".format(
                         edges.size, grayscale['sections'] + 1))
                 return None, None

--- a/scanomatic/image_analysis/image_grayscale.py
+++ b/scanomatic/image_analysis/image_grayscale.py
@@ -221,7 +221,7 @@ def detect_grayscale(im_trimmed, grayscale):
 
     if gs_l_diff < NEW_GS_ALG_L_DIFF_T:
 
-        _logger.info('Using new method')
+        _logger.info('Using default grayscale detection method')
 
         deltas, observed_spikes, observed_to_expected_map = signal.get_signal_data(
             para_signal_trimmed_im, up_spikes, grayscale,

--- a/scanomatic/image_analysis/signal.py
+++ b/scanomatic/image_analysis/signal.py
@@ -57,12 +57,11 @@ def get_signal_data(strip_values, up_spikes, grayscale, delta_threshold):
     return np.array(deltas), observed_spikes, observed_to_expected_index_map
 
 
-def get_signal_edges(observed_to_expected_index_map, deltas, observed_spikes, number_of_segments):
-
-    _logger.info('observed_to_expected_index_map ' + list(observed_to_expected_index_map))
-    _logger.info('deltas ' + list(deltas))
-    _logger.info('observed_spikes ' + observed_spikes)
-    _logger.info('number_of_segments ' + number_of_segments)
+def get_signal_edges(
+        observed_to_expected_index_map,
+        deltas,
+        observed_spikes,
+        number_of_segments):
 
     edges = np.ones((number_of_segments + 1,)) * np.nan
 
@@ -78,11 +77,17 @@ def get_signal_edges(observed_to_expected_index_map, deltas, observed_spikes, nu
 
     nan_edges = np.isnan(edges)
     fin_edges = np.isfinite(edges)
-    edge_ordinals = np.arange(edges.size, dtype=np.float) + 1
-    edges[nan_edges] = np.interp(edge_ordinals[nan_edges], edge_ordinals[fin_edges],
-                                 edges[fin_edges],
-                                 left=np.nan,
-                                 right=np.nan)
+    if fin_edges.any() and nan_edges.any():
+        edge_ordinals = np.arange(edges.size, dtype=np.float) + 1
+        edges[nan_edges] = np.interp(
+            edge_ordinals[nan_edges],
+            edge_ordinals[fin_edges],
+            edges[fin_edges],
+            left=np.nan,
+            right=np.nan)
+
+    elif nan_edges.any():
+        _logger.warning("No finite edges")
 
     return edges
 

--- a/scanomatic/image_analysis/signal.py
+++ b/scanomatic/image_analysis/signal.py
@@ -59,6 +59,11 @@ def get_signal_data(strip_values, up_spikes, grayscale, delta_threshold):
 
 def get_signal_edges(observed_to_expected_index_map, deltas, observed_spikes, number_of_segments):
 
+    _logger.info('observed_to_expected_index_map ' + list(observed_to_expected_index_map))
+    _logger.info('deltas ' + list(deltas))
+    _logger.info('observed_spikes ' + observed_spikes)
+    _logger.info('number_of_segments ' + number_of_segments)
+
     edges = np.ones((number_of_segments + 1,)) * np.nan
 
     for edge_i in range(number_of_segments + 1):

--- a/scanomatic/image_analysis/test/test_signal.py
+++ b/scanomatic/image_analysis/test/test_signal.py
@@ -67,19 +67,7 @@ class TestGetSignalEdges:
             22, 22, 22, 22, 22, 22, 22, 23, 23, 23, 23, 23
         ])
 
-        deltas = np.array([
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan,
-        ])
+        deltas = np.ones(observed_to_expected_index_map.shape) * np.nan
 
         observed_spikes = np.array([
             0, 1, 2, 3, 4, 5, 6, 32, 61, 62, 91, 120, 121, 150, 151, 179, 180,

--- a/scanomatic/image_analysis/test/test_signal.py
+++ b/scanomatic/image_analysis/test/test_signal.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scanomatic.image_analysis import signal
 
+
 class TestGetSignalEdges:
 
     def test_works_with_useful_data(self):
@@ -68,21 +69,16 @@ class TestGetSignalEdges:
 
         deltas = np.array([
             np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
             np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
             np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan, np.nan,
-            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
-            np.nan,
         ])
 
         observed_spikes = np.array([

--- a/scanomatic/image_analysis/test/test_signal.py
+++ b/scanomatic/image_analysis/test/test_signal.py
@@ -1,0 +1,107 @@
+import numpy as np
+from scanomatic.image_analysis import signal
+
+class TestGetSignalEdges:
+
+    def test_works_with_useful_data(self):
+        observed_to_expected_index_map = np.array([
+            0, 0, 0, 0, 0, 0, 0, 1, 2, 2, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 8,
+            9, 9, 10, 10, 11, 11, 11, 12, 12, 13, 13, 14, 14, 14, 15, 15, 16,
+            16, 16, 17, 17, 17, 17, 18, 18, 18, 19, 19, 19, 20, 20, 20, 20,
+            20, 20, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 22, 22, 22,
+            22, 22, 22, 22, 22, 22, 22, 23, 23, 23, 23, 23
+        ])
+
+        deltas = np.array([
+            0.05, 1.05, 2.05, 3.05, 4.05, 5.05, 6.05, 2.75, 2.45, 3.45, 3.15,
+            2.85, 3.85, 3.55, 4.55, 3.25, 4.25, 3.95, 4.95, 3.65, 4.65, 5.65,
+            4.35, 5.35, 5.05, 6.05, 4.75, 5.75, 6.75, 5.45, 6.45, 6.15, 7.15,
+            5.85, 6.85, 7.85, 6.55, 7.55, 6.25, 7.25, 8.25, 6.05, 6.95, 7.95,
+            np.nan, 7.65, 8.65, np.nan, 7.35, 8.35, np.nan, 1.05, 2.05, 3.05,
+            7.05, 8.05, np.nan, np.nan, 4.25, 2.25, 1.25, 0.25, 0.75, 4.75,
+            6.75, 7.75, 8.75, np.nan, np.nan, np.nan, np.nan, 7.55, 7.45, 8.45,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            3.85,
+        ])
+
+        observed_spikes = np.array([
+            0, 1, 2, 3, 4, 5, 6, 32, 61, 62, 91, 120, 121, 150, 151, 179, 180,
+            209, 210, 238, 239, 240, 268, 269, 298, 299, 327, 328, 329, 357,
+            358, 387, 388, 416, 417, 418, 446, 447, 475, 476, 477, 492, 505,
+            506, 507, 535, 536, 537, 564, 565, 566, 587, 588, 589, 593, 594,
+            595, 605, 611, 613, 614, 615, 616, 620, 622, 623, 624, 626, 630,
+            631, 635, 637, 652, 653, 654, 655, 657, 658, 660, 662, 663, 664,
+            670
+        ])
+
+        number_of_segments = 23
+
+        edges = signal.get_signal_edges(
+            observed_to_expected_index_map,
+            deltas,
+            observed_spikes,
+            number_of_segments)
+
+        assert len(edges) == 24
+        assert np.isfinite(edges).sum() == 17
+
+    def test_no_signal_returns_none(self):
+
+        edges = signal.get_signal_edges(
+            np.array([]),
+            np.array([]),
+            np.array([]),
+            23)
+
+        assert len(edges) == 24
+        assert not np.isfinite(edges).any()
+
+    def test_no_finite_deltas(self):
+
+        observed_to_expected_index_map = np.array([
+            0, 0, 0, 0, 0, 0, 0, 1, 2, 2, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 8,
+            9, 9, 10, 10, 11, 11, 11, 12, 12, 13, 13, 14, 14, 14, 15, 15, 16,
+            16, 16, 17, 17, 17, 17, 18, 18, 18, 19, 19, 19, 20, 20, 20, 20,
+            20, 20, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 22, 22, 22,
+            22, 22, 22, 22, 22, 22, 22, 23, 23, 23, 23, 23
+        ])
+
+        deltas = np.array([
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan, np.nan,
+            np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
+            np.nan,
+        ])
+
+        observed_spikes = np.array([
+            0, 1, 2, 3, 4, 5, 6, 32, 61, 62, 91, 120, 121, 150, 151, 179, 180,
+            209, 210, 238, 239, 240, 268, 269, 298, 299, 327, 328, 329, 357,
+            358, 387, 388, 416, 417, 418, 446, 447, 475, 476, 477, 492, 505,
+            506, 507, 535, 536, 537, 564, 565, 566, 587, 588, 589, 593, 594,
+            595, 605, 611, 613, 614, 615, 616, 620, 622, 623, 624, 626, 630,
+            631, 635, 637, 652, 653, 654, 655, 657, 658, 660, 662, 663, 664,
+            670
+        ])
+
+        number_of_segments = 23
+
+        edges = signal.get_signal_edges(
+            observed_to_expected_index_map,
+            deltas,
+            observed_spikes,
+            number_of_segments)
+
+        assert len(edges) == 24
+        assert not np.isfinite(edges).any()

--- a/scanomatic/util/analysis.py
+++ b/scanomatic/util/analysis.py
@@ -81,41 +81,50 @@ def produce_grid_images(path=".", plates=None, image=None, mark_position=None, c
                      marked_position=mark_position)
 
 
+def make_grid(im, grid_plot, grid, marked_position):
+
+        x = 0
+        y = 1
+        for row in range(grid.shape[1]):
+
+            grid_plot.plot(
+                grid[x, row, :], -grid[y, row, :] + im.shape[y], 'r-')
+
+        for col in range(grid.shape[2]):
+
+            grid_plot.plot(
+                grid[x, :, col], -grid[y, :, col] + im.shape[y], 'r-')
+
+        if marked_position is None:
+            marked_position = (-1, 0)
+
+        grid_plot.plot(
+            grid[x, marked_position[0], marked_position[1]],
+            grid[y, marked_position[0], marked_position[1]] +
+            im.shape[y],
+            'o', alpha=0.75, ms=10, mfc='none', mec='blue', mew=1)
+
+
 def make_grid_im(im, grid, save_grid_name, marked_position=None):
 
-    with ExpiringModule("matplotlib", run_code="mod.use('Svg')") as _:
+    with ExpiringModule("matplotlib", run_code="mod.use('Svg')"):
         with ExpiringModule("matplotlib.pyplot") as plt:
 
             grid_image = plt.figure()
             grid_plot = grid_image.add_subplot(111)
             grid_plot.imshow(im.T, cmap=plt.cm.gray)
-            x = 0
-            y = 1
 
             if grid is not None:
-                for row in range(grid.shape[1]):
-
-                    grid_plot.plot(
-                        grid[x, row, :], -grid[y, row, :] + im.shape[y], 'r-')
-
-                for col in range(grid.shape[2]):
-
-                    grid_plot.plot(
-                        grid[x, :, col], -grid[y, :, col] + im.shape[y], 'r-')
-
-                if marked_position is None:
-                    marked_position = (-1, 0)
-
-                    grid_plot.plot(
-                        grid[x, marked_position[0], marked_position[1]],
-                        grid[y, marked_position[0], marked_position[1]] +
-                        im.shape[y],
-                        'o', alpha=0.75, ms=10, mfc='none', mec='blue', mew=1)
+                make_grid(im, grid_plot, grid, marked_position)
 
             ax = grid_image.gca()
-            ax.set_xlim(0, im.shape[x])
-            ax.set_ylim(0, im.shape[y])
+            ax.set_xlim(0, im.shape[0])
+            ax.set_ylim(0, im.shape[1])
             ax.get_xaxis().set_visible(False)
             ax.get_yaxis().set_visible(False)
 
-            grid_image.savefig(save_grid_name, pad_inches=0.01, format='svg', bbox_inches='tight')
+            grid_image.savefig(
+                save_grid_name,
+                pad_inches=0.01,
+                format='svg',
+                bbox_inches='tight')


### PR DESCRIPTION
## Solution

It is hard to know exactly what caused the problem, but the contents of this merge ensures that if no spikes where found or if no deltas were finite, the function should fail gracefully and the failing should be handled correctly.

In attempting to recreate this, a side effect error of the original case with producing grid images when some of the expected data was missing occurred. This is also included in this PR.

## Tests

Added tests for the function `scanomatic.image_analysis.signal.get_signal_edges` that hopefully captures both the scenario of having useful signal and having at least two kinds of bad signal.

## Original Traceback
```
Process RpcJob-3:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/local/lib/python2.7/dist-packages/scanomatic/server/rpcjob.py", line 115, in run
    effector_iterator.next()
  File "/usr/local/lib/python2.7/dist-packages/scanomatic/server/compile_effector.py", line 116, in next
    self._analyse_image(self._compile_job.images[self._image_to_analyse])
  File "/usr/local/lib/python2.7/dist-packages/scanomatic/server/compile_effector.py", line 143, in _analyse_image
    image_model = first_pass.analyse(compile_image_model, self._fixture_settings, issues=issues)
  File "/usr/local/lib/python2.7/dist-packages/scanomatic/image_analysis/first_pass.py", line 47, in analyse
    _do_grayscale(compile_analysis_model, fixture_image)
  File "/usr/local/lib/python2.7/dist-packages/scanomatic/image_analysis/first_pass.py", line 87, in _do_grayscale
    image.analyse_grayscale()
  File "/usr/local/lib/python2.7/dist-packages/scanomatic/image_analysis/first_pass_image.py", line 402, in analyse_grayscale
    current_model.grayscale.values = image_grayscale.get_grayscale(self, current_model.grayscale)[1]
  File "/usr/local/lib/python2.7/dist-packages/scanomatic/image_analysis/image_grayscale.py", line 141, in get_grayscale
    return get_grayscale_image_analysis(im, grayscale_area_model.name, debug=debug)
  File "/usr/local/lib/python2.7/dist-packages/scanomatic/image_analysis/image_grayscale.py", line 158, in get_grayscale_image_analysis
    return detect_grayscale(im_p, gs)
  File "/usr/local/lib/python2.7/dist-packages/scanomatic/image_analysis/image_grayscale.py", line 241, in detect_grayscale
    grayscale['sections'])
  File "/usr/local/lib/python2.7/dist-packages/scanomatic/image_analysis/signal.py", line 80, in get_signal_edges
    right=np.nan)
  File "/usr/local/lib/python2.7/dist-packages/numpy/lib/function_base.py", line 1881, in interp
    return interp_func(x, xp, fp, left, right)
ValueError: array of sample points is empty

```