### PR TITLE
Image upload endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ nohup.out
 data/config/rpc.admin
 /htmlcov
 /Scan_o_Matic.egg-info
-docker-compose.override.yml
+/docker-compose.override.yml
 /scanomatic/ui_server_data/js/ccc.js
 /scanomatic/ui_server_data/coverage
 geckodriver.log

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 flask
 flask_cors
+flask-restful
 numpy
 scipy
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,14 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+aniso8601==1.3.0          # via flask-restful
 chardet==3.0.2
 click==6.7                # via flask
 cycler==0.10.0            # via matplotlib
 decorator==4.0.11         # via networkx
 enum34==1.1.6
 flask-cors==3.0.2
+flask-restful==0.3.6
 flask==0.12.1
 functools32==3.2.3.post2  # via matplotlib
 itsdangerous==0.24        # via flask
@@ -24,15 +26,15 @@ pandas==0.20.1
 pillow==4.1.1
 psutil==5.2.2
 pyparsing==2.2.0          # via matplotlib
-python-dateutil==2.6.0    # via matplotlib, pandas
-pytz==2017.2              # via matplotlib, pandas
+python-dateutil==2.6.0    # via aniso8601, matplotlib, pandas
+pytz==2017.2              # via flask-restful, matplotlib, pandas
 pywavelets==0.5.2         # via scikit-image
 requests==2.14.1
 scikit-image==0.13.0
 scipy==0.19.0
 setproctitle==1.1.10
 sh==1.12.13
-six==1.10.0               # via cycler, flask-cors, matplotlib, python-dateutil, scikit-image
+six==1.10.0               # via cycler, flask-cors, flask-restful, matplotlib, python-dateutil, scikit-image
 subprocess32==3.2.7       # via matplotlib
 uuid==1.30
 werkzeug==0.12.1          # via flask

--- a/scanomatic/io/scanstore.py
+++ b/scanomatic/io/scanstore.py
@@ -1,0 +1,27 @@
+import os
+from scanomatic.io.paths import Paths
+
+
+class UnknownProjectError(Exception):
+    pass
+
+
+class ScanStore(object):
+    def __init__(self, path):
+        self._path = path
+
+    def add_scan(self, project_fullname, scan):
+        project_dir = os.path.join(self._path, project_fullname)
+        if not os.path.isdir(project_dir):
+            raise UnknownProjectError()
+        project_name = os.path.basename(project_fullname)
+        filename = Paths().experiment_scan_image_pattern.format(
+            project_name,
+            '{:04d}'.format(scan.index),
+            scan.timedelta.total_seconds(),
+        )
+        path = os.path.join(self._path, project_fullname, filename)
+        with open(path, 'w') as f:
+            f.write(scan.image.read())
+            f.flush()
+            os.fsync(f)

--- a/scanomatic/models/scan.py
+++ b/scanomatic/models/scan.py
@@ -1,0 +1,3 @@
+from collections import namedtuple
+
+Scan = namedtuple('Scan', ['image', 'index', 'timedelta'])

--- a/scanomatic/ui_server/experiment_api.py
+++ b/scanomatic/ui_server/experiment_api.py
@@ -2,6 +2,7 @@ import os
 from types import StringTypes
 
 from flask import request, jsonify
+from flask_restful import Api
 
 from scanomatic.io.app_config import Config
 from scanomatic.models.compile_project_model import COMPILE_ACTION
@@ -14,6 +15,7 @@ from scanomatic.util import bioscreen
 from scanomatic.data_processing import phenotyper
 
 from .general import get_2d_list, json_abort
+from .resources import ScanCollection
 
 
 def add_routes(app, rpc_client, logger):
@@ -355,3 +357,6 @@ def add_routes(app, rpc_client, logger):
             return jsonify(
                 success=True if job_id else False,
                 reason="" if job_id else "Invalid parameters")
+
+    api = Api(app)
+    api.add_resource(ScanCollection, '/api/scans', endpoint='scans')

--- a/scanomatic/ui_server/resources.py
+++ b/scanomatic/ui_server/resources.py
@@ -1,0 +1,53 @@
+from datetime import timedelta
+from hashlib import sha256
+import httplib as HTTPStatus
+
+from flask import current_app
+from flask_restful import reqparse, abort, Resource, inputs
+from werkzeug.datastructures import FileStorage
+
+from scanomatic.io.scanstore import UnknownProjectError
+from scanomatic.models.scan import Scan
+
+
+class ScanCollection(Resource):
+    reqparser = reqparse.RequestParser()
+    reqparser.add_argument(
+        'project', type=inputs.regex('^\w+(/\w+)*$'), required=True,
+    )
+    reqparser.add_argument('scan_index', type=inputs.natural, required=True)
+    reqparser.add_argument('timedelta', type=inputs.natural, required=True)
+    reqparser.add_argument(
+        'image', type=FileStorage, location='files', required=True,
+    )
+    reqparser.add_argument('digest', type=str, required=True)
+
+    def post(self):
+        args = self.reqparser.parse_args()
+        self._validate_image(args.image, args.digest)
+        args.image.seek(0)
+        scan = Scan(
+            image=args.image,
+            index=args.scan_index,
+            timedelta=timedelta(seconds=args.timedelta),
+        )
+        try:
+            current_app.config['scanstore'].add_scan(args.project, scan)
+        except UnknownProjectError:
+            abort(HTTPStatus.BAD_REQUEST)
+        return '', HTTPStatus.CREATED
+
+    def _validate_image(self, image, digest):
+        message = {}
+        if image.content_type != 'image/tiff':
+            message['image'] = (
+                'Unexpected image format {}'.format(image.content_type)
+            )
+        image_digest = sha256(image.read()).hexdigest()
+        if digest != image_digest:
+            message['digest'] = (
+                'invalid image digest: expected {}, got {}'
+                .format(image_digest, digest)
+            )
+        if message:
+            abort(HTTPStatus.BAD_REQUEST, message=message)

--- a/scanomatic/ui_server/ui_server.py
+++ b/scanomatic/ui_server/ui_server.py
@@ -15,6 +15,7 @@ from scanomatic.io.logger import Logger, LOG_RECYCLE_TIME
 from scanomatic.io.paths import Paths
 from scanomatic.io.rpc_client import get_client
 from scanomatic.io.backup import backup_file
+from scanomatic.io.scanstore import ScanStore
 from scanomatic.data_processing import phenotyper
 
 from . import qc_api
@@ -58,6 +59,7 @@ def launch_server(host, port, debug):
     global _URL, _DEBUG_MODE
     _DEBUG_MODE = debug
     app = Flask("Scan-o-Matic UI", template_folder=Paths().ui_templates)
+    app.config['scanstore'] = ScanStore(Config().paths.projects_root)
 
     rpc_client = get_client(admin=True)
 

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -2,10 +2,15 @@ import pytest
 import requests
 from selenium import webdriver
 
+import py.path
+
 
 @pytest.fixture(scope='session')
 def docker_compose_file(pytestconfig):
-    return pytestconfig.rootdir.join('docker-compose.yml')
+    return [
+        pytestconfig.rootdir.join('docker-compose.yml'),
+        py.path.local(__file__).dirpath().join('docker-compose.override.yml'),
+    ]
 
 
 @pytest.fixture(scope='session')

--- a/tests/system/docker-compose.override.yml
+++ b/tests/system/docker-compose.override.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  scanomatic:
+    volumes:
+      - my-project:/somprojects/my/project
+
+volumes:
+  my-project: {}

--- a/tests/system/test_scanner_api.py
+++ b/tests/system/test_scanner_api.py
@@ -1,0 +1,59 @@
+from StringIO import StringIO
+from collections import namedtuple
+from hashlib import sha256
+import httplib
+
+import pytest
+import requests
+
+
+@pytest.fixture
+def image():
+    data = b'I am an image'
+    return namedtuple('image', ['image', 'filename', 'digest'])(
+        StringIO(data), 'my_image.tiff', sha256(data).hexdigest()
+    )
+
+
+def get_nb_of_images(scanomatic, project):
+    response = requests.get(
+        scanomatic + '/api/tools/path/root/{}'.format(project),
+        params={'suffix': '.tiff', 'isDirectory': 0, 'checkHasAnalysis': 0},
+    )
+    return len(response.json()['suggestions'])
+
+
+def test_upload_image(scanomatic, image):
+    project = 'my/project'
+    response = requests.post(
+        scanomatic + '/api/scans',
+        data={
+            'project': project,
+            'scan_index': 5,
+            'timedelta': 789,
+            'digest': image.digest,
+        },
+        files={
+            'image': (image.filename, image.image, 'image/tiff'),
+        },
+    )
+    assert response.status_code == httplib.CREATED, response.content
+    assert get_nb_of_images(scanomatic, project) == 1
+
+
+def test_upload_image_unknown_project(scanomatic, image):
+    project = 'unknown/project'
+    response = requests.post(
+        scanomatic + '/api/scans',
+        data={
+            'project': project,
+            'scan_index': 5,
+            'timedelta': 789,
+            'digest': image.digest,
+        },
+        files={
+            'image': (image.filename, image.image, 'image/tiff'),
+        },
+    )
+    assert response.status_code == httplib.NOT_FOUND, response.content
+    assert get_nb_of_images(scanomatic, project) == 0

--- a/tests/system/test_scanner_api.py
+++ b/tests/system/test_scanner_api.py
@@ -16,7 +16,7 @@ def image():
     )
 
 
-def get_nb_of_images(scanomatic, project):
+def get_number_of_images(scanomatic, project):
     response = requests.get(
         scanomatic + '/api/tools/path/root/{}/'.format(project),
         params={'suffix': '.tiff', 'isDirectory': 0, 'checkHasAnalysis': 0},
@@ -27,7 +27,7 @@ def get_nb_of_images(scanomatic, project):
 
 def test_upload_image(scanomatic, image):
     project = 'my/project'
-    assert get_nb_of_images(scanomatic, project) == 0
+    assert get_number_of_images(scanomatic, project) == 0
     response = requests.post(
         scanomatic + '/api/scans',
         data={
@@ -41,7 +41,7 @@ def test_upload_image(scanomatic, image):
         },
     )
     assert response.status_code == httplib.CREATED, response.content
-    assert get_nb_of_images(scanomatic, project) == 1
+    assert get_number_of_images(scanomatic, project) == 1
 
 
 def test_upload_image_unknown_project(scanomatic, image):
@@ -59,4 +59,4 @@ def test_upload_image_unknown_project(scanomatic, image):
         },
     )
     assert response.status_code == httplib.BAD_REQUEST, response.content
-    assert get_nb_of_images(scanomatic, project) == 0
+    assert get_number_of_images(scanomatic, project) == 0

--- a/tests/system/test_scanner_api.py
+++ b/tests/system/test_scanner_api.py
@@ -55,5 +55,5 @@ def test_upload_image_unknown_project(scanomatic, image):
             'image': (image.filename, image.image, 'image/tiff'),
         },
     )
-    assert response.status_code == httplib.NOT_FOUND, response.content
+    assert response.status_code == httplib.BAD_REQUEST, response.content
     assert get_nb_of_images(scanomatic, project) == 0

--- a/tests/system/test_scanner_api.py
+++ b/tests/system/test_scanner_api.py
@@ -1,5 +1,6 @@
 from StringIO import StringIO
 from collections import namedtuple
+import fnmatch
 from hashlib import sha256
 import httplib
 
@@ -17,14 +18,16 @@ def image():
 
 def get_nb_of_images(scanomatic, project):
     response = requests.get(
-        scanomatic + '/api/tools/path/root/{}'.format(project),
+        scanomatic + '/api/tools/path/root/{}/'.format(project),
         params={'suffix': '.tiff', 'isDirectory': 0, 'checkHasAnalysis': 0},
     )
-    return len(response.json()['suggestions'])
+    suggestions = fnmatch.filter(response.json()['suggestions'], '*.tiff')
+    return len(suggestions)
 
 
 def test_upload_image(scanomatic, image):
     project = 'my/project'
+    assert get_nb_of_images(scanomatic, project) == 0
     response = requests.post(
         scanomatic + '/api/scans',
         data={

--- a/tests/unit/io/test_scanstore.py
+++ b/tests/unit/io/test_scanstore.py
@@ -1,0 +1,31 @@
+from datetime import timedelta
+from StringIO import StringIO
+
+import pytest
+
+from scanomatic.io.scanstore import ScanStore, UnknownProjectError
+from scanomatic.models.scan import Scan
+
+
+@pytest.fixture
+def scan():
+    return Scan(
+        image=StringIO('I am an image'),
+        index=42,
+        timedelta=timedelta(seconds=1234.56789),
+    )
+
+
+def test_add_scan(tmpdir, scan):
+    projectstore = ScanStore(str(tmpdir))
+    projectdir = tmpdir.mkdir('my').mkdir('pr0ject')
+    projectstore.add_scan('my/pr0ject', scan)
+    imagepath = projectdir.join('pr0ject_0042_1234.5679.tiff')
+    assert imagepath in projectdir.listdir()
+    assert imagepath.read() == 'I am an image'
+
+
+def test_add_scan_unknown_project(tmpdir, scan):
+    projectstore = ScanStore(str(tmpdir))
+    with pytest.raises(UnknownProjectError):
+        projectstore.add_scan('unknown/pr0ject', scan)

--- a/tests/unit/ui_server/test_experiment_api.py
+++ b/tests/unit/ui_server/test_experiment_api.py
@@ -1,26 +1,44 @@
-import pytest
-import os
-import logging
+from StringIO import StringIO
+from datetime import timedelta
+from hashlib import sha256
+import httplib as HTTPStatus
 import json
+import logging
+import os
+import pytest
 
-from flask import Flask
-from mock import Mock, patch
+from flask import Flask, url_for
+from mock import MagicMock, Mock, patch
+import pytest
 
-from scanomatic.io.paths import Paths
 from scanomatic.io.app_config import Config
+from scanomatic.io.paths import Paths
+from scanomatic.io.scanstore import ScanStore, UnknownProjectError
 from scanomatic.ui_server import experiment_api
 
 
-@pytest.fixture(scope="function")
-def test_app():
-    app = Flask("Scan-o-Matic UI", template_folder=Paths().ui_templates)
-    rpc_client = Mock()
-    experiment_api.add_routes(app, rpc_client, logging)
-    app.testing = True
+@pytest.fixture
+def scanstore():
+    return MagicMock(ScanStore)
 
+
+@pytest.fixture
+def rpc_client():
+    return MagicMock()
+
+
+@pytest.fixture
+def app(scanstore, rpc_client):
+    app = Flask(__name__, template_folder=Paths().ui_templates)
+    app.config['scanstore'] = scanstore
+    experiment_api.add_routes(app, rpc_client, logging)
+    return app
+
+
+@pytest.fixture(scope="function")
+def test_app(app, rpc_client):
     test_app = app.test_client()
     test_app.rpc_client = rpc_client
-
     return test_app
 
 
@@ -88,3 +106,61 @@ class TestFeatureExtractEndpoint:
         })
         assert response.status_code == 200
         assert json.loads(response.data)['success']
+
+
+class TestPostScan:
+    @pytest.fixture
+    def data(self):
+        return {
+            'project': 'my/project',
+            'scan_index': 3,
+            'timedelta': 60,
+            'image': (StringIO('I am an image'), 'image.tiff'),
+            'digest': sha256('I am an image').hexdigest(),
+        }
+
+    @pytest.fixture
+    def url(self):
+        return url_for('scans')
+
+    def test_post_scan(self, client, url, data, scanstore):
+        res = client.post(url, data=data)
+        assert res.status_code == HTTPStatus.CREATED, res.data
+        scanstore.add_scan.assert_called()
+        project, scan = scanstore.add_scan.call_args[0]
+        assert project == 'my/project'
+        assert scan.index == 3
+        assert scan.timedelta == timedelta(seconds=60)
+        assert scan.image.read() == 'I am an image'
+
+    @pytest.mark.parametrize('key, value', [
+        ('project', ''),
+        ('project', '..'),
+        ('project', 'foo/'),
+        ('project', '/foo'),
+        ('scan_index', 'xxx'),
+        ('scan_index', -1),
+        ('timedelta', 'xxx'),
+        ('timedelta', -1),
+        ('image', 'zzz'),
+        ('digest', 1234),
+        ('digest', 'zzzz'),
+        ('image', (StringIO('I am an image'), 'image.xls')),
+    ])
+    def test_invalid_data(self, client, url, data, key, value):
+        data[key] = value
+        res = client.post(url, data=data)
+        assert res.status_code == HTTPStatus.BAD_REQUEST
+
+    @pytest.mark.parametrize('key', [
+        'project', 'scan_index', 'timedelta', 'image', 'image', 'digest',
+    ])
+    def test_missing_data(self, client, url, data, key):
+        del data[key]
+        res = client.post(url, data=data)
+        assert res.status_code == HTTPStatus.BAD_REQUEST
+
+    def test_unknown_project(self, client, url, data, scanstore):
+        scanstore.add_scan.side_effect = UnknownProjectError()
+        res = client.post(url, data=data)
+        assert res.status_code == HTTPStatus.BAD_REQUEST

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pytest
     pytest-cov
     pytest-docker
+    pytest-flask
     selenium
 setenv =
     SCANOMATIC_DATA = {toxinidir}/data/


### PR DESCRIPTION
Add a new endpoint `/api/scans` to post scans (images). The scans are saved in the project directory according to the current file pattern.

I couldn't identify a clear pattern in the design of the current API endpoints so I designed the new endpoint as a REST API because we are already using it at molflow for other projects and there is plenty of resources and tools for it. I suggest that future endpoint should also use REST.

There is already code in Scan-o-Matic that saves scan images. I did try to refactor this to use the same code as the new endpoint but the image-saving code is quite entangled in the scanning "effector" which proved quite painful to get under tests. Or understand.
