### PR TITLE
Javascript coverage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+    "presets": ["env", "react"],
+    "env": {
+        "test": {
+            "plugins": [ "istanbul" ]
+        }
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ data/config/rpc.admin
 /htmlcov
 /Scan_o_Matic.egg-info
 docker-compose.override.yml
-scanomatic/ui_server_data/js/ccc.js
+/scanomatic/ui_server_data/js/ccc.js
+/scanomatic/ui_server_data/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ addons:
   firefox: latest
 
 before_install:
-    - pip install tox python-coveralls
+    - pip install tox coveralls
+    - gem install coveralls-lcov
     - wget -N http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip -P ~/
     - unzip ~/chromedriver_linux64.zip -d ~/
     - rm ~/chromedriver_linux64.zip
@@ -29,4 +30,5 @@ script:
     - tox
     - npm test
 after_success:
-    - coveralls
+    - coveralls-lcov -v -n scanomatic/ui_server_data/coverage/report-lcov/lcov.info > js-coverage.json
+    - coveralls --merge=js-coverage.json

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,7 +33,16 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['mocha'],
+    reporters: ['mocha', 'coverage'],
+
+    coverageReporter: {
+        dir: 'coverage',
+        reporters: [
+            { type: 'html', subdir: 'report-html' },
+            { type: 'lcov', subdir: 'report-lcov' },
+        ],
+    },
+
 
     // web server port
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jasmine-core": "^2.8.0",
     "karma": "^1.7.1",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.1.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "scripts": {
-    "test": "karma start --single-run",
+    "test": "BABEL_ENV=test karma start --single-run",
     "build": "webpack"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-istanbul": "^4.1.5",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "enzyme": "^3.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,9 +12,6 @@ module.exports = {
                 exclude: /node_modules/,
                 use: {
                     loader: 'babel-loader',
-                    options: {
-                        presets: ['env', 'react']
-                    }
                 }
             },
             {


### PR DESCRIPTION
Generate coverage report for the javascript tests and send to coveralls.

It's a tad convoluted: you need to generate the javascript coverage in the lcov file format, convert it to coveralls' json format using a ruby script and then pass this file to the python coveralls client that merges it with the python coverage. 