### PR TITLE
Add a button to finalize CCC

### DIFF
--- a/scanomatic/ui_server_data/js/ccc/api.js
+++ b/scanomatic/ui_server_data/js/ccc/api.js
@@ -252,3 +252,10 @@ export function SetNewCalibrationPolynomial(cccId, power, accessToken) {
         {access_token: accessToken},
     );
 }
+
+export function finalizeCalibration(cccId, accessToken) {
+    return API.postJSON(
+        `/api/calibration/${cccId}/finalize`,
+        { access_token: accessToken },
+    );
+}

--- a/scanomatic/ui_server_data/js/ccc/components/CCCEditor.js
+++ b/scanomatic/ui_server_data/js/ccc/components/CCCEditor.js
@@ -31,7 +31,10 @@ export default function CCCEditor(props) {
                 cccMetadata={props.cccMetadata}
                 onFinish={props.onFinishUpload}
             />
-            <PolynomialConstructionContainer cccMetadata={props.cccMetadata} />
+            <PolynomialConstructionContainer
+                cccMetadata={props.cccMetadata}
+                onFinalizeCCC={props.onFinalizeCCC}
+            />
         </div>
     );
 }
@@ -44,6 +47,7 @@ CCCEditor.propTypes = {
         plateId: PropTypes.number.isRequired,
     })).isRequired,
     currentPlate: PropTypes.number,
+    onFinalizeCCC: PropTypes.func.isRequired,
     onFinishPlate: PropTypes.func.isRequired,
     onFinishUpload: PropTypes.func.isRequired,
 };

--- a/scanomatic/ui_server_data/js/ccc/components/FinalizedCCC.jsx
+++ b/scanomatic/ui_server_data/js/ccc/components/FinalizedCCC.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import CCCPropTypes from '../prop-types';
+
+export default function FinalizedCCC(props) {
+    return (
+        <div className="row">
+            <div className="col-md-6 col-md-offset-3 text-center">
+                <h3>Well Done!</h3>
+                <p>
+                    Calibration activated and ready to use.
+                    It will be available as
+                    &ldquo;{props.cccMetadata.species}, {props.cccMetadata.reference}&rdquo;
+                    in new experiments.
+                </p>
+                <div className="text-center">
+                    <a href="/" className="btn btn-primary">Go to home page</a>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+FinalizedCCC.propTypes = {
+    cccMetadata: CCCPropTypes.cccMetadata.isRequired,
+};

--- a/scanomatic/ui_server_data/js/ccc/components/PolynomialConstruction.js
+++ b/scanomatic/ui_server_data/js/ccc/components/PolynomialConstruction.js
@@ -28,9 +28,16 @@ export default function PolynomialConstruction(props) {
     return (
         <div>
             <button
-                className="btn btn-default"
+                className="btn btn-default btn-construct"
                 onClick={props.onConstruction}
             >Construct Cell Count Calibration Polynomial</button>
+            <button
+                className="btn btn-success btn-finalize"
+                disabled={!props.polynomial}
+                onClick={props.onFinalizeCCC}
+            >
+                Finalize and publish calibration
+            </button>
             {error}
             {results}
         </div>
@@ -40,6 +47,7 @@ export default function PolynomialConstruction(props) {
 PolynomialConstruction.propTypes = {
     onConstruction: PropTypes.func.isRequired,
     onClearError: PropTypes.func.isRequired,
+    onFinalizeCCC: PropTypes.func.isRequired,
     polynomial: PropTypes.shape({
         power: PropTypes.number.isRequired,
         coefficients: PropTypes.array.isRequired,

--- a/scanomatic/ui_server_data/js/ccc/components/Root.jsx
+++ b/scanomatic/ui_server_data/js/ccc/components/Root.jsx
@@ -4,14 +4,18 @@ import React from 'react';
 import CCCPropTypes from '../prop-types';
 import CCCInitializationContainer from '../containers/CCCInitializationContainer';
 import CCCEditorContainer from '../containers/CCCEditorContainer';
+import FinalizedCCC from './FinalizedCCC';
 
 
 export default function Root(props) {
     let view;
-    if (props.cccMetadata) {
+    if (props.cccMetadata && props.finalized) {
+        view = <FinalizedCCC cccMetadata={props.cccMetadata} />;
+    } else if (props.cccMetadata) {
         view = (
             <CCCEditorContainer
                 cccMetadata={props.cccMetadata}
+                onFinalizeCCC={props.onFinalizeCCC}
             />
         );
     } else {
@@ -37,11 +41,14 @@ export default function Root(props) {
 Root.propTypes = {
     cccMetadata: CCCPropTypes.cccMetadata,
     error: PropTypes.string,
+    finalized: PropTypes.bool,
     onError: PropTypes.func.isRequired,
+    onFinalizeCCC: PropTypes.func.isRequired,
     onInitializeCCC: PropTypes.func.isRequired,
 };
 
 Root.defaultProps = {
     cccMetadata: null,
     error: null,
+    finalized: false,
 };

--- a/scanomatic/ui_server_data/js/ccc/containers/CCCEditorContainer.js
+++ b/scanomatic/ui_server_data/js/ccc/containers/CCCEditorContainer.js
@@ -59,6 +59,7 @@ export default class CCCEditorContainer extends React.Component {
                 cccMetadata={this.props.cccMetadata}
                 plates={this.state.plates}
                 currentPlate={this.state.currentPlate}
+                onFinalizeCCC={this.props.onFinalizeCCC}
                 onFinishUpload={this.handleFinishUpload}
                 onFinishPlate={this.handleFinishPlate}
                 ready={this.state.ready}
@@ -69,4 +70,5 @@ export default class CCCEditorContainer extends React.Component {
 
 CCCEditorContainer.propTypes = {
     cccMetadata: CCCPropTypes.cccMetadata.isRequired,
+    onFinalizeCCC: PropTypes.func.isRequired,
 };

--- a/scanomatic/ui_server_data/js/ccc/containers/PolynomialConstructionContainer.js
+++ b/scanomatic/ui_server_data/js/ccc/containers/PolynomialConstructionContainer.js
@@ -64,10 +64,12 @@ export default class PolynomialConstructionContainer extends React.Component {
             error={this.state.error}
             onClearError={this.handleClearError}
             onConstruction={this.handleConstruction}
+            onFinalizeCCC={this.props.onFinalizeCCC}
         />;
     }
 }
 
 PolynomialConstructionContainer.propTypes = {
     cccMetadata: CCCPropTypes.cccMetadata.isRequired,
+    onFinalizeCCC: PropTypes.func.isRequired,
 };

--- a/scanomatic/ui_server_data/js/ccc/containers/RootContainer.jsx
+++ b/scanomatic/ui_server_data/js/ccc/containers/RootContainer.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Root from '../components/Root';
-import { InitiateCCC } from '../api';
+import { InitiateCCC, finalizeCalibration } from '../api';
 
 
 export default class RootContainer extends React.Component {
@@ -10,9 +10,11 @@ export default class RootContainer extends React.Component {
         this.state = {
             cccMetadata: null,
             error: null,
+            finalized: false,
         };
         this.handleError = this.handleError.bind(this);
         this.handleInitializeCCC = this.handleInitializeCCC.bind(this);
+        this.handleFinalizeCCC = this.handleFinalizeCCC.bind(this);
     }
 
     handleInitializeCCC(species, reference, fixtureName, pinningFormat) {
@@ -29,6 +31,16 @@ export default class RootContainer extends React.Component {
         );
     }
 
+    handleFinalizeCCC() {
+        const { id, accessToken } = this.state.cccMetadata;
+        finalizeCalibration(id, accessToken).then(
+            () => this.setState({ error: null, finalized: true }),
+            reason => this.setState({
+                error: `Finalization error: ${reason}`,
+            }),
+        );
+    }
+
     handleError(error) {
         this.setState({ error });
     }
@@ -38,7 +50,9 @@ export default class RootContainer extends React.Component {
             <Root
                 cccMetadata={this.state.cccMetadata}
                 error={this.state.error}
+                finalized={this.state.finalized}
                 onInitializeCCC={this.handleInitializeCCC}
+                onFinalizeCCC={this.handleFinalizeCCC}
                 onError={this.handleError}
             />
         );

--- a/scanomatic/ui_server_data/js/specs/api.spec.js
+++ b/scanomatic/ui_server_data/js/specs/api.spec.js
@@ -707,7 +707,7 @@ describe('API', () => {
         });
     });
 
-   describe('finalizeCalibration', () => {
+    describe('finalizeCalibration', () => {
         const args = ['CCC0', 'T0K3N'];
 
         it('should query the correct URL', () => {

--- a/scanomatic/ui_server_data/js/specs/api.spec.js
+++ b/scanomatic/ui_server_data/js/specs/api.spec.js
@@ -706,4 +706,45 @@ describe('API', () => {
             });
         });
     });
+
+   describe('finalizeCalibration', () => {
+        const args = ['CCC0', 'T0K3N'];
+
+        it('should query the correct URL', () => {
+            API.finalizeCalibration(...args);
+            expect(mostRecentRequest().url)
+                .toEqual('/api/calibration/CCC0/finalize');
+        });
+
+        it('should send a POST request', () => {
+            API.finalizeCalibration(...args);
+            expect(mostRecentRequest().method).toEqual('POST');
+        });
+
+        it('should send the access_coken', () => {
+            API.finalizeCalibration(...args);
+            expect(JSON.parse(mostRecentRequest().params).access_token)
+                .toEqual('T0K3N');
+        });
+
+        it('should return a promise that resolves on success', (done) => {
+            API.finalizeCalibration(...args).then((value) => {
+                expect(value).toEqual({});
+                done();
+            });
+            mostRecentRequest().respondWith({
+                status: 200, responseText: JSON.stringify({}),
+            });
+        });
+
+        it('should return a promise that rejects on error', (done) => {
+            API.finalizeCalibration(...args).catch((reason) => {
+                expect(reason).toEqual('(+_+)');
+                done();
+            });
+            mostRecentRequest().respondWith({
+                status: 400, responseText: JSON.stringify({ reason: '(+_+)' }),
+            });
+        });
+    });
 });

--- a/scanomatic/ui_server_data/js/specs/components/CCCEditor.spec.js
+++ b/scanomatic/ui_server_data/js/specs/components/CCCEditor.spec.js
@@ -6,6 +6,7 @@ import CCCEditor from '../../ccc/components/CCCEditor';
 import cccMetadata from '../fixtures/cccMetadata';
 
 describe('<CCCEditor />', () => {
+    const onFinalizeCCC = jasmine.createSpy('onFinalizeCCC');
     const onFinishPlate = jasmine.createSpy('onFinishPlate');
     const onFinishUpload = jasmine.createSpy('onFinishUpload');
     const props = {
@@ -16,6 +17,7 @@ describe('<CCCEditor />', () => {
             { imageName: 'other-image.tiff', imageId: '1M4G32', plateId: 2 },
         ],
         currentPlate: 1,
+        onFinalizeCCC,
         onFinishPlate,
         onFinishUpload,
     };
@@ -40,6 +42,12 @@ describe('<CCCEditor />', () => {
         const wrapper = shallow(<CCCEditor {...props} />);
         expect(wrapper.find('PolynomialConstructionContainer').prop('cccMetadata'))
             .toEqual(cccMetadata);
+    });
+
+    it('should pass onFinalizeCCC to <PolynomialConstructionContainer />', () => {
+        const wrapper = shallow(<CCCEditor {...props} />);
+        expect(wrapper.find('PolynomialConstructionContainer').prop('onFinalizeCCC'))
+            .toBe(onFinalizeCCC);
     });
 
     describe('when currentImage is null', () => {

--- a/scanomatic/ui_server_data/js/specs/components/FinalizedCCC.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/FinalizedCCC.spec.jsx
@@ -1,0 +1,29 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import './enzyme-setup';
+import FinalizedCCC from '../../ccc/components/FinalizedCCC';
+import cccMetadata from '../fixtures/cccMetadata';
+
+
+describe('<FinalizedCCC />', () => {
+    const props = { cccMetadata };
+
+    it('should say "Well Done!"', () => {
+        const wrapper = shallow(<FinalizedCCC {...props} />);
+        expect(wrapper.text()).toContain('Well Done!');
+    });
+
+    it('should show the calibration as string', () => {
+        const wrapper = shallow(<FinalizedCCC {...props} />);
+        expect(wrapper.text()).toContain('S. Kombuchae, Professor X');
+    });
+
+    it('should show a button to go to the home page', () => {
+        const wrapper = shallow(<FinalizedCCC {...props} />);
+        const btnWrapper = wrapper.find('a.btn');
+        expect(btnWrapper.exists()).toBeTruthy();
+        expect(btnWrapper.text()).toContain('Go to home page');
+        expect(btnWrapper.prop('href')).toEqual('/');
+    });
+});

--- a/scanomatic/ui_server_data/js/specs/components/PolynomialConstruction.spec.js
+++ b/scanomatic/ui_server_data/js/specs/components/PolynomialConstruction.spec.js
@@ -6,9 +6,11 @@ import PolynomialConstruction from
     '../../ccc/components/PolynomialConstruction';
 
 describe('<PolynomialConstruction />', () => {
+    const onFinalizeCCC = jasmine.createSpy('onFinalizeCCC');
     const props = {
         onConstruction: jasmine.createSpy('onConstruction'),
         onClearError: () => {},
+        onFinalizeCCC,
         polynomial: {
             power: -7,
             coefficients: [42, 42, 42],
@@ -22,10 +24,31 @@ describe('<PolynomialConstruction />', () => {
     });
 
 
-    it('should render a button', () => {
+    it('should render a button to construct the polynomial', () => {
         const wrapper = shallow(<PolynomialConstruction {...props} />);
-        expect(wrapper.find('button.btn').exists()).toBeTruthy();
-        expect(wrapper.find('button.btn').length).toEqual(1);
+        expect(wrapper.find('button.btn-construct').exists()).toBeTruthy();
+        expect(wrapper.find('button.btn-construct').length).toEqual(1);
+    });
+
+    it('should render a finalize button', () => {
+        const wrapper = shallow(<PolynomialConstruction {...props} />);
+        expect(wrapper.find('button.btn-finalize').exists()).toBeTruthy();
+    });
+
+    it('should enable the finalize button if there is a polynomial', () => {
+        const wrapper = shallow(<PolynomialConstruction {...props} />);
+        expect(wrapper.find('button.btn-finalize').prop('disabled')).toBeFalsy();
+    });
+
+    it('should disable the finalize button if there is no polynomial', () => {
+        const wrapper = shallow(<PolynomialConstruction {...props} polynomial={null} />);
+        expect(wrapper.find('button.btn-finalize').prop('disabled')).toBeTruthy();
+    });
+
+    it('should call onFinalizeCCC when the finalize button is clicked', () => {
+        const wrapper = shallow(<PolynomialConstruction {...props} polynomial={null} />);
+        wrapper.find('button.btn-finalize').simulate('click');
+        expect(onFinalizeCCC).toHaveBeenCalled();
     });
 
     it('should render a PolynomialResultsInfo', () => {
@@ -43,7 +66,7 @@ describe('<PolynomialConstruction />', () => {
 
     it('should call onConstruction when clicked', () => {
         const wrapper = shallow(<PolynomialConstruction {...props} />);
-        wrapper.find('button.btn').simulate('click');
+        wrapper.find('button.btn-construct').simulate('click');
         expect(props.onConstruction).toHaveBeenCalled();
     });
 

--- a/scanomatic/ui_server_data/js/specs/components/Root.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/Root.spec.jsx
@@ -8,8 +8,9 @@ import cccMetadata from '../fixtures/cccMetadata';
 
 describe('<Root />', () => {
     const onInitializeCCC = jasmine.createSpy('onInitialzeCCC');
+    const onFinalizeCCC = jasmine.createSpy('onFinalizeCCC');
     const onError = jasmine.createSpy('onError');
-    const props = { onError, onInitializeCCC };
+    const props = { onError, onInitializeCCC, onFinalizeCCC };
 
     it('should render the error', () => {
         const error = 'Bad! Wrong! Boooh!';
@@ -47,6 +48,24 @@ describe('<Root />', () => {
             const wrapper = shallow(<Root {...props} cccMetadata={cccMetadata} />);
             expect(wrapper.find('CCCEditorContainer').prop('cccMetadata'))
                 .toEqual(cccMetadata);
+        });
+
+        it('should pass onFinalizeCCC to <CCCEditorContainer />', () => {
+            const wrapper = shallow(<Root {...props} cccMetadata={cccMetadata} />);
+            expect(wrapper.find('CCCEditorContainer').prop('onFinalizeCCC'))
+                .toEqual(onFinalizeCCC);
+        });
+    });
+
+    describe('finalized', () => {
+        it('should render a <FinalizedCCC />', () => {
+            const wrapper = shallow(<Root {...props} cccMetadata={cccMetadata} finalized />);
+            expect(wrapper.find('FinalizedCCC').exists()).toBeTruthy();
+        });
+
+        it('should pass cccMetadata to <FinalizedCCC />', () => {
+            const wrapper = shallow(<Root {...props} cccMetadata={cccMetadata} finalized />);
+            expect(wrapper.find('FinalizedCCC').prop('cccMetadata')).toEqual(cccMetadata);
         });
     });
 });

--- a/scanomatic/ui_server_data/js/specs/containers/CCCEditorContainer.spec.js
+++ b/scanomatic/ui_server_data/js/specs/containers/CCCEditorContainer.spec.js
@@ -8,7 +8,9 @@ import cccMetadata from '../fixtures/cccMetadata';
 import FakePromise from '../helpers/FakePromise';
 
 describe('<CCCEditorContainer />', () => {
-    const props = { cccMetadata };
+    const props = {
+        cccMetadata, onFinalizeCCC: jasmine.createSpy('onFinalizeCCC'),
+    };
 
     const image = {
         name: 'new-image.tiff',
@@ -27,6 +29,12 @@ describe('<CCCEditorContainer />', () => {
     it('should pass cccMetadata to <CCCEditor />', () => {
         const wrapper = shallow(<CCCEditorContainer {...props} />);
         expect(wrapper.find('CCCEditor').prop('cccMetadata')).toEqual(props.cccMetadata);
+    });
+
+    it('should pass onFinalizeCCC to <CCCEditor />', () => {
+        const wrapper = shallow(<CCCEditorContainer {...props} />);
+        expect(wrapper.find('CCCEditor').prop('onFinalizeCCC'))
+            .toBe(props.onFinalizeCCC);
     });
 
     it('should pass accessToken to <CCCEditor />', () => {

--- a/scanomatic/ui_server_data/js/specs/containers/PolynomialConstructionContainer.spec.js
+++ b/scanomatic/ui_server_data/js/specs/containers/PolynomialConstructionContainer.spec.js
@@ -8,7 +8,8 @@ import * as API from '../../ccc/api';
 import cccMetadata from '../fixtures/cccMetadata';
 
 describe('<PolynomialConstructionContainer />', () => {
-    const props = { cccMetadata };
+    const onFinalizeCCC = jasmine.createSpy('onFinalizeCCC');
+    const props = { cccMetadata, onFinalizeCCC };
 
     const results = {
         polynomial_coefficients: [1, 1, 2, 0.4],
@@ -21,6 +22,12 @@ describe('<PolynomialConstructionContainer />', () => {
             <PolynomialConstructionContainer {...props} />
         );
         expect(wrapper.find('PolynomialConstruction').exists()).toBeTruthy();
+    });
+
+    it('should pass onFinalizeCCC to <PolynomialContruction />', () => {
+        const wrapper = shallow(<PolynomialConstructionContainer {...props} />);
+        expect(wrapper.find('PolynomialConstruction').prop('onFinalizeCCC'))
+            .toBe(onFinalizeCCC);
     });
 
     it('should set properties of PolynomialConstruction from state', () => {

--- a/scanomatic/ui_server_data/js/specs/containers/RootContainer.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/containers/RootContainer.spec.jsx
@@ -13,6 +13,7 @@ describe('<RootContainer />', () => {
         spyOn(API, 'InitiateCCC').and.returnValue(new FakePromise());
         spyOn(API, 'GetFixtures').and.returnValue(new FakePromise());
         spyOn(API, 'GetPinningFormats').and.returnValue(new FakePromise());
+        spyOn(API, 'finalizeCalibration').and.returnValue(new FakePromise());
     });
 
     it('should render <Root />', () => {
@@ -78,6 +79,32 @@ describe('<RootContainer />', () => {
             initializeCCC(wrapper);
             wrapper.update();
             expect(wrapper.prop('error')).toBeFalsy();
+        });
+
+        it('should finalize the CCC on onFinalizeCCC', () => {
+            const wrapper = shallow(<RootContainer />);
+            initializeCCC(wrapper);
+            wrapper.prop('onFinalizeCCC')();
+            expect(API.finalizeCalibration)
+                .toHaveBeenCalledWith(cccMetadata.id, cccMetadata.accessToken);
+        });
+
+        it('should set the error if finalization fails', () => {
+            API.finalizeCalibration.and.returnValue(FakePromise.reject('Wobbly'));
+            const wrapper = shallow(<RootContainer />);
+            initializeCCC(wrapper);
+            wrapper.prop('onFinalizeCCC')();
+            wrapper.update();
+            expect(wrapper.prop('error')).toEqual('Finalization error: Wobbly');
+        });
+
+        it('should set finalized to true if finalization succeeds', () => {
+            API.finalizeCalibration.and.returnValue(FakePromise.resolve());
+            const wrapper = shallow(<RootContainer />);
+            initializeCCC(wrapper);
+            wrapper.prop('onFinalizeCCC')();
+            wrapper.update();
+            expect(wrapper.prop('finalized')).toBeTruthy();
         });
     });
 });


### PR DESCRIPTION
The finalize button is placed next to the construct button and enabled only if there's a polynomial.
Add a simple component that replaces the CCCEditor when the CCC is finalized.