### PR TITLE
Improving calibration poly guessing and tests of related functions

### DIFF
--- a/scanomatic/data_processing/calibration.py
+++ b/scanomatic/data_processing/calibration.py
@@ -589,8 +589,8 @@ def get_calibration_optimization_function(degree=5):
     arr = np.zeros((degree + 1,), np.float)
 
     def poly(data_store, c1, cn):
-        arr[-2] = c1
-        arr[0] = cn
+        arr[-2] = max(c1, 0)
+        arr[0] = max(cn, 0)
         return tuple(
             (np.polyval(arr, values) * counts).sum()
             for values, counts in
@@ -614,7 +614,8 @@ def poly_as_text(poly):
 
     def coeffs():
         for i, coeff in enumerate(poly[::-1]):
-            yield "{0:.2E} x^{1}".format(coeff, i)
+            if (coeff != 0):
+                yield "{0:.2E} x^{1}".format(coeff, i)
 
     return "y = {0}".format(" + ".join(coeffs()))
 
@@ -642,8 +643,8 @@ def calculate_polynomial(data_store, degree=5):
         raise CCCConstructionError("Invalid data (probably too little)")
 
     poly_vals = np.zeros((degree + 1))
-    poly_vals[-2] = c1
-    poly_vals[0] = cn
+    poly_vals[-2] = max(c1, 0)
+    poly_vals[0] = max(cn, 0)
 
     _logger.info(
         "Produced polynomial {} (x^1, x^{})".format(

--- a/scanomatic/data_processing/calibration.py
+++ b/scanomatic/data_processing/calibration.py
@@ -589,8 +589,8 @@ def get_calibration_optimization_function(degree=5):
     arr = np.zeros((degree + 1,), np.float)
 
     def poly(data_store, c1, cn):
-        arr[-2] = max(c1, 0)
-        arr[0] = max(cn, 0)
+        arr[-2] = abs(c1)
+        arr[0] = abs(cn)
         return tuple(
             (np.polyval(arr, values) * counts).sum()
             for values, counts in
@@ -643,8 +643,8 @@ def calculate_polynomial(data_store, degree=5):
         raise CCCConstructionError("Invalid data (probably too little)")
 
     poly_vals = np.zeros((degree + 1))
-    poly_vals[-2] = max(c1, 0)
-    poly_vals[0] = max(cn, 0)
+    poly_vals[-2] = abs(c1)
+    poly_vals[0] = abs(cn)
 
     _logger.info(
         "Produced polynomial {} (x^1, x^{})".format(

--- a/scanomatic/data_processing/test/test_calibration.py
+++ b/scanomatic/data_processing/test/test_calibration.py
@@ -80,10 +80,10 @@ class TestGetCalibrationOptimizationFunction:
         data = calibration.CalibrationData(
             source_value_counts=[[10, 2], [3]],
             source_values=[[1, 2], [3]],
-            target_value=[0, 0]
+            target_value=[100, 126]
         )
-        c1 = -1
-        c2 = -44
+        c1 = -2
+        c2 = -4
         sums = colony_summer(data, c1, c2)
         assert all(
             calc == target for calc, target in zip(sums, data.target_value)

--- a/scanomatic/ui_server/test/test_calibration_api.py
+++ b/scanomatic/ui_server/test/test_calibration_api.py
@@ -518,7 +518,7 @@ class TestConstructCalibration:
             assert data['reason'].startswith(
                 u"Construction refused. "
                 "Validation of polynomial says: BadSlope "
-                "(y = 0.00E+00 x^0 + 1.00E+00 x^1 + 2.00E+00 x^2) "
+                "(y = 1.00E+00 x^1 + 2.00E+00 x^2) "
                 "correlation: {"
             )
             assert "'stderr': 0.5" in data['reason']


### PR DESCRIPTION
It isn't physically reasonable that any of the coefficients may become negative, so the solver should not allow for this. Unfortunately I didn't find any way to limit search space for the coefficients in the `optimize.leastsq` so I did manual assurance making both the poly and the results are always positive. Reason it is needed in both is that the solver may overstep into negative coeffs, thinking it is actually using them an thus reporting them as negative while they were actually positive. 

Another way to do the same thing would have been to optimize not on the coefficients but the log of the coefficients, but I think that code may turn a bit more obscure.

I added tests also for surrounding methods that didn't have particular unit tests.