### PR TITLE
Add an <input /> for the cell count in the CCC Colony Editor

### DIFF
--- a/scanomatic/ui_server_data/CCC.html
+++ b/scanomatic/ui_server_data/CCC.html
@@ -36,7 +36,6 @@
 
 <div id="cont" class="container QCCont">
     <h1>Cell Count Calibration</h1>
-    <h2>Selection</h2>
     <div class="section-frame">
         <div class="row">
             <div class="col-md-12">

--- a/scanomatic/ui_server_data/js/ccc/api.js
+++ b/scanomatic/ui_server_data/js/ccc/api.js
@@ -233,14 +233,15 @@ export function SetColonyDetection(cccId, imageId, plate, accessToken, row, col,
     });
 }
 
-export function SetColonyCompression(cccId, imageId, plate, accessToken, colony, row, col, successCallback, errorCallback) {
+export function SetColonyCompression(cccId, imageId, plate, accessToken, colony, cellCount, row, col, successCallback, errorCallback) {
     var path = SetColonyCompressionPath.replace("#0#", cccId).replace("#1#", imageId).replace("#2#", plate).replace("#3#", col).replace("#4#", row);
 
     var data = {
         access_token: accessToken,
         image: colony.image,
         blob: colony.blob,
-        background: colony.background
+        background: colony.background,
+        cell_count: cellCount,
     };
     $.ajax({
         url: path,

--- a/scanomatic/ui_server_data/js/ccc/components/ColonyEditor.js
+++ b/scanomatic/ui_server_data/js/ccc/components/ColonyEditor.js
@@ -55,7 +55,6 @@ export default class ColonyEditor extends React.Component {
                 <div><br /></div>
                 <div><span>Colony MetaData</span></div>
                 <ColonyFeatures data={this.state.data} />
-                <div><span>Cell Count</span></div>
                 <div className={cellCountFormGroupClass} >
                     <label className="control-label" htmlFor="cell-count">Cell Count</label>
                     <input

--- a/scanomatic/ui_server_data/js/ccc/components/ColonyEditor.js
+++ b/scanomatic/ui_server_data/js/ccc/components/ColonyEditor.js
@@ -12,6 +12,7 @@ export default class ColonyEditor extends React.Component {
             data: props.data,
         }
         this.handleClickFix = this.handleClickFix.bind(this);
+        this.handleInputChange = this.handleInputChange.bind(this);
         this.handleUpdate = this.handleUpdate.bind(this);
     }
 
@@ -31,7 +32,18 @@ export default class ColonyEditor extends React.Component {
         this.props.onUpdate && this.props.onUpdate(data);
     }
 
+    handleInputChange(event) {
+        if (this.props.onCellCountChange) {
+            this.props.onCellCountChange(parseInt(event.target.value));
+        }
+    }
+
+
     render() {
+        const cellCountValue =
+            this.props.cellCount == null ? '' : this.props.cellCount;
+        const cellCountFormGroupClass =
+            'form-group' + (this.props.cellCountError ? ' has-error' : '');
         return (
             <div>
                 <div><span>Colony Image</span></div>
@@ -43,6 +55,17 @@ export default class ColonyEditor extends React.Component {
                 <div><br /></div>
                 <div><span>Colony MetaData</span></div>
                 <ColonyFeatures data={this.state.data} />
+                <div><span>Cell Count</span></div>
+                <div className={cellCountFormGroupClass} >
+                    <label className="control-label" htmlFor="cell-count">Cell Count</label>
+                    <input
+                        className="form-control"
+                        type="number"
+                        name="cell-count"
+                        value={cellCountValue}
+                        onChange={this.handleInputChange}
+                    />
+                </div>
                 <div className="text-center">
                     <div className="btn-group">
                         <button
@@ -66,6 +89,9 @@ export default class ColonyEditor extends React.Component {
 
 ColonyEditor.propTypes = {
     data: PropTypes.object.isRequired,
+    cellCount: PropTypes.number,
+    cellCountError: PropTypes.bool,
+    onCellCountChange: PropTypes.func,
     onFix: PropTypes.func,
     onSet: PropTypes.func,
     onSkip: PropTypes.func,

--- a/scanomatic/ui_server_data/js/ccc/containers/ColonyEditorContainer.js
+++ b/scanomatic/ui_server_data/js/ccc/containers/ColonyEditorContainer.js
@@ -59,7 +59,7 @@ export default class ColonyEditorContainer extends React.Component {
     }
 
     handleSet() {
-        if (!this.state.cellCount || this.state.cellCountError) {
+        if (this.state.cellCount == null || this.state.cellCountError) {
             this.setState({ cellCountError: true });
             return;
         }

--- a/scanomatic/ui_server_data/js/ccc/containers/ColonyEditorContainer.js
+++ b/scanomatic/ui_server_data/js/ccc/containers/ColonyEditorContainer.js
@@ -7,7 +7,12 @@ import { SetColonyCompression, SetColonyDetection } from '../api';
 export default class ColonyEditorContainer extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {};
+        this.state = {
+            colonyData: null,
+            cellCount: null,
+            cellCountError: false,
+        };
+        this.handleCellCountChange = this.handleCellCountChange.bind(this);
         this.handleSet = this.handleSet.bind(this);
         this.handleSkip = this.handleSkip.bind(this);
         this.handleUpdate = this.handleUpdate.bind(this);
@@ -18,7 +23,11 @@ export default class ColonyEditorContainer extends React.Component {
     }
 
     componentWillReceiveProps(newProps) {
-        this.setState({ colonyData: null });
+        this.setState({
+            cellCount: null,
+            cellCountError: false,
+            colonyData: null,
+        });
         this.getColonyData(newProps);
     }
 
@@ -28,6 +37,10 @@ export default class ColonyEditorContainer extends React.Component {
             this.handleColonyDetectionSuccess.bind(this),
             () => {},
         );
+    }
+
+    handleCellCountChange(cellCount) {
+        this.setState({ cellCount, cellCountError: cellCount < 0 });
     }
 
     handleColonyDetectionSuccess(data) {
@@ -46,10 +59,14 @@ export default class ColonyEditorContainer extends React.Component {
     }
 
     handleSet() {
+        if (!this.state.cellCount || this.state.cellCountError) {
+            this.setState({ cellCountError: true });
+            return;
+        }
         const { ccc, image, plate, row, col, accessToken } = this.props;
-        const { colonyData } = this.state;
+        const { cellCount, colonyData } = this.state;
         SetColonyCompression(
-            ccc, image, plate, accessToken, colonyData, row, col,
+            ccc, image, plate, accessToken, colonyData, cellCount, row, col,
             () => { this.props.onFinish && this.props.onFinish() },
             (data) => { alert(`Set Colony compression Error: ${data.reason}`); }
         );
@@ -66,6 +83,9 @@ export default class ColonyEditorContainer extends React.Component {
         return (
             <ColonyEditor
                 data={this.state.colonyData}
+                cellCount={this.state.cellCount}
+                cellCountError={this.state.cellCountError}
+                onCellCountChange={this.handleCellCountChange}
                 onSet={this.handleSet}
                 onSkip={this.handleSkip}
                 onUpdate={this.handleUpdate}

--- a/scanomatic/ui_server_data/js/specs/api.spec.js
+++ b/scanomatic/ui_server_data/js/specs/api.spec.js
@@ -68,6 +68,7 @@ describe('API', () => {
     describe('SetColonyCompression', () => {
         const onSuccess = jasmine.createSpy('onSuccess');
         const onError = jasmine.createSpy('onError');
+        const cellCount = 666;
         const args = [
             'CCC42',
             '1M4G3',
@@ -77,6 +78,7 @@ describe('API', () => {
                 blob: [[true, false], [false, true]],
                 background: [[false, true], [true, false]],
             },
+            cellCount,
             4,
             1,
             onSuccess,
@@ -97,6 +99,12 @@ describe('API', () => {
             SetColonyCompression(...args);
             expect(jasmine.Ajax.requests.mostRecent().url)
                 .toBe('/api/data/calibration/CCC42/image/1M4G3/plate/PL4T3/compress/colony/1/4');
+        });
+
+        it('should send the cell count', () => {
+            SetColonyCompression(...args);
+            const params = JSON.parse(jasmine.Ajax.requests.mostRecent().params);
+            expect(params.cell_count).toEqual(cellCount);
         });
 
         it('should call onSuccess on success', () => {

--- a/scanomatic/ui_server_data/js/specs/components/ColonyEditor.spec.js
+++ b/scanomatic/ui_server_data/js/specs/components/ColonyEditor.spec.js
@@ -14,6 +14,7 @@ describe('<ColonyEditor />', () => {
     const onSet = jasmine.createSpy('onSet');
     const onSkip = jasmine.createSpy('onSkip');
     const onUpdate = jasmine.createSpy('onUpdate');
+    const onCellCountChange = jasmine.createSpy('onCellCountChange');
     let wrapper;
 
 
@@ -21,8 +22,17 @@ describe('<ColonyEditor />', () => {
         onSet.calls.reset();
         onSkip.calls.reset();
         onUpdate.calls.reset();
+        onCellCountChange.calls.reset();
         wrapper = shallow(
-            <ColonyEditor data={data} onSet={onSet} onSkip={onSkip} onUpdate={onUpdate} />
+            <ColonyEditor
+                data={data}
+                cellCount={1234}
+                cellCountError={false}
+                onSet={onSet}
+                onSkip={onSkip}
+                onUpdate={onUpdate}
+                onCellCountChange={onCellCountChange}
+            />
         );
     });
 
@@ -51,6 +61,30 @@ describe('<ColonyEditor />', () => {
         const button = wrapper.find('button.btn-skip')
         expect(button.exists()).toBeTruthy();
         expect(button.text()).toEqual('Skip');
+    });
+
+    it('should render an <input /> for the cell count', () => {
+        const input = wrapper.find('input[name="cell-count"]');
+        expect(input.exists()).toBeTruthy();
+        expect(input.prop('value')).toEqual(1234);
+    });
+
+    it('should not mark the <input /> as error if cellCountError is false', () => {
+        wrapper.setProps({ cellCountError: false });
+        const input = wrapper.find('input[name="cell-count"]');
+        expect(input.parent().prop('className')).not.toContain('has-error');
+    });
+
+    it('should mark the <input /> as error if cellCountError is true', () => {
+        wrapper.setProps({ cellCountError: true });
+        const input = wrapper.find('input[name="cell-count"]');
+        expect(input.parent().prop('className')).toContain('has-error');
+    });
+
+    it('should call the onCellCountChange callback when the input is changed', () => {
+        const input = wrapper.find('input[name="cell-count"]');
+        input.simulate('change', { target: { value: '666' } });
+        expect(onCellCountChange).toHaveBeenCalledWith(666);
     });
 
     it('should set `draw` to true when the "fix" button is clicked', () => {

--- a/scanomatic/ui_server_data/js/specs/containers/ColonyEditorContainer.spec.js
+++ b/scanomatic/ui_server_data/js/specs/containers/ColonyEditorContainer.spec.js
@@ -54,46 +54,100 @@ describe('</ColonyEditorContainer />', () => {
             jasmine.any(Function));
     });
 
+    it('should reset the cellCount and cellCountError state when props are updated', () => {
+        const wrapper = mount(<ColonyEditorContainer {...props}/>);
+        wrapper.setState({ cellCount: 33, cellCountError: true });
+        wrapper.setProps({ col: 2 });
+        expect(wrapper.state('cellCount')).toBe(null);
+        expect(wrapper.state('cellCountError')).toBeFalsy();
+    });
+
     it('should pass the loaded data to the <ColonyEditor />', () => {
         const wrapper = mount(<ColonyEditorContainer {...props}/>);
         expect(wrapper.find('ColonyEditor').prop('data'))
             .toEqual(colonyData);
     });
 
+    describe('#handleCellCountChange', () => {
+        it('should set cell count', () => {
+            const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.find('ColonyEditor').prop('onCellCountChange')(666);
+            wrapper.update();
+            expect(wrapper.find('ColonyEditor').prop('cellCount')).toEqual(666);
+        });
+
+        it('should set cellCountError to true if cell count is < 0', () => {
+            const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.find('ColonyEditor').prop('onCellCountChange')(-666);
+            wrapper.update();
+            expect(wrapper.find('ColonyEditor').prop('cellCountError')).toBeTruthy();
+        });
+
+        it('should set cellCountError to false if cell count is >= 0', () => {
+            const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.find('ColonyEditor').prop('onCellCountChange')(666);
+            expect(wrapper.find('ColonyEditor').prop('cellCountError')).toBeFalsy();
+        });
+    });
+
     describe('#handleSet', () => {
-        it('should send the data to the server', () => {
+        it('should not call the API if cell count not set', () => {
             const wrapper = mount(<ColonyEditorContainer {...props}/>);
             wrapper.find('ColonyEditor').prop('onSet')();
+            expect(API.SetColonyCompression).not.toHaveBeenCalled()
+        });
+
+        it('should set cellCountError to true if cell count is not set', () => {
+            const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.find('ColonyEditor').prop('onSet')();
+            wrapper.update();
+            expect(wrapper.find('ColonyEditor').prop('cellCountError')).toBeTruthy();
+        });
+
+        it('should not call the API if cell count error is true', () => {
+            const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.setState({ cellCount: -666 });
+            wrapper.setState({ cellCountError: true });
+            wrapper.find('ColonyEditor').prop('onSet')();
+            expect(API.SetColonyCompression).not.toHaveBeenCalled()
+        });
+
+
+        it('should send the data to the server', () => {
+            const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.setState({ cellCount: 666 });
+            wrapper.find('ColonyEditor').prop('onSet')();
             expect(API.SetColonyCompression).toHaveBeenCalledWith(
-                props.ccc, props.image, props.plate,
-                props.accessToken, colonyData, props.row, props.col,
+                props.ccc, props.image, props.plate, props.accessToken,
+                colonyData, 666, props.row, props.col,
                 jasmine.any(Function), jasmine.any(Function),
             );
         });
 
         it('should call the onFinish callback on success', () => {
             API.SetColonyCompression.and.callFake(
-                (ccc, image, plate, accessToken, row, col, data, onSuccess) => {
+                (ccc, image, plate, accessToken, row, col, data, cellCount, onSuccess) => {
                     onSuccess();
                 }
             );
             const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.setState({ cellCount: 666 });
             wrapper.find('ColonyEditor').prop('onSet')();
             expect(props.onFinish).toHaveBeenCalled();
         });
 
         it('should show an alert on error', () => {
             API.SetColonyCompression.and.callFake(
-                (ccc, image, plate, accessToken, row, col, data, onSuccess, onError) => {
+                (ccc, image, plate, accessToken, row, col, data, cellCount, onSuccess, onError) => {
                     onError({ reason: 'Whoops' });
                 }
             );
             spyOn(window, 'alert');
             const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.setState({ cellCount: 666 });
             wrapper.find('ColonyEditor').prop('onSet')();
             expect(window.alert)
                 .toHaveBeenCalledWith("Set Colony compression Error: Whoops");
-
         });
     });
 

--- a/scanomatic/ui_server_data/js/specs/containers/ColonyEditorContainer.spec.js
+++ b/scanomatic/ui_server_data/js/specs/containers/ColonyEditorContainer.spec.js
@@ -83,9 +83,15 @@ describe('</ColonyEditorContainer />', () => {
             expect(wrapper.find('ColonyEditor').prop('cellCountError')).toBeTruthy();
         });
 
-        it('should set cellCountError to false if cell count is >= 0', () => {
+        it('should set cellCountError to false if cell count is > 0', () => {
             const wrapper = mount(<ColonyEditorContainer {...props}/>);
             wrapper.find('ColonyEditor').prop('onCellCountChange')(666);
+            expect(wrapper.find('ColonyEditor').prop('cellCountError')).toBeFalsy();
+        });
+
+        it('should set cellCountError to false if cell count is = 0', () => {
+            const wrapper = mount(<ColonyEditorContainer {...props}/>);
+            wrapper.find('ColonyEditor').prop('onCellCountChange')(0);
             expect(wrapper.find('ColonyEditor').prop('cellCountError')).toBeFalsy();
         });
     });
@@ -111,7 +117,6 @@ describe('</ColonyEditorContainer />', () => {
             wrapper.find('ColonyEditor').prop('onSet')();
             expect(API.SetColonyCompression).not.toHaveBeenCalled()
         });
-
 
         it('should send the data to the server', () => {
             const wrapper = mount(<ColonyEditorContainer {...props}/>);


### PR DESCRIPTION
Cell count needs to be set and a positive number to be able to "Set" the
colony.
If there is no cell count when pressing set, or if the cell count is
negative, it gets the bootstrap class "has-error".