### PR TITLE
Scaling residual with measurement to emulate proportional error

### DIFF
--- a/scanomatic/data_processing/calibration.py
+++ b/scanomatic/data_processing/calibration.py
@@ -553,7 +553,7 @@ def validate_polynomial(slope, p_value, stderr):
 
     # return CalibrationValidation.OK
 
-    if abs(1.0 - slope) > 0.12:
+    if abs(1.0 - slope) > 0.1:
         _logger.error("Bad slope for polynomial: {0}".format(slope))
         return CalibrationValidation.BadSlope
 

--- a/scanomatic/data_processing/calibration.py
+++ b/scanomatic/data_processing/calibration.py
@@ -615,7 +615,10 @@ def get_calibration_optimization_function(degree=5):
 def get_calibration_polynomial_residuals(
         guess, colony_sum_function, data_store):
 
-    return data_store.target_value - colony_sum_function(data_store, *guess)
+    return (
+        np.log2(data_store.target_value)
+        - np.log2(colony_sum_function(data_store, *guess))
+    )
 
 
 def get_calibration_polynomial(coefficients_array):


### PR DESCRIPTION
This replaces the residual used in the CCC with residual scaled with the measured OD. This is to emulate a proportional error instead of the absolute error, which seems to fit the calibration data better. 

The problem this tries to address is that, if the absolute residual is used and the actual error is proportional, the fit will only respect the values for measured colonies with high cell counts, giving very poor precision for the majority of the colonies since colony size grows super-linearly.

Using the proportional error is not a perfect solution to this (we know or suspect that the proportional error is larger for smaller colonies for instance), but it should give a fairer fit over all. Best results would probably come from letting the user set the uncertainty per colony.

Updating the residual also means that the linear regression as it is used today doesn't work, so that need to be updated if we do something about this. Until that, and the ramifications of this or similar approaches have been investigated, consider this PR code sharing.