### PR TITLE
Don't print coverage information in the terminal

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,6 @@ passenv =
     DISPLAY
 commands =
     pytest \
-        --cov scanomatic --cov scripts --cov-report xml --cov-report term \
+        --cov scanomatic --cov scripts --cov-report xml \
         --junitxml result.xml --ignore dev \
         {posargs}


### PR DESCRIPTION
I find the coverage table to be a bit too big and not that useful, especially with coveralls keeping track.
