### PR TITLE
Fix issue where "setting" a colony without background would lose the `scope`.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
         "js/d3.js",
         "js/*.js",
         'js/specs/helpers/*.js',
-        { pattern: 'js/specs/*.js', watched: false },
+        { pattern: 'js/specs/**/*.spec.js', watched: false },
     ],
 
     // list of files to exclude
@@ -28,7 +28,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-        'js/specs/*.js': ['webpack'],
+        'js/specs/**/*.spec.js': ['webpack'],
     },
 
     // test results reporter to use

--- a/package.json
+++ b/package.json
@@ -7,12 +7,21 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-preset-env": "^1.6.1",
+    "babel-preset-react": "^6.24.1",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
     "jasmine-core": "^2.8.0",
     "karma": "^1.7.1",
     "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^1.1.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "^2.0.5",
+    "react-test-renderer": "^16.0.0",
     "webpack": "^3.8.1"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   }
 }

--- a/scanomatic/ui_server_data/CCC.html
+++ b/scanomatic/ui_server_data/CCC.html
@@ -163,52 +163,7 @@
                                             <canvas id="cvsPlateGridColonyMarker"></canvas>
                                         </div>
                                         <div class="col-md-6">
-                                            <div><span>Colony Image</span></div>
-                                            <div>
-                                                <div style="position: relative; background: white; display: inline-block; padding: 3px; ">
-                                                    <canvas id="colonyImageCanvas" style="z-index: 1;left:0px;top:0px;"></canvas>
-                                                    <canvas id="colonyMarkingsCanvas" style="position: absolute;z-index: 2;left:0px;top:0px;"></canvas>
-                                                </div>
-                                                <div>
-                                                    <button class="btn btn-default" id="btnColonyBlobSizePlus" style="horiz-align: center">+</button>
-                                                    <button class="btn btn-default" id="btnColonyBlobSizeMinus" style="horiz-align: center">-</button>
-                                                    <button class="btn btn-default" id="btnSetUpdatedColonyMetadata" style="horiz-align: center">Update</button>
-                                                </div>
-                                            </div>
-                                            <div>
-                                                <br/>
-                                            </div>
-                                            <div><span>Colony MetaData</span></div>
-                                            <div id="dvColPlotMarkers" style="background: white; display: inline-block; padding: 3px;text-align:center;">
-                                                <canvas id="colonyPlotCanvas" ></canvas>
-                                                <ul class="colonyPlot" style="color: black">
-                                                    <li>
-                                                        <div class="input-color">
-                                                            <input type="text" value="Blob" />
-                                                            <div class="color-box" style="background-color: red;"></div>
-                                                        </div>
-                                                    </li>
-                                                    <li>
-                                                        <div class="input-color">
-                                                            <input type="text" value="Background" />
-                                                            <div class="color-box" style="background-color: #7FFFD4;"></div>
-                                                        </div>
-                                                    </li>
-                                                    <li>
-                                                        <div class="input-color">
-                                                            <input type="text" value="Either" />
-                                                            <div class="color-box" style="background-color: black;"></div>
-                                                        </div>
-                                                    </li>
-                                                </ul>
-                                                <button class="btn btn-default" id="btnFixColonyMetadata" style="horiz-align: center">Fix</button>
-                                            </div>
-                                            <div>
-                                                <br />
-                                            </div>
-                                            <div style="text-align: center">
-                                                <button class="btn btn-default" id="btnNextColonyDetect" style="margin-left: 30px">Set</button>
-                                            </div>
+                                            <div id="colony-editor"></div>
                                         </div>
                                     </div>
                                     <div class="row" id="div">

--- a/scanomatic/ui_server_data/js/ccc/Blob.js
+++ b/scanomatic/ui_server_data/js/ccc/Blob.js
@@ -1,4 +1,4 @@
-export default function ColonyBlob(x, y, r, fill) {
+export default function Blob(x, y, r, fill) {
     this.x = x || 0;
     this.y = y || 0;
     this.r = r || 1;

--- a/scanomatic/ui_server_data/js/ccc/api.js
+++ b/scanomatic/ui_server_data/js/ccc/api.js
@@ -273,8 +273,6 @@ export function SetColonyCompressionV2(scope, cccId, imageId, plate, accessToken
         contentType: "application/json; charset=utf-8",
         dataType: "json",
         success: function (data) {
-            scope.ColonyRow = row;
-            scope.ColonyCol = col;
             successCallback(data, scope);
         },
         error: errorCallback

--- a/scanomatic/ui_server_data/js/ccc/components/ColonyEditor.js
+++ b/scanomatic/ui_server_data/js/ccc/components/ColonyEditor.js
@@ -32,13 +32,6 @@ export default class ColonyEditor extends React.Component {
     }
 
     render() {
-        const style = {
-            background: 'white',
-            display: 'inline-block',
-            paddingd: '3px',
-            textAlign: 'center',
-        };
-
         return (
             <div>
                 <div><span>Colony Image</span></div>
@@ -49,9 +42,7 @@ export default class ColonyEditor extends React.Component {
                 />
                 <div><br /></div>
                 <div><span>Colony MetaData</span></div>
-                <div style={style} >
-                    <ColonyFeatures data={this.state.data} />
-                </div>
+                <ColonyFeatures data={this.state.data} />
                 <button
                     className="btn btn-default btn-fix"
                     style={{ horizAlign: 'center' }}

--- a/scanomatic/ui_server_data/js/ccc/components/ColonyEditor.js
+++ b/scanomatic/ui_server_data/js/ccc/components/ColonyEditor.js
@@ -1,0 +1,77 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import ColonyFeatures from './ColonyFeatures';
+import ColonyImage from './ColonyImage';
+
+export default class ColonyEditor extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            drawing: false,
+            data: props.data,
+        }
+        this.handleClickFix = this.handleClickFix.bind(this);
+        this.handleUpdate = this.handleUpdate.bind(this);
+    }
+
+    componentWillReceiveProps(props) {
+        this.setState({
+            drawing: false,
+            data: props.data,
+        });
+    }
+
+    handleClickFix() {
+        this.setState({ drawing: true });
+    }
+
+    handleUpdate(data) {
+        this.setState({ drawing: false });
+        this.props.onUpdate && this.props.onUpdate(data);
+    }
+
+    render() {
+        const style = {
+            background: 'white',
+            display: 'inline-block',
+            paddingd: '3px',
+            textAlign: 'center',
+        };
+
+        return (
+            <div>
+                <div><span>Colony Image</span></div>
+                <ColonyImage
+                    data={this.state.data}
+                    draw={this.state.drawing}
+                    onUpdate={this.handleUpdate}
+                />
+                <div><br /></div>
+                <div><span>Colony MetaData</span></div>
+                <div style={style} >
+                    <ColonyFeatures data={this.state.data} />
+                </div>
+                <button
+                    className="btn btn-default btn-fix"
+                    style={{ horizAlign: 'center' }}
+                    onClick={this.handleClickFix}
+                >Fix</button>
+                <div style={{ textAlign: 'center' }}>
+                    <button
+                        className="btn btn-default btn-set"
+                        style={{ marginLeft: '30px' }}
+                        onClick={this.props.onSet}
+                    >Set</button>
+                </div>
+            </div>
+        );
+    }
+}
+
+ColonyEditor.propTypes = {
+    data: PropTypes.object.isRequired,
+    onFix: PropTypes.func,
+    onSet: PropTypes.func,
+    onUpdate: PropTypes.func,
+};

--- a/scanomatic/ui_server_data/js/ccc/components/ColonyFeatures.js
+++ b/scanomatic/ui_server_data/js/ccc/components/ColonyFeatures.js
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { createCanvasMarker } from '../helpers';
+
+export default class ColonyFeatures extends React.Component {
+    componentDidMount() {
+        this.updateCanvas();
+    }
+
+    componentDidUpdate() {
+        this.updateCanvas();
+    }
+
+    updateCanvas() {
+        createCanvasMarker(this.props.data, this.canvas);
+    }
+
+    render() {
+        const legend = [
+            { color: "red", text: "Blob" },
+            { color: "#7FFFD4", text: "Background" },
+            { color: "black", text: "Neither" },
+        ];
+        return (
+            <div>
+                <canvas ref={canvas => this.canvas = canvas} />;
+                <ul className="data" style={ { color: 'black' } }>
+                    {legend.map( ({ color, text }) => {
+                        const style = { backgroundColor: color };
+                        return (
+                            <li key={text}>
+                                <div className="input-color">
+                                    <input type="text" value={text} readOnly />
+                                    <div className="color-box" style={style} />
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </div>
+        );
+    }
+}
+ColonyFeatures.propTypes = {
+    data: PropTypes.object.isRequired,
+};

--- a/scanomatic/ui_server_data/js/ccc/components/ColonyFeatures.js
+++ b/scanomatic/ui_server_data/js/ccc/components/ColonyFeatures.js
@@ -22,8 +22,16 @@ export default class ColonyFeatures extends React.Component {
             { color: "#7FFFD4", text: "Background" },
             { color: "black", text: "Neither" },
         ];
+
+        const style = {
+            background: 'white',
+            display: 'inline-block',
+            paddingd: '3px',
+            textAlign: 'center',
+        };
+
         return (
-            <div>
+            <div style={style} >
                 <canvas ref={canvas => this.canvas = canvas} />;
                 <ul className="colonyPlot" style={ { color: 'black' } }>
                     {legend.map( ({ color, text }) => {

--- a/scanomatic/ui_server_data/js/ccc/components/ColonyFeatures.js
+++ b/scanomatic/ui_server_data/js/ccc/components/ColonyFeatures.js
@@ -25,7 +25,7 @@ export default class ColonyFeatures extends React.Component {
         return (
             <div>
                 <canvas ref={canvas => this.canvas = canvas} />;
-                <ul className="data" style={ { color: 'black' } }>
+                <ul className="colonyPlot" style={ { color: 'black' } }>
                     {legend.map( ({ color, text }) => {
                         const style = { backgroundColor: color };
                         return (

--- a/scanomatic/ui_server_data/js/ccc/components/ColonyImage.js
+++ b/scanomatic/ui_server_data/js/ccc/components/ColonyImage.js
@@ -1,0 +1,101 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { createCanvasImage, getMarkerData } from '../helpers';
+import CanvasState from '../CanvasState';
+import Blob from '../Blob';
+
+export default class ColonyImage extends React.Component {
+    constructor(props) {
+        super(props);
+        this.handleClickPlus = this.handleClickPlus.bind(this);
+        this.handleClickMinus = this.handleClickMinus.bind(this);
+        this.handleClickUpdate = this.handleClickUpdate.bind(this);
+    }
+
+    componentDidMount() {
+        this.updateCanvas();
+    }
+
+    componentDidUpdate() {
+        this.updateCanvas();
+    }
+
+    updateCanvas() {
+        createCanvasImage(this.props.data, this.colonyImageCanvas);
+        if (this.props.draw) {
+            const { width, height } = this.colonyImageCanvas;
+            this.colonyMarkingsCanvas.width = width;
+            this.colonyMarkingsCanvas.height = height;
+            this.metaDataCanvasState = new CanvasState(this.colonyMarkingsCanvas);
+            this.blob = new Blob(width / 2, height / 2, 15, "rgba(255, 0, 0, .2)");
+            this.metaDataCanvasState.addShape(this.blob);
+        }
+    }
+
+    handleClickPlus() {
+        this.blob.r += 5;
+        this.metaDataCanvasState.needsRender = true;
+    }
+
+    handleClickMinus() {
+        this.blob.r -= 5;
+        this.metaDataCanvasState.needsRender = true;
+    }
+
+    handleClickUpdate() {
+        if (this.props.onUpdate) {
+            const data = getMarkerData(this.colonyMarkingsCanvas);
+            this.props.onUpdate(data);
+        }
+    }
+
+    render() {
+        const style = {
+            position: 'relative',
+            background: 'white',
+            display: 'inline-block',
+            padding: '3px',
+        };
+
+        const buttonStyle = { horizAlign: 'center' };
+        return (
+            <div>
+                <div style={style}>
+                    <canvas
+                        ref={canvas => this.colonyImageCanvas = canvas}
+                        style={{ zIndex: 1 }}
+                    />
+                    {this.props.draw &&
+                        <canvas
+                            ref={canvas => this.colonyMarkingsCanvas = canvas}
+                            style={{ position: 'absolute', zIndex: 2, left:0, top: 0 }}
+                        />}
+                </div>
+                {this.props.draw &&
+                    <div>
+                        <button
+                            className="btn btn-default btn-plus"
+                            style={buttonStyle}
+                            onClick={this.handleClickPlus}
+                        >+</button>
+                        <button
+                            className="btn btn-default btn-minus"
+                            style={buttonStyle}
+                            onClick={this.handleClickMinus}
+                        >-</button>
+                        <button
+                            className="btn btn-default btn-update"
+                            style={buttonStyle}
+                            onClick={this.handleClickUpdate}
+                        >Update</button>
+                    </div>
+                }
+            </div>
+        );
+    }
+}
+ColonyImage.propTypes = {
+    data: PropTypes.object.isRequired,
+    onUpdate: PropTypes.func,
+};

--- a/scanomatic/ui_server_data/js/ccc/containers/ColonyEditorContainer.js
+++ b/scanomatic/ui_server_data/js/ccc/containers/ColonyEditorContainer.js
@@ -13,17 +13,15 @@ export default class ColonyEditorContainer extends React.Component {
     }
 
     componentDidMount() {
-        const { scope, ccc, image, plate, row, col, accessToken } = this.props;
-        SetColonyDetection(
-            scope, ccc, image, plate, accessToken, row, col,
-            this.handleColonyDetectionSuccess.bind(this),
-            () => {},
-        );
+        this.getColonyData(this.props);
     }
 
     componentWillReceiveProps(newProps) {
         this.setState({ colonyData: null });
-        const { scope, ccc, image, plate, row, col, accessToken } = newProps;
+        this.getColonyData(newProps);
+    }
+
+    getColonyData({ scope, ccc, image, plate, row, col, accessToken }) {
         SetColonyDetection(
             scope, ccc, image, plate, accessToken, row, col,
             this.handleColonyDetectionSuccess.bind(this),

--- a/scanomatic/ui_server_data/js/ccc/containers/ColonyEditorContainer.js
+++ b/scanomatic/ui_server_data/js/ccc/containers/ColonyEditorContainer.js
@@ -1,0 +1,82 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import ColonyEditor from '../components/ColonyEditor';
+import { SetColonyCompressionV2, SetColonyDetection } from '../api';
+
+export default class ColonyEditorContainer extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+        this.handleSet = this.handleSet.bind(this);
+        this.handleUpdate = this.handleUpdate.bind(this);
+    }
+
+    componentDidMount() {
+        const { scope, ccc, image, plate, row, col, accessToken } = this.props;
+        SetColonyDetection(
+            scope, ccc, image, plate, accessToken, row, col,
+            this.handleColonyDetectionSuccess.bind(this),
+            () => {},
+        );
+    }
+
+    componentWillReceiveProps(newProps) {
+        this.setState({ colonyData: null });
+        const { scope, ccc, image, plate, row, col, accessToken } = newProps;
+        SetColonyDetection(
+            scope, ccc, image, plate, accessToken, row, col,
+            this.handleColonyDetectionSuccess.bind(this),
+            () => {},
+        );
+    }
+
+    handleColonyDetectionSuccess(data) {
+        this.setState({ colonyData: {
+            image: data.image,
+            imageMin: data.image_min,
+            imageMax: data.image_max,
+            blob: data.blob,
+            background: data.background,
+        }});
+    }
+
+    handleUpdate(data) {
+        const colonyData = Object.assign({}, this.state.colonyData, data);
+        this.setState({ colonyData });
+    }
+
+    handleSet() {
+        const { scope, ccc, image, plate, row, col, accessToken } = this.props;
+        const { colonyData } = this.state;
+        SetColonyCompressionV2(
+            scope, ccc, image, plate, accessToken, colonyData, row, col,
+            () => { this.props.onFinish && this.props.onFinish() },
+            (data) => { alert(`Set Colony compression Error: ${data.reason}`); }
+        );
+    }
+
+    render() {
+        if (!this.state.colonyData) {
+            return null;
+        }
+        return (
+            <ColonyEditor
+                data={this.state.colonyData}
+                onSet={this.handleSet}
+                onUpdate={this.handleUpdate}
+            />
+        );
+    }
+}
+
+ColonyEditorContainer.propTypes = {
+    accessToken: PropTypes.string.isRequired,
+    ccc: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired,
+    plate: PropTypes.string.isRequired,
+    row: PropTypes.number.isRequired,
+    col: PropTypes.number.isRequired,
+    scope: PropTypes.object.isRequired,
+    onFinish: PropTypes.func,
+};

--- a/scanomatic/ui_server_data/js/ccc/helpers.js
+++ b/scanomatic/ui_server_data/js/ccc/helpers.js
@@ -20,7 +20,6 @@ export function getDataUrlfromUrl(src, callback) {
 
 
 export function createCanvasImage(data, canvas) {
-
     var cs = getLinearMapping(data);
     var rows = data.image.length;
     var cols = data.image[0].length;

--- a/scanomatic/ui_server_data/js/ccc/helpers.js
+++ b/scanomatic/ui_server_data/js/ccc/helpers.js
@@ -86,9 +86,8 @@ export function createCanvasMarker(data, canvas) {
     ctx.putImageData(imgdata, 0, 0);
 }
 
-export function getMarkerData(canvasId) {
+export function getMarkerData(cvPlot) {
 
-    var cvPlot = document.getElementById(canvasId);
     var rows = cvPlot.height;
     var cols = cvPlot.width;
 
@@ -150,7 +149,7 @@ export function hexToRgb(hex) {
 export function getLinearMapping(data) {
 
     var colorScheme = ["white", "grey", "black"];
-    var intensityMin = data.blobMin;
+    var intensityMin = data.imageMin;
     var intensityMax = data.imageMax;
     var intensityMean = (intensityMax + intensityMin) / 2;
 

--- a/scanomatic/ui_server_data/js/ccc/helpers.js
+++ b/scanomatic/ui_server_data/js/ccc/helpers.js
@@ -1,4 +1,4 @@
-function getDataUrlfromUrl(src, callback) {
+export function getDataUrlfromUrl(src, callback) {
     var img = new Image();
     img.crossOrigin = 'Anonymous';
     img.onload = function () {

--- a/scanomatic/ui_server_data/js/ccc/scope.js
+++ b/scanomatic/ui_server_data/js/ccc/scope.js
@@ -10,6 +10,7 @@ function Scope() {
     this.AccessToken = null;
     this.Plate = null;
     this.PlateNextTaskInQueue = null;
+    this.PlateColonies = null;
     this.PlateDataURL = null;
     this.PlateGridding = null;
     this.PlateCurrentColony = null;

--- a/scanomatic/ui_server_data/js/specs/components/ColonyEditor.spec.js
+++ b/scanomatic/ui_server_data/js/specs/components/ColonyEditor.spec.js
@@ -1,0 +1,78 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import './enzyme-setup';
+import ColonyEditor from '../../ccc/components/ColonyEditor';
+
+
+describe('<ColonyEditor />', () => {
+    const data = {
+        image: [[0, 1], [1, 0]],
+        blob: [[true, false], [false, true]],
+        background: [[false, true], [true, false]],
+    };
+    const onSet = jasmine.createSpy('onSet');
+    const onUpdate = jasmine.createSpy('onUpdate');
+    let wrapper;
+
+
+    beforeEach(() => {
+        onSet.calls.reset();
+        onUpdate.calls.reset();
+        wrapper = shallow(
+            <ColonyEditor data={data} onSet={onSet} onUpdate={onUpdate} />
+        );
+    });
+
+    it('should render a <ColonyFeatures/>', () => {
+        expect(wrapper.find('ColonyFeatures').exists()).toBe(true);
+    });
+
+    it('should render a "Fix" <button/>', () => {
+        const button = wrapper.find('button.btn-fix');
+        expect(button.exists()).toBe(true);
+        expect(button.text()).toEqual("Fix");
+    });
+
+    it('should render a <ColonyImage/>', () => {
+        expect(wrapper.find('ColonyImage').exists()).toBe(true);
+    });
+
+    it('should render a "Set" <button />', () => {
+        const button = wrapper.find('button.btn-set');
+        expect(button.exists()).toBe(true);
+        expect(button.text()).toEqual('Set');
+
+    });
+
+    it('should set `draw` to true when the "fix" button is clicked', () => {
+        const button = wrapper.find('button.btn-fix');
+        button.simulate('click');
+        const imageCanvas = wrapper.find('ColonyImage');
+        expect(imageCanvas.prop('draw')).toBe(true);
+    });
+
+    it('should call the onSet callback whet the "Set" button is clicked', () => {
+        const button = wrapper.find('button.btn-set');
+        button.simulate('click');
+        expect(onSet).toHaveBeenCalledWith();
+    });
+
+    describe('when the blob is updated', () => {
+        const updatedData = { blob: [[false, false], [true, true]] };
+
+        beforeEach(() => {
+            wrapper.find('button.btn-fix').simulate('click');
+            wrapper.find('ColonyImage').simulate('update', updatedData);
+        });
+
+        it('should set `draw` to false', () => {
+            expect(wrapper.find('ColonyImage').prop('draw')).toBe(false);
+        });
+
+        it('should call the onUpdate callback', () => {
+            expect(onUpdate).toHaveBeenCalledWith(updatedData);
+        });
+
+    });
+});

--- a/scanomatic/ui_server_data/js/specs/components/ColonyFeatures.spec.js
+++ b/scanomatic/ui_server_data/js/specs/components/ColonyFeatures.spec.js
@@ -1,0 +1,14 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import './enzyme-setup';
+import ColonyFeatures from '../../ccc/components/ColonyFeatures';
+import data from '../fixtures/colonyData';
+
+
+describe('<ColonyFeatures />', () => {
+    it('should render a <canvas />', () => {
+        const wrapper = mount(<ColonyFeatures data={data} />);
+        expect(wrapper.find('canvas').exists()).toBe(true);
+    });
+});

--- a/scanomatic/ui_server_data/js/specs/components/ColonyImage.spec.js
+++ b/scanomatic/ui_server_data/js/specs/components/ColonyImage.spec.js
@@ -1,0 +1,50 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import './enzyme-setup';
+import ColonyImage from '../../ccc/components/ColonyImage';
+
+describe('<ColonyImage/>', () => {
+    const data = {
+        image: [[0, 1], [1, 0]],
+        imageMin: 0,
+        imageMax: 1,
+        blob: [[true, false], [false, true]],
+        background: [[false, true], [true, false]],
+    };
+
+    it('should render 1 <canvas/>', () => {
+        const wrapper = mount(<ColonyImage data={data} />);
+        expect(wrapper.find('canvas').length).toEqual(1);
+    });
+
+    it('should render no <button />', () => {
+        const wrapper = mount(<ColonyImage data={data} />);
+        expect(wrapper.find('button').length).toEqual(0);
+    });
+
+
+    describe('when draw=true', () => {
+        it('should render 2 <canvas/>', () => {
+            const wrapper = mount(<ColonyImage data={data} draw/>);
+            expect(wrapper.find('canvas').length).toEqual(2);
+        });
+
+        it('should render a "+", "-" and "Update" buttons', () => {
+            const wrapper = mount(<ColonyImage data={data} draw/>);
+            const buttons = wrapper.find('button')
+            expect(buttons.length).toEqual(3);
+            expect(buttons.at(0).text()).toEqual('+');
+            expect(buttons.at(1).text()).toEqual('-');
+            expect(buttons.at(2).text()).toEqual('Update');
+        });
+
+        it('should call the onUpdate callback when the "Update" button is clicked', () => {
+            const onUpdate = jasmine.createSpy('onUpdate');
+            const wrapper = mount(<ColonyImage data={data} onUpdate={onUpdate} draw/>);
+            const button = wrapper.find('button.btn-update');
+            button.simulate('click');
+            expect(onUpdate).toHaveBeenCalled();
+        });
+    });
+});

--- a/scanomatic/ui_server_data/js/specs/components/enzyme-setup.js
+++ b/scanomatic/ui_server_data/js/specs/components/enzyme-setup.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });

--- a/scanomatic/ui_server_data/js/specs/containers/ColonyEditorContainer.spec.js
+++ b/scanomatic/ui_server_data/js/specs/containers/ColonyEditorContainer.spec.js
@@ -1,0 +1,115 @@
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+
+import '../components/enzyme-setup';
+import ColonyEditorContainer from '../../ccc/containers/ColonyEditorContainer';
+import colonyData from '../fixtures/colonyData.json';
+import * as API from '../../ccc/api';
+
+describe('</ColonyEditorContainer />', () => {
+    const props = {
+        accessToken: 'T0P53CR3T',
+        ccc: 'CCC42',
+        col: 1,
+        image: '1M4G3',
+        plate: 'PL4T3',
+        row: 4,
+        scope: {},
+        onFinish: jasmine.createSpy('onFinish'),
+    };
+
+    beforeEach(() => {
+        props.onFinish.calls.reset();
+        spyOn(API, 'SetColonyDetection').and.callFake(
+            (scope, ccc, image, plate, accessToken, row, col, onSuccess) => {
+                onSuccess({
+                    image: colonyData.image,
+                    image_min: colonyData.imageMin,
+                    image_max: colonyData.imageMax,
+                    blob: colonyData.blob,
+                    background: colonyData.background,
+                });
+            }
+        );
+        spyOn(API, 'SetColonyCompressionV2')    });
+
+    it('should render a <ColonyEditor />', () => {
+        const wrapper = shallow(<ColonyEditorContainer {...props} />);
+        expect(wrapper.find('ColonyEditor').exists()).toBe(true);
+    });
+
+    it('should load the colony data from the api', () => {
+        mount(<ColonyEditorContainer {...props}/>);
+        expect(API.SetColonyDetection).toHaveBeenCalledWith(
+            props.scope, props.ccc, props.image, props.plate,
+            props.accessToken, props.row, props.col, jasmine.any(Function),
+            jasmine.any(Function));
+    });
+
+    it('should reload data from the API when props are updated', () => {
+        const wrapper = mount(<ColonyEditorContainer {...props}/>);
+        wrapper.setProps({ col: 2 });
+        expect(API.SetColonyDetection).toHaveBeenCalledWith(
+            props.scope, props.ccc, props.image, props.plate,
+            props.accessToken, props.row, 2, jasmine.any(Function),
+            jasmine.any(Function));
+    });
+
+    it('should pass the loaded data to the <ColonyEditor />', () => {
+        const wrapper = mount(<ColonyEditorContainer {...props}/>);
+        expect(wrapper.find('ColonyEditor').prop('data'))
+            .toEqual(colonyData);
+    });
+
+    describe('#handleSet', () => {
+        it('should send the data to the server', () => {
+            const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.find('ColonyEditor').prop('onSet')();
+            expect(API.SetColonyCompressionV2).toHaveBeenCalledWith(
+                props.scope, props.ccc, props.image, props.plate,
+                props.accessToken, colonyData, props.row, props.col,
+                jasmine.any(Function), jasmine.any(Function),
+            );
+        });
+
+        it('should call the onFinish callback on success', () => {
+            API.SetColonyCompressionV2.and.callFake(
+                (scope, ccc, image, plate, accessToken, row, col, data, onSuccess) => {
+                    onSuccess();
+                }
+            );
+            const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.find('ColonyEditor').prop('onSet')();
+            expect(props.onFinish).toHaveBeenCalled();
+        });
+
+        it('should show an alert on error', () => {
+            API.SetColonyCompressionV2.and.callFake(
+                (scope, ccc, image, plate, accessToken, row, col, data, onSuccess, onError) => {
+                    onError({ reason: 'Whoops' });
+                }
+            );
+            spyOn(window, 'alert');
+            const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.find('ColonyEditor').prop('onSet')();
+            expect(window.alert)
+                .toHaveBeenCalledWith("Set Colony compression Error: Whoops");
+
+        });
+    });
+
+    describe('#handleUpdate', () => {
+        const newData = {
+            blob: [[true, true], [false, false]],
+            background: [[false, false], [true, true]],
+        };
+
+        it('should update the state', () => {
+            const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.children().prop('onUpdate')(newData);
+            wrapper.update();
+            expect(wrapper.state('colonyData').blob).toEqual(newData.blob);
+            expect(wrapper.state('colonyData').background).toEqual(newData.background);
+        });
+    });
+});

--- a/scanomatic/ui_server_data/js/specs/fixtures/colonyData.json
+++ b/scanomatic/ui_server_data/js/specs/fixtures/colonyData.json
@@ -1,0 +1,7 @@
+{
+    "image": [[0, 1], [1, 0]],
+    "imageMin": 0,
+    "imageMax": 1,
+    "blob": [[true, false], [false, true]],
+    "background": [[false, true], [true, false]]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        presets: ['env']
+                        presets: ['env', 'react']
                     }
                 }
             },


### PR DESCRIPTION
"Fix" by refactoring the colony editor (for lack of a better name) to a react component.
Instead of storing the current colony data in the `scope` object, it uses local component state and doesn't have the reported problem.

Try to keep the UI mostly the same (DOM structure, styles) and reused most of the helper code (API and canvas manipulation).

Add test for the re-factored interaction (corresponding roughly to the removed jquery code) but not the re-used code (API and canvas drawing).