### PR TITLE
Bug: Faulty slicing in downsampling

### DIFF
--- a/scanomatic/data_processing/norm.py
+++ b/scanomatic/data_processing/norm.py
@@ -87,7 +87,6 @@ def get_downsampled_plates(data, subsampling="BR"):
                 The subsampling used
     """
 
-
     # Generic -> Per plate
     if isinstance(subsampling, StringTypes):
         subsampling = [subsampling for _ in range(data.shape[0])]
@@ -110,17 +109,14 @@ def get_downsampled_plates(data, subsampling="BR"):
     for i, plate in enumerate(data):
         offset = subsampling[i]
 
-        # How much smaller the cut should be than the original
-        # (e.g. take every second)
-        subsample_scale = 2 if offset.sum() == 1 else 0
-        if not subsample_scale:
+        if offset.sum() != 1 or offset.shape != (2, 2):
             raise ValueError(
-                "Only exactly one reference position offset per plate allowed. "
+                "Only exactly 1 reference position offset per plate allowed. "
                 "You had {0}".format(offset))
 
         d1, d2 = np.where(offset)
 
-        out.append(plate[d1::2, d2::2])
+        out.append(plate[d1[0]::2, d2[0]::2])
 
     return out
 

--- a/scanomatic/data_processing/test/test_norm.py
+++ b/scanomatic/data_processing/test/test_norm.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+
+from scanomatic.data_processing import norm
+
+
+class TestDownSampling:
+
+    def test_get_default_downsampling(self):
+        """Test using Two plates with shape 4 x 6 each."""
+        data = np.arange(48).reshape(2, 4, 6)
+        sampled = norm.get_downsampled_plates(data)
+        assert len(sampled) == 2
+        a, b = sampled
+        assert a.shape == (2, 3)
+        assert a[0, 0] == 7
+        assert b.shape == (2, 3)
+        assert b[0, 0] == 31
+
+    @pytest.mark.parametrize("setting,expected", [
+        ('TL', 0),
+        ('TR', 1),
+        ('BL', 2),
+        ('BR', 3),
+    ])
+    def test_get_downsampling_specified_downsampling_as_string(
+            self, setting, expected):
+
+        data = np.arange(4).reshape(1, 2, 2)
+        sample = norm.get_downsampled_plates(data, setting)[0]
+        assert sample.shape == (1, 1)
+        assert sample[0, 0] == expected
+
+    def test_get_specified_downsampling(self):
+
+        data = np.arange(4).reshape(1, 2, 2)
+        setting = np.array([
+            [
+                [1, 0],
+                [0, 0],
+            ]
+        ])
+        expected = 0
+        sample = norm.get_downsampled_plates(data, setting)[0]
+        assert sample.shape == (1, 1)
+        assert sample[0, 0] == expected
+
+    @pytest.mark.parametrize('settings', [
+        (
+            np.array([
+                [
+                    [0, 0],
+                    [0, 0],
+                ]
+            ]),
+        ),
+        (
+            np.array([
+                [
+                    [0, 1],
+                    [0, 1],
+                ]
+            ]),
+        ),
+        (
+            np.array([
+                [
+                    [0, 0, 1],
+                    [0, 0, 0],
+                ]
+            ]),
+        ),
+
+    ])
+    def test_faulty_downsampling_raises(self, settings):
+
+        data = np.arange(4).reshape(1, 2, 2)
+        expected = 0
+
+        with pytest.raises(ValueError):
+            norm.get_downsampled_plates(data, settings)


### PR DESCRIPTION
## Description

I hope the reason this error appears is due to numpy version differences. I am assuming that before it could interpret a `(1,)` size array in a slice as that array's value, while it isn't possible anymore.

```
a = np.array([1], dtype=int)
np.arange(10)[a::2]
```
Would before have returned `[1, 3, 5, 7, 9]`, now it raises an error.

The function where this happened `scanomatic.data_processing.norm.get_downsampled_plates` was also more limited than the implementation than it let on. It required the sub-sampling patterns per plate to be 2x2 arrays rather than any 2d array with exactly one true value in it.

I therefor updated it so that the sanity-check inside the function on the down-sampling pattern so that it matched the implementation.

## Testing 

Added a bunch of tests for the different invocations that should and should not work.
I can't reproduce the problem directly, but this PR should deal with what caused the traceback (below).

## Original Log
_(omitting the flask/request related lines)_
```
scanomatic_1  |   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1598, in dispatch_request
scanomatic_1  |     return self.view_functions[rule.endpoint](**req.view_args)
scanomatic_1  |   File "/usr/local/lib/python2.7/dist-packages/scanomatic/ui_server/qc_api.py", line 1306, in _do_normalize
scanomatic_1  |     state.normalize_phenotypes()
scanomatic_1  |   File "/usr/local/lib/python2.7/dist-packages/scanomatic/data_processing/phenotyper.py", line 1491, in normalize_phenotypes
scanomatic_1  |     data, self._reference_surface_positions, method=norm_method)):
scanomatic_1  |   File "/usr/local/lib/python2.7/dist-packages/scanomatic/data_processing/norm.py", line 719, in get_normalized_data
scanomatic_1  |     pre_surface = get_downsampled_plates(surface, offsets)
scanomatic_1  |   File "/usr/local/lib/python2.7/dist-packages/scanomatic/data_processing/norm.py", line 123, in get_downsampled_plates
scanomatic_1  |     out.append(plate[d1::2, d2::2])
scanomatic_1  | TypeError: only integer scalar arrays can be converted to a scalar index
```
