### PR TITLE
Scanner job API

### DIFF
--- a/scanomatic/io/scanning_store.py
+++ b/scanomatic/io/scanning_store.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from collections import namedtuple
 
+from ..models.scanjob import ScanJob
+
 
 class ScanJobCollisionError(ValueError):
     pass
@@ -9,11 +11,6 @@ class ScanJobCollisionError(ValueError):
 class ScanJobUnknownError(ValueError):
     pass
 
-
-ScanJob = namedtuple(
-    'ScanJob',
-    ['identifier', 'name', 'duration', 'interval', 'scanner_id']
-)
 
 Scanner = namedtuple(
     'Scanner',

--- a/scanomatic/io/scanning_store.py
+++ b/scanomatic/io/scanning_store.py
@@ -71,3 +71,8 @@ class ScanningStore:
             if getattr(job, key) == value:
                 return True
         return False
+
+    def get_current_scanjob(self, scanner_id, t):
+        for job in self._scanjobs.values():
+            if job.scanner_id == scanner_id and job.is_active(t):
+                return job

--- a/scanomatic/io/scanning_store.py
+++ b/scanomatic/io/scanning_store.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from collections import namedtuple
 
-from ..models.scanjob import ScanJob
-
 
 class ScanJobCollisionError(ValueError):
     pass

--- a/scanomatic/io/scanning_store.py
+++ b/scanomatic/io/scanning_store.py
@@ -70,7 +70,7 @@ class ScanningStore:
                 return True
         return False
 
-    def get_current_scanjob(self, scanner_id, t):
+    def get_current_scanjob(self, scanner_id, timepoint):
         for job in self._scanjobs.values():
-            if job.scanner_id == scanner_id and job.is_active(t):
+            if job.scanner_id == scanner_id and job.is_active(timepoint):
                 return job

--- a/scanomatic/models/scanjob.py
+++ b/scanomatic/models/scanjob.py
@@ -23,8 +23,8 @@ class ScanJob(ScanJobBase):
             self, identifier, name, duration, interval, scanner_id, start,
         )
 
-    def is_active(self, t):
+    def is_active(self, timepoint):
         return (
             self.start is not None
-            and self.start <= t <= self.start + self.duration
+            and self.start <= timepoint <= self.start + self.duration
         )

--- a/scanomatic/models/scanjob.py
+++ b/scanomatic/models/scanjob.py
@@ -17,4 +17,9 @@ class ScanJob(ScanJobBase):
         return super(ScanJob, self).__new__(
             self, identifier, name, duration, interval, scanner_id, start,
         )
-    pass
+
+    def is_active(self, t):
+        return (
+            self.start is not None
+            and self.start <= t <= self.start + self.duration
+        )

--- a/scanomatic/models/scanjob.py
+++ b/scanomatic/models/scanjob.py
@@ -1,0 +1,20 @@
+from collections import namedtuple
+from datetime import datetime
+
+
+ScanJobBase = namedtuple(
+    'ScanJobBase',
+    ['identifier', 'name', 'duration', 'interval', 'scanner_id', 'start']
+)
+
+
+class ScanJob(ScanJobBase):
+    def __new__(
+        self, identifier, name, duration, interval, scanner_id, start=None,
+    ):
+        if start is not None and not isinstance(start, datetime):
+            raise ValueError('start should be a datetime')
+        return super(ScanJob, self).__new__(
+            self, identifier, name, duration, interval, scanner_id, start,
+        )
+    pass

--- a/scanomatic/models/scanjob.py
+++ b/scanomatic/models/scanjob.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 ScanJobBase = namedtuple(
@@ -14,6 +14,10 @@ class ScanJob(ScanJobBase):
     ):
         if start is not None and not isinstance(start, datetime):
             raise ValueError('start should be a datetime')
+        if not isinstance(duration, timedelta):
+            raise ValueError('duration should be a timedelta')
+        if not isinstance(interval, timedelta):
+            raise ValueError('interval should be a timedelta')
         return super(ScanJob, self).__new__(
             self, identifier, name, duration, interval, scanner_id, start,
         )

--- a/scanomatic/models/scanjob.py
+++ b/scanomatic/models/scanjob.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from collections import namedtuple
 from datetime import datetime, timedelta
 

--- a/scanomatic/ui_server/scan_jobs_api.py
+++ b/scanomatic/ui_server/scan_jobs_api.py
@@ -5,7 +5,8 @@ from uuid import uuid1
 
 from flask import request, jsonify, Blueprint, current_app
 
-from scanomatic.io.scanning_store import ScanJobCollisionError, ScanJob
+from scanomatic.io.scanning_store import ScanJobCollisionError
+from scanomatic.models.scanjob import ScanJob
 from .general import json_abort
 from .serialization import job2json
 

--- a/scanomatic/ui_server/scan_jobs_api.py
+++ b/scanomatic/ui_server/scan_jobs_api.py
@@ -7,6 +7,8 @@ from flask import request, jsonify, Blueprint, current_app
 
 from scanomatic.io.scanning_store import ScanJobCollisionError, ScanJob
 from .general import json_abort
+from .serialization import job2json
+
 
 blueprint = Blueprint('scan_jobs_api', __name__)
 
@@ -73,16 +75,7 @@ def scan_jobs_add():
 
 @blueprint.route("", methods=['GET'])
 def scan_jobs_list():
-    def py2js(data):
-        return {
-            'identifier': data.identifier,
-            'name': data.name,
-            'duration': data.duration.total_seconds(),
-            'interval': data.interval.total_seconds(),
-            'scannerId': data.scanner_id,
-        }
-
     scanning_store = current_app.config['scanning_store']
     return jsonify([
-        py2js(job) for job in scanning_store.get_all_scanjobs()
+        job2json(job) for job in scanning_store.get_all_scanjobs()
     ])

--- a/scanomatic/ui_server/scan_jobs_api.py
+++ b/scanomatic/ui_server/scan_jobs_api.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from datetime import timedelta
-from httplib import BAD_REQUEST, FORBIDDEN, INTERNAL_SERVER_ERROR, CREATED
+from httplib import BAD_REQUEST, CONFLICT, INTERNAL_SERVER_ERROR, CREATED
 from uuid import uuid1
 
 from flask import request, jsonify, Blueprint, current_app
@@ -24,7 +24,7 @@ def scan_jobs_add():
         return json_abort(BAD_REQUEST, reason="No name supplied")
     if scanning_store.exists_scanjob_with('name', name):
         return json_abort(
-            FORBIDDEN,
+            CONFLICT,
             reason="Name '{}' duplicated".format(name)
         )
 

--- a/scanomatic/ui_server/scanners_api.py
+++ b/scanomatic/ui_server/scanners_api.py
@@ -39,9 +39,7 @@ class ScannerJob(Resource):
         if not db.has_scanner(scannerid):
             raise NotFound
         job = db.get_current_scanjob(scannerid, datetime.now())
-        if job is None:
-            return None
-        else:
+        if job:
             return job2json(job)
 
 

--- a/scanomatic/ui_server/scanners_api.py
+++ b/scanomatic/ui_server/scanners_api.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import
-from flask import request, jsonify, Blueprint, current_app
+from datetime import datetime
 from httplib import NOT_FOUND
+
+from flask import request, jsonify, Blueprint, current_app
+from flask_restful import Api, Resource
+from werkzeug.exceptions import NotFound
+
 from .general import json_abort
 
 blueprint = Blueprint("scanners_api", __name__)
@@ -25,3 +30,26 @@ def scanner_get(scanner):
     return json_abort(
         NOT_FOUND, reason="Scanner '{}' unknown".format(scanner)
     )
+
+
+class ScannerJob(Resource):
+    def get(self, scannerid):
+        db = current_app.config['scanning_store']
+        if not db.has_scanner(scannerid):
+            raise NotFound
+        job = db.get_current_scanjob(scannerid, datetime.now())
+        if job is None:
+            return None
+        else:
+            return {
+                'duration': job.duration.total_seconds(),
+                'id': job.identifier,
+                'interval': job.interval.total_seconds(),
+                'name': job.name,
+                'scannerId': job.scanner_id,
+                'start': job.start.isoformat(),
+            }
+
+
+api = Api(blueprint)
+api.add_resource(ScannerJob, '/<scannerid>/job', endpoint='scanner-job')

--- a/scanomatic/ui_server/scanners_api.py
+++ b/scanomatic/ui_server/scanners_api.py
@@ -7,6 +7,7 @@ from flask_restful import Api, Resource
 from werkzeug.exceptions import NotFound
 
 from .general import json_abort
+from .serialization import job2json
 
 blueprint = Blueprint("scanners_api", __name__)
 
@@ -41,14 +42,7 @@ class ScannerJob(Resource):
         if job is None:
             return None
         else:
-            return {
-                'duration': job.duration.total_seconds(),
-                'id': job.identifier,
-                'interval': job.interval.total_seconds(),
-                'name': job.name,
-                'scannerId': job.scanner_id,
-                'start': job.start.isoformat(),
-            }
+            return job2json(job)
 
 
 api = Api(blueprint)

--- a/scanomatic/ui_server/serialization.py
+++ b/scanomatic/ui_server/serialization.py
@@ -1,0 +1,11 @@
+def job2json(job):
+    obj = {
+        'identifier': job.identifier,
+        'name': job.name,
+        'duration': job.duration.total_seconds(),
+        'interval': job.interval.total_seconds(),
+        'scannerId': job.scanner_id,
+    }
+    if job.start is not None:
+        obj['start'] = job.start.isoformat()
+    return obj

--- a/scanomatic/ui_server_data/js/specs/api.spec.js
+++ b/scanomatic/ui_server_data/js/specs/api.spec.js
@@ -746,4 +746,54 @@ describe('API', () => {
             });
         });
     });
+
+    describe('sumbitScanningJob', () => {
+        const args = [{
+            name: 'Some Job',
+            duration: { days: 1, hours: 3, minutes: 5 },
+            interval: 20,
+            scannerId: 'sc4nn3r',
+        }];
+
+        it('should query the correct URL', () => {
+            API.submitScanningJob(...args);
+            expect(mostRecentRequest().url)
+                .toEqual('/api/scan-jobs');
+        });
+
+        it('should send a POST request', () => {
+            API.submitScanningJob(...args);
+            expect(mostRecentRequest().method).toEqual('POST');
+        });
+
+        it('should send the job', () => {
+            API.submitScanningJob(...args);
+            expect(JSON.parse(mostRecentRequest().params)).toEqual({
+                name: 'Some Job',
+                scannerId: 'sc4nn3r',
+                interval: 1200,
+                duration: 97500,
+            });
+        });
+
+        it('should return a promise that resolves on success', (done) => {
+            API.submitScanningJob(...args).then((value) => {
+                expect(value).toEqual({});
+                done();
+            });
+            mostRecentRequest().respondWith({
+                status: 200, responseText: JSON.stringify({}),
+            });
+        });
+
+        it('should return a promise that rejects on error', (done) => {
+            API.submitScanningJob(...args).catch((reason) => {
+                expect(reason).toEqual('(+_+)');
+                done();
+            });
+            mostRecentRequest().respondWith({
+                status: 400, responseText: JSON.stringify({ reason: '(+_+)' }),
+            });
+        });
+    });
 });

--- a/scanomatic/ui_server_data/js/specs/api.spec.js
+++ b/scanomatic/ui_server_data/js/specs/api.spec.js
@@ -747,13 +747,69 @@ describe('API', () => {
         });
     });
 
-    describe('sumbitScanningJob', () => {
-        const args = [{
+
+    describe('getScanningJobs', () => {
+        const scanJob = {
+            identifier: 'xyz',
             name: 'Some Job',
             duration: { days: 1, hours: 3, minutes: 5 },
             interval: 20,
             scannerId: 'sc4nn3r',
-        }];
+        };
+        const jsonScanJob = {
+            identifier: 'xyz',
+            name: 'Some Job',
+            scannerId: 'sc4nn3r',
+            interval: 1200,
+            duration: 97500,
+        };
+
+        it('should query the correct URL', () => {
+            API.getScanningJobs();
+            expect(mostRecentRequest().url)
+                .toEqual('/api/scan-jobs');
+        });
+
+        it('should send a GET request', () => {
+            API.getScanningJobs();
+            expect(mostRecentRequest().method).toEqual('GET');
+        });
+
+        it('should return a promise that resolves on success', (done) => {
+            API.getScanningJobs().then((value) => {
+                expect(value).toEqual([scanJob]);
+                done();
+            });
+            mostRecentRequest().respondWith({
+                status: 200, responseText: JSON.stringify([jsonScanJob]),
+            });
+        });
+
+        it('should return a promise that rejects on error', (done) => {
+            API.getScanningJobs().catch((reason) => {
+                expect(reason).toEqual('(+_+)');
+                done();
+            });
+            mostRecentRequest().respondWith({
+                status: 400, responseText: JSON.stringify({ reason: '(+_+)' }),
+            });
+        });
+    });
+
+    describe('submitScanningJob', () => {
+        const scanJob = {
+            name: 'Some Job',
+            duration: { days: 1, hours: 3, minutes: 5 },
+            interval: 20,
+            scannerId: 'sc4nn3r',
+        };
+        const jsonScanJob = {
+            name: 'Some Job',
+            scannerId: 'sc4nn3r',
+            interval: 1200,
+            duration: 97500,
+        };
+        const args = [scanJob];
 
         it('should query the correct URL', () => {
             API.submitScanningJob(...args);
@@ -768,12 +824,7 @@ describe('API', () => {
 
         it('should send the job', () => {
             API.submitScanningJob(...args);
-            expect(JSON.parse(mostRecentRequest().params)).toEqual({
-                name: 'Some Job',
-                scannerId: 'sc4nn3r',
-                interval: 1200,
-                duration: 97500,
-            });
+            expect(JSON.parse(mostRecentRequest().params)).toEqual(jsonScanJob);
         });
 
         it('should return a promise that resolves on success', (done) => {

--- a/scanomatic/ui_server_data/js/src/api.js
+++ b/scanomatic/ui_server_data/js/src/api.js
@@ -4,6 +4,10 @@ const GetSliceImagePath = '/api/calibration/#0#/image/#1#/slice/get/#2#';
 const GetTranposedMarkerPath = '/api/data/fixture/calculate/';
 const GetGrayScaleAnalysisPath = '/api/data/grayscale/image/';
 
+const secondsPerMinute = 60;
+const secondsPerHour = 3600;
+const secondsPerDay = 86400;
+
 class API {
     static get(url) {
         return new Promise((resolve, reject) => $.ajax({
@@ -253,17 +257,28 @@ export function submitScanningJob(job) {
     const data = {
         name: job.name,
         scannerId: job.scannerId,
-        interval: job.interval * 60,
+        interval: job.interval * secondsPerMinute,
         duration:
-            (job.duration.days * 86400)
-            + (job.duration.hours * 3600)
-            + (job.duration.minutes * 60),
+            (job.duration.days * secondsPerDay)
+            + (job.duration.hours * secondsPerHour)
+            + (job.duration.minutes * secondsPerMinute),
     };
     return API.postJSON('/api/scan-jobs', data);
 }
 
 export function getScanningJobs() {
-    return API.get('/api/scan-jobs');
+    return API.get('/api/scan-jobs').then(jobs => jobs.map(jsonJob => ({
+        identifier: jsonJob.identifier,
+        name: jsonJob.name,
+        scannerId: jsonJob.scannerId,
+        interval: jsonJob.interval / secondsPerMinute,
+        duration: {
+            days: Math.floor(jsonJob.duration / secondsPerDay),
+            hours:
+                Math.floor((jsonJob.duration % secondsPerDay) / secondsPerHour),
+            minutes: (jsonJob.duration % secondsPerHour) / secondsPerMinute,
+        },
+    })));
 }
 
 export function getScanners() {

--- a/scanomatic/ui_server_data/js/src/api.js
+++ b/scanomatic/ui_server_data/js/src/api.js
@@ -250,7 +250,16 @@ export function finalizeCalibration(cccId, accessToken) {
 }
 
 export function submitScanningJob(job) {
-    return API.postJSON('/api/scan-jobs', job);
+    const data = {
+        name: job.name,
+        scannerId: job.scannerId,
+        interval: job.interval * 60,
+        duration:
+            (job.duration.days * 86400)
+            + (job.duration.hours * 3600)
+            + (job.duration.minutes * 60),
+    };
+    return API.postJSON('/api/scan-jobs', data);
 }
 
 export function getScanningJobs() {

--- a/tests/unit/io/test_scanning_store.py
+++ b/tests/unit/io/test_scanning_store.py
@@ -15,16 +15,16 @@ def scanning_store():
 JOB1 = ScanJob(
     identifier=5,
     name="Hello",
-    duration="to",
-    interval="you",
+    duration=timedelta(days=1),
+    interval=timedelta(minutes=20),
     scanner_id="9a8486a6f9cb11e7ac660050b68338ac",
 )
 
 JOB2 = ScanJob(
     identifier=6,
     name="Hello",
-    duration="to",
-    interval="you",
+    duration=timedelta(days=1),
+    interval=timedelta(minutes=20),
     scanner_id="9a8486a6f9cb11e7ac660050b68338ac",
 )
 

--- a/tests/unit/io/test_scanning_store.py
+++ b/tests/unit/io/test_scanning_store.py
@@ -3,8 +3,9 @@ from datetime import datetime, timedelta
 
 import pytest
 from scanomatic.io.scanning_store import (
-    ScanningStore, ScanJobCollisionError, ScanJobUnknownError, ScanJob, Scanner
+    ScanningStore, ScanJobCollisionError, ScanJobUnknownError, Scanner
 )
+from scanomatic.models.scanjob import ScanJob
 
 
 @pytest.fixture(scope='function')

--- a/tests/unit/models/test_scanjob.py
+++ b/tests/unit/models/test_scanjob.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from datetime import datetime, timedelta
 
 import pytest

--- a/tests/unit/models/test_scanjob.py
+++ b/tests/unit/models/test_scanjob.py
@@ -5,7 +5,7 @@ import pytest
 from scanomatic.models.scanjob import ScanJob
 
 
-class TestScanJob:
+class TestInit:
     def test_init(self):
         job = ScanJob(
             identifier='xxxx',
@@ -42,3 +42,41 @@ class TestScanJob:
                 scanner_id='yyyy',
                 start='xxx',
             )
+
+
+class TestIsActive:
+    def test_not_active_if_not_started(self):
+        job = ScanJob(
+            identifier='xxxx',
+            name='Unknown',
+            duration=timedelta(days=3),
+            interval=timedelta(minutes=5),
+            scanner_id='yyyy',
+        )
+        assert not job.is_active(datetime(1985, 10, 26, 1, 20))
+
+    @pytest.fixture
+    def started_job(self):
+        return ScanJob(
+            identifier='xxxx',
+            name='Unknown',
+            duration=timedelta(minutes=1),
+            interval=timedelta(seconds=5),
+            scanner_id='yyyy',
+            start=datetime(1985, 10, 26, 1, 20)
+        )
+
+    @pytest.mark.parametrize('now', [
+        datetime(1985, 10, 26, 1, 20),
+        datetime(1985, 10, 26, 1, 20, 30),
+        datetime(1985, 10, 26, 1, 21),
+    ])
+    def test_active(self, started_job, now):
+        assert started_job.is_active(now)
+
+    @pytest.mark.parametrize('now', [
+        datetime(1985, 10, 26, 1, 19),
+        datetime(1985, 10, 26, 1, 22),
+    ])
+    def test_not_active(self, started_job, now):
+        assert not started_job.is_active(now)

--- a/tests/unit/models/test_scanjob.py
+++ b/tests/unit/models/test_scanjob.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from scanomatic.models.scanjob import ScanJob
+
+
+class TestScanJob:
+    def test_init(self):
+        job = ScanJob(
+            identifier='xxxx',
+            name='Unknown',
+            duration=timedelta(days=3),
+            interval=timedelta(minutes=5),
+            scanner_id='yyyy',
+            start=datetime(1985, 10, 26, 1, 20),
+        )
+        assert job.identifier == 'xxxx'
+        assert job.name == 'Unknown'
+        assert job.duration == timedelta(days=3)
+        assert job.interval == timedelta(minutes=5)
+        assert job.scanner_id == 'yyyy'
+        assert job.start == datetime(1985, 10, 26, 1, 20)
+
+    def test_init_without_start(self):
+        job = ScanJob(
+            identifier='xxxx',
+            name='Unknown',
+            duration=timedelta(days=3),
+            interval=timedelta(minutes=5),
+            scanner_id='yyyy',
+        )
+        assert job.start is None
+
+    def test_init_bad_start(self):
+        with pytest.raises(ValueError):
+            ScanJob(
+                identifier='xxxx',
+                name='Unknown',
+                duration=timedelta(days=3),
+                interval=timedelta(minutes=5),
+                scanner_id='yyyy',
+                start='xxx',
+            )

--- a/tests/unit/ui_server/test_scan_jobs_api.py
+++ b/tests/unit/ui_server/test_scan_jobs_api.py
@@ -43,12 +43,8 @@ class TestScanJobs:
         return {
             'name': 'Binary yeast',
             'scannerId': '9a8486a6f9cb11e7ac660050b68338ac',
-            'interval': 32,
-            'duration': {
-                'days': 1024,
-                'hours': 64,
-                'minutes': 8,
-            }
+            'interval': 500,
+            'duration': 86400,
         }
 
     def test_get_jobs_and_there_are_none(self, test_app):

--- a/tests/unit/ui_server/test_scan_jobs_api.py
+++ b/tests/unit/ui_server/test_scan_jobs_api.py
@@ -3,7 +3,7 @@ import pytest
 import json
 from types import MethodType
 from flask import Flask
-from httplib import BAD_REQUEST, FORBIDDEN, OK, CREATED
+from httplib import BAD_REQUEST, CONFLICT, OK, CREATED
 
 from scanomatic.ui_server.ui_server import add_configs
 from scanomatic.io.paths import Paths
@@ -60,7 +60,7 @@ class TestScanJobs:
         response = test_app.post_json(self.URI, job)
         assert response.status_code == CREATED
         response = test_app.post_json(self.URI, job)
-        assert response.status_code == FORBIDDEN
+        assert response.status_code == CONFLICT
         assert response.json['reason'] == "Name 'Binary yeast' duplicated"
 
     @pytest.mark.parametrize("key,reason", (

--- a/tests/unit/ui_server/test_scanners_api.py
+++ b/tests/unit/ui_server/test_scanners_api.py
@@ -1,11 +1,15 @@
 from __future__ import absolute_import
-import pytest
-from flask import Flask
+from datetime import datetime, timedelta
 from httplib import OK, NOT_FOUND
 
-from scanomatic.ui_server.ui_server import add_configs
+from flask import Flask
+import mock
+import pytest
+
 from scanomatic.io.paths import Paths
+from scanomatic.models.scanjob import ScanJob
 from scanomatic.ui_server import scanners_api
+from scanomatic.ui_server.ui_server import add_configs
 
 
 @pytest.fixture
@@ -53,3 +57,54 @@ class TestScannerStatus:
         response = test_app.get(self.URI + "/Unknown")
         response.status_code == NOT_FOUND
         assert response.json['reason'] == "Scanner 'Unknown' unknown"
+
+
+class TestGetScannerJob(object):
+    URI = '/api/scanners/xxxx/job'
+
+    @pytest.fixture
+    def fakedb(self):
+        return mock.MagicMock()
+
+    @pytest.fixture
+    def app(self, fakedb):
+        app = Flask(__name__, template_folder=Paths().ui_templates)
+        app.config['scanning_store'] = fakedb
+        app.register_blueprint(
+            scanners_api.blueprint, url_prefix="/api/scanners"
+        )
+        return app
+
+    def test_invalid_scanner(self, fakedb, client):
+        fakedb.has_scanner.return_value = False
+        response = client.get(self.URI)
+        assert response.status_code == NOT_FOUND
+
+    def test_has_no_scanjob(self, fakedb, client):
+        fakedb.has_scanner.return_value = True
+        fakedb.get_current_scanjob.return_value = None
+        response = client.get(self.URI)
+        assert response.status_code == OK
+        assert response.json is None
+
+    def test_has_scanjob(self, fakedb, client):
+        fakedb.has_scanner.return_value = True
+        fakedb.get_current_scanjob.return_value = ScanJob(
+            identifier='xxxx',
+            name='The Job',
+            duration=timedelta(days=3),
+            interval=timedelta(minutes=5),
+            scanner_id='yyyy',
+            start=datetime(1985, 10, 26, 1, 20),
+        )
+        response = client.get(self.URI)
+        assert response.status_code == OK
+        assert response.json == {
+            'id': 'xxxx',
+            'name': 'The Job',
+            'duration': 259200,
+            'interval': 300,
+            'scannerId': 'yyyy',
+            'start': '1985-10-26T01:20:00',
+        }
+        pass

--- a/tests/unit/ui_server/test_scanners_api.py
+++ b/tests/unit/ui_server/test_scanners_api.py
@@ -100,7 +100,7 @@ class TestGetScannerJob(object):
         response = client.get(self.URI)
         assert response.status_code == OK
         assert response.json == {
-            'id': 'xxxx',
+            'identifier': 'xxxx',
             'name': 'The Job',
             'duration': 259200,
             'interval': 300,


### PR DESCRIPTION
Add an API endpoint at `/scanners/ID/job` to get a scanner's current job.

Adds a start time to the `ScanJob` model and refactor both the model and it's json representation to simplify time interval serialization.

