### PR TITLE
Invert stages hoping first tox system test will run faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_script:
     - sleep 3
 script:
     - npm test
-    - tox
     - docker-compose build
+    - tox
 
 after_success:
     - coveralls-lcov -v -n scanomatic/ui_server_data/coverage/report-lcov/lcov.info > js-coverage.json


### PR DESCRIPTION
Tried manually monitoring the travis progress and the test that previous sometimes took more than 10 minutes according to travis now took roughly 2-3minutes. Could be a coincidence, but at least a positive indication.