### PR TITLE
Runtime warning grid empty mean

### DIFF
--- a/scanomatic/image_analysis/grid.py
+++ b/scanomatic/image_analysis/grid.py
@@ -152,7 +152,7 @@ def get_grid_parameters(x_data, y_data, grid_shape, spacings=(54, 54)):
 
     data = (x_data, y_data)
     new_spacings = get_grid_spacings(x_data, y_data, *spacings)
-    if new_spacings is None:
+    if None in new_spacings:
         return None, None
     centers = get_centre_candidates(grid_shape, new_spacings)
     votes = get_votes(data, centers)
@@ -160,7 +160,8 @@ def get_grid_parameters(x_data, y_data, grid_shape, spacings=(54, 54)):
     sigma = np.max((spacings[0], new_spacings[1])) * 0.1 / np.sqrt(2) + 0.5
     heatmap = get_heatmap(data, votes, weights, sigma)
 
-    _center_dim2, _center_dim1 = np.unravel_index(heatmap.argmax(), heatmap.shape)
+    _center_dim2, _center_dim1 = np.unravel_index(
+        heatmap.argmax(), heatmap.shape)
 
     new_center = (_center_dim1, _center_dim2)
 

--- a/scanomatic/image_analysis/grid.py
+++ b/scanomatic/image_analysis/grid.py
@@ -446,7 +446,6 @@ def get_grid(
         x_data=None,
         y_data=None,
         expected_center=(100, 100),
-        run_dev=False,
         dev_reduce_grid_data_fraction=None,
         validate_parameters=False,
         grid_correction=None):
@@ -491,38 +490,22 @@ def get_grid(
 
     if adjusted_values is False:
 
-        if run_dev:
+        center, spacings = get_grid_parameters(
+            x_data, y_data, grid_shape, spacings=expected_spacing)
 
-            center, spacings = get_grid_parameters(
-                x_data, y_data, grid_shape, spacings=expected_spacing)
+        if center is None or spacings is None:
+            return None, x_data, y_data, center, spacings, adjusted_values
 
-            if center is None or spacings is None:
-                return None, x_data, y_data, center, spacings, adjusted_values
+        if grid_correction is not None:
+            center = tuple(a + b for a, b in
+                           zip(center, [i * j for i, j in
+                                        zip(grid_correction, spacings)]))
 
-            if validate_parameters:
-                center, spacings, adjusted_values = get_valid_parameters(
-                    center, spacings, expected_center, expected_spacing)
-            else:
-                adjusted_values = False
+            adjusted_values = True
 
-        else:
-
-            center, spacings = get_grid_parameters(
-                x_data, y_data, grid_shape, spacings=expected_spacing)
-
-            if center is None or spacings is None:
-                return None, x_data, y_data, center, spacings, adjusted_values
-
-            if grid_correction is not None:
-                center = tuple(a + b for a, b in
-                               zip(center, [i * j for i, j in
-                                            zip(grid_correction, spacings)]))
-
-                adjusted_values = True
-
-            if validate_parameters:
-                center, spacings, adjusted_values = get_valid_parameters(
-                    center, spacings, expected_center, expected_spacing)
+        if validate_parameters:
+            center, spacings, adjusted_values = get_valid_parameters(
+                center, spacings, expected_center, expected_spacing)
 
     dx, dy = spacings
 

--- a/scanomatic/image_analysis/grid_array.py
+++ b/scanomatic/image_analysis/grid_array.py
@@ -427,6 +427,9 @@ class GridArray(object):
             grid_shape=self._pinning_matrix,
             grid_correction=grid_correction)
 
+        if draft_grid is None:
+            return None
+        
         dx, dy = spacings
 
         self._grid, _, self._valid_grid = grid.get_validated_grid(

--- a/scanomatic/image_analysis/grid_array.py
+++ b/scanomatic/image_analysis/grid_array.py
@@ -371,8 +371,8 @@ class GridArray(object):
         spacings = self._calculate_grid_and_get_spacings(
             im, grid_correction=grid_correction)
 
-        if self._grid is None or not self._valid_grid or \
-                np.isnan(spacings).any():
+        if (self._grid is None or not self._valid_grid or
+                spacings is None or np.isnan(spacings).any()):
 
             if self._analysis_model.output_directory:
 
@@ -429,7 +429,7 @@ class GridArray(object):
 
         if draft_grid is None:
             return None
-        
+
         dx, dy = spacings
 
         self._grid, _, self._valid_grid = grid.get_validated_grid(

--- a/scanomatic/image_analysis/test/conftest.py
+++ b/scanomatic/image_analysis/test/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+from scipy import ndimage
+
+
+@pytest.fixture(scope='session')
+def easy_plate():
+    return ndimage.io.imread(
+        './scanomatic/image_analysis/test/testdata/test_fixture_easy.tiff')
+
+
+@pytest.fixture(scope='session')
+def hard_plate():
+    return ndimage.io.imread(
+        './scanomatic/image_analysis/test/testdata/test_fixture_difficult.tiff'
+    )

--- a/scanomatic/image_analysis/test/test_grid.py
+++ b/scanomatic/image_analysis/test/test_grid.py
@@ -86,3 +86,75 @@ class TestGetGridParameters:
 
         assert center is None
         assert new_spacings is None
+
+
+class TestGetGrid:
+
+    def test_getting_grid_easy_plate(self, easy_plate):
+        """Expect grid and to be inside image.
+
+        TODO: Expect proximity to curated positions
+        """
+        expected_spacings = (212, 212)
+        expected_center = tuple([s / 2.0 for s in easy_plate.shape])
+        validate_parameters = False
+        grid_shape = (12, 8)
+        grid_correction = None
+
+        draft_grid, _, _, _, spacings, _ = grid.get_grid(
+            easy_plate,
+            expected_spacing=expected_spacings,
+            expected_center=expected_center,
+            validate_parameters=validate_parameters,
+            grid_shape=grid_shape,
+            grid_correction=grid_correction)
+
+        assert draft_grid is not None
+        assert draft_grid.shape == (2, ) + grid_shape
+
+        assert spacings is not None
+        for dim in range(2):
+            d_spacing = spacings[dim]
+            coord_components = draft_grid[dim]
+            assert (coord_components > d_spacing / 2.0).all()
+            assert (coord_components <
+                    easy_plate.shape[dim] - d_spacing / 2.0).all()
+
+    def test_getting_expecting_wrong_spacings_fails(self, easy_plate):
+
+        expected_spacings = (137, 137)
+        expected_center = tuple([s / 2.0 for s in easy_plate.shape])
+        validate_parameters = False
+        grid_shape = (12, 8)
+        grid_correction = None
+
+        draft_grid, _, _, _, spacings, _ = grid.get_grid(
+            easy_plate,
+            expected_spacing=expected_spacings,
+            expected_center=expected_center,
+            validate_parameters=validate_parameters,
+            grid_shape=grid_shape,
+            grid_correction=grid_correction)
+
+        assert draft_grid is None
+
+    def test_getting_grid_hard_plate(self, hard_plate):
+        """Only expect to be a correctly shaped grid."""
+        expected_spacings = (212, 212)
+        expected_center = tuple([s / 2.0 for s in hard_plate.shape])
+        validate_parameters = False
+        grid_shape = (12, 8)
+        grid_correction = None
+
+        draft_grid, _, _, _, spacings, _ = grid.get_grid(
+            hard_plate,
+            expected_spacing=expected_spacings,
+            expected_center=expected_center,
+            validate_parameters=validate_parameters,
+            grid_shape=grid_shape,
+            grid_correction=grid_correction)
+
+        assert draft_grid is not None
+        assert draft_grid.shape == (2, ) + grid_shape
+
+        assert spacings is not None

--- a/scanomatic/image_analysis/test/test_grid.py
+++ b/scanomatic/image_analysis/test/test_grid.py
@@ -1,0 +1,88 @@
+import numpy as np
+import pytest
+
+from scanomatic.image_analysis import grid
+
+
+class TestGetGridSpacings:
+
+    def test_getting_spacing(self):
+
+        x = np.array([1, 12, 10, 11])
+        y = np.array([20, 80, 40, 42])
+
+        spacings = grid.get_grid_spacings(x, y, 10, 20, leeway=0.01)
+        assert spacings == (10.0, 20.0)
+
+    @pytest.mark.parametrize('x,y,expect_x,expect_y,leeway,expected_outcome', [
+        (
+            np.array([1, 10]),
+            np.array([0, 10]),
+            10,
+            10,
+            0.01,
+            (None, 10.0)
+        ),
+        (
+            np.array([0, 10]),
+            np.array([1, 10]),
+            10,
+            10,
+            0.01,
+            (10.0, None)
+        ),
+        (
+            np.array([0, 10]),
+            np.array([1, 10]),
+            10,
+            10,
+            0.0,
+            (None, None)
+        ),
+        (
+            np.array([]),
+            np.array([1, 10]),
+            10,
+            10,
+            0.0,
+            (None, None)
+        ),
+    ])
+    def test_failing_spacings_returns_none(
+            self, x, y, expect_x, expect_y, leeway, expected_outcome):
+
+        spacings = grid.get_grid_spacings(
+            x, y, expect_x, expect_y, leeway=leeway)
+        assert spacings == expected_outcome
+
+
+class TestGetGridParameters:
+
+    def test_getting_grid_parameters(self):
+
+        x = np.array([0, 11, 16, 21, 33, 34, 41, 51])
+        y = np.array([1000, 1041, 1031, 1071, 1077, 1024, 1081, 1101])
+        grid_shape = (4, 6)
+        spacings = (10, 10)
+        center, new_spacings = grid.get_grid_parameters(
+            x, y, grid_shape, spacings=spacings)
+
+        assert None not in center
+        assert (x > center[0]).any()
+        assert (x < center[0]).any()
+        assert (y > center[1]).any()
+        assert (y < center[1]).any()
+
+        np.testing.assert_allclose(new_spacings, spacings, rtol=0.01)
+
+    def test_failing_spacings_returns_nones(self):
+
+        x = np.array([0, 25])
+        y = np.array([1000, 1041, 1031, 1071, 1077, 1024, 1081, 1101])
+        grid_shape = (4, 6)
+        spacings = (10, 10)
+        center, new_spacings = grid.get_grid_parameters(
+            x, y, grid_shape, spacings=spacings)
+
+        assert center is None
+        assert new_spacings is None

--- a/scanomatic/image_analysis/test/test_grid_array.py
+++ b/scanomatic/image_analysis/test/test_grid_array.py
@@ -1,25 +1,21 @@
 from itertools import product
 import pytest
 
-from scipy import ndimage
-
 from scanomatic.image_analysis import grid_array as grid_array_module
 from scanomatic.models.factories.analysis_factories import AnalysisModelFactory
 
 
-@pytest.fixture(scope="class")
-def grid_array():
+@pytest.fixture(scope='session')
+def grid_array(easy_plate):
     """Instantiate a GridArray object with a gridded image"""
     image_identifier = [42, 1337]
     pinning = (8, 12)
     analysis_model = AnalysisModelFactory.create()
     analysis_model.output_directory = ""
-    image = ndimage.io.imread(
-        './scanomatic/image_analysis/test/testdata/test_fixture_easy.tiff')
     grid_array_instance = grid_array_module.GridArray(
         image_identifier, pinning, analysis_model)
     correction = (0, 0)
-    grid_array_instance.detect_grid(image, grid_correction=correction)
+    grid_array_instance.detect_grid(easy_plate, grid_correction=correction)
     return grid_array_instance
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,5 @@ setenv =
 commands =
     pytest \
         --cov scanomatic --cov scripts --cov-report xml --cov-report term \
-        --junitxml result.xml --ignore dev\
+        --junitxml result.xml --ignore dev \
         {posargs}


### PR DESCRIPTION
## Description

One of the grid functions could attempt mean of an empty slice. Fixed so it now treats this as a gridding failure. Unfortunately the function was used by a function that was used by a ... you get it. So I needed logic to all those functions and tests for those too.

## Tests

Many for all the different functions involved.
Some of them are a bit weird in what they test for lack of more direct signs of failing grid detection.
Also fixed `tox.ini`
Also some test using the hard image, could start to fail if we improve the gridding because the hard image isn't impossible, but then we just need a new harder/impossible fixture image.

## Original warning

```
/usr/local/lib/python2.7/dist-packages/scanomatic/image_analysis/grid.py:278: RuntimeWarning: Mean of empty slice.
  deltas < expected_delta * (1 + leeway))].mean()
```