### PR TITLE
Fix feature colors

### DIFF
--- a/scanomatic/ui_server_data/js/ccc/components/ColonyFeatures.js
+++ b/scanomatic/ui_server_data/js/ccc/components/ColonyFeatures.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { createCanvasMarker } from '../helpers';
+import { createCanvasMarker, featureColors } from '../helpers';
 
 export default class ColonyFeatures extends React.Component {
     componentDidMount() {
@@ -18,9 +18,9 @@ export default class ColonyFeatures extends React.Component {
 
     render() {
         const legend = [
-            { color: "red", text: "Blob" },
-            { color: "#7FFFD4", text: "Background" },
-            { color: "black", text: "Neither" },
+            { color: featureColors.blob.toCSSString(), text: "Blob" },
+            { color: featureColors.background.toCSSString(), text: "Background" },
+            { color: featureColors.neither.toCSSString(), text: "Neither" },
         ];
 
         const style = {

--- a/scanomatic/ui_server_data/js/ccc/helpers.js
+++ b/scanomatic/ui_server_data/js/ccc/helpers.js
@@ -1,6 +1,26 @@
 import * as API from './api';
 
 
+export class RGBColor {
+    constructor(r, g, b) {
+        this.r = r;
+        this.g = g;
+        this.b = b;
+    }
+
+    toCSSString() {
+        return `rgb(${this.r}, ${this.g}, ${this.b})`;
+    }
+}
+
+
+export const featureColors = {
+    blob: new RGBColor(253, 231, 35),
+    background: new RGBColor(32, 144, 140),
+    neither: new RGBColor(68, 1, 84),
+};
+
+
 export function getDataUrlfromUrl(src, callback) {
     var img = new Image();
     img.crossOrigin = 'Anonymous';
@@ -73,11 +93,11 @@ export function createCanvasMarker(data, canvas) {
         }
         var rgb;
         if (data.blob[imageRow][imageCol] === true) {
-            rgb = { r: 255, g: 0, b: 0 }
+            rgb = featureColors.blob;
         } else if (data.background[imageRow][imageCol] === true) {
-            rgb = { r: 0, g: 128, b: 0 }
+            rgb = featureColors.background;
         } else {
-            rgb = { r: 0, g: 0, b: 0 };
+            rgb = featureColors.neither;
         }
 
         imgdata.data[i + 0] = rgb.r;    // RED (0-255)

--- a/scanomatic/ui_server_data/js/specs/helpers.spec.js
+++ b/scanomatic/ui_server_data/js/specs/helpers.spec.js
@@ -1,4 +1,4 @@
-import { loadImage, uploadImage } from '../ccc/helpers';
+import { RGBColor, loadImage, uploadImage } from '../ccc/helpers';
 import testPlateImageURL from './fixtures/testPlate.png';
 import * as API from '../ccc/api';
 
@@ -127,5 +127,19 @@ describe('UploadImage', () => {
             expect(value).toEqual(imageId);
             done();
         });
+    });
+});
+
+describe('RGBColor', () => {
+    it('should have attribute r, g and b', () => {
+        const color = new RGBColor(0, 128, 255);
+        expect(color.r).toEqual(0);
+        expect(color.g).toEqual(128);
+        expect(color.b).toEqual(255);
+    });
+
+    it('should be able to generate a CSS string representation of the color', () => {
+        const color = new RGBColor(0, 128, 255);
+        expect(color.toCSSString()).toEqual('rgb(0, 128, 255)');
     });
 });


### PR DESCRIPTION
By popular demand, here are two changes to the way colony features are visualized:
- use a better (I hope) color palette. The new color are two extremes plus middle values from the viridis color map in matplotlib.
- derive the color used in the legend from the actual rgb value so that there is no discrepancy

Here is how it looks, first the wrong features returned by the API that shows the "neither" color, then the "fixed" features:
![screenshot-2017-11-17 cell count calibration 11](https://user-images.githubusercontent.com/38019/32960617-e0f7e986-cbc5-11e7-8e73-c2826e36b3b0.png)![screenshot-2017-11-17 cell count calibration 12](https://user-images.githubusercontent.com/38019/32960619-e1f5b3ae-cbc5-11e7-9402-d6a18e325e3e.png)

(Note that this revealed some artifacts that appear when turning the circle shape into a pixel array. I'm guessing they were already there before but less visible. But maybe it's a feature ;o))

