### PR TITLE
Add `/start` endpoint for scan jobs

### DIFF
--- a/scanomatic/io/scanning_store.py
+++ b/scanomatic/io/scanning_store.py
@@ -85,3 +85,6 @@ class ScanningStore:
         for job in self._scanjobs.values():
             if job.scanner_id == scanner_id and job.is_active(timepoint):
                 return job
+
+    def has_current_scanjob(self, scanner_id, timepoint):
+        return self.get_current_scanjob(scanner_id, timepoint) is not None

--- a/scanomatic/io/scanning_store.py
+++ b/scanomatic/io/scanning_store.py
@@ -58,6 +58,17 @@ class ScanningStore:
                 "{} is not a known job".format(identifier)
             )
 
+    def get_scanjob(self, identifier):
+        try:
+            return self._scanjobs[identifier]
+        except KeyError:
+            raise ScanJobUnknownError(identifier)
+
+    def update_scanjob(self, job):
+        if job.identifier not in self._scanjobs:
+            raise ScanJobUnknownError(job.identifier)
+        self._scanjobs[job.identifier] = job
+
     def get_all_scanjobs(self):
         return list(self._scanjobs.values())
 

--- a/scanomatic/models/scanjob.py
+++ b/scanomatic/models/scanjob.py
@@ -7,29 +7,35 @@ from scanomatic.util.datetime import is_utc
 
 ScanJobBase = namedtuple(
     'ScanJobBase',
-    ['identifier', 'name', 'duration', 'interval', 'scanner_id', 'start']
+    ['identifier', 'name', 'duration', 'interval', 'scanner_id', 'start_time']
 )
 
 
 class ScanJob(ScanJobBase):
     def __new__(
-        self, identifier, name, duration, interval, scanner_id, start=None,
+        self,
+        identifier,
+        name,
+        duration,
+        interval,
+        scanner_id,
+        start_time=None,
     ):
-        if start is not None:
-            if not isinstance(start, datetime):
-                raise ValueError('start should be a datetime')
-            if not is_utc(start):
-                raise ValueError('start should be UTC')
+        if start_time is not None:
+            if not isinstance(start_time, datetime):
+                raise ValueError('start_time should be a datetime')
+            if not is_utc(start_time):
+                raise ValueError('start_time should be UTC')
         if not isinstance(duration, timedelta):
             raise ValueError('duration should be a timedelta')
         if not isinstance(interval, timedelta):
             raise ValueError('interval should be a timedelta')
         return super(ScanJob, self).__new__(
-            self, identifier, name, duration, interval, scanner_id, start,
+            self, identifier, name, duration, interval, scanner_id, start_time,
         )
 
     def is_active(self, timepoint):
         return (
-            self.start is not None
-            and self.start <= timepoint <= self.start + self.duration
+            self.start_time is not None
+            and self.start_time <= timepoint <= self.start_time + self.duration
         )

--- a/scanomatic/ui_server/scan_jobs_api.py
+++ b/scanomatic/ui_server/scan_jobs_api.py
@@ -5,6 +5,7 @@ from uuid import uuid1
 
 from flask import request, jsonify, Blueprint, current_app
 from flask_restful import Api, Resource
+import pytz
 from werkzeug.exceptions import NotFound
 
 from scanomatic.io.scanning_store import (
@@ -103,11 +104,12 @@ class ScanJobStartController(Resource):
             job = db.get_scanjob(scanjobid)
         except ScanJobUnknownError:
             raise NotFound
+        now = datetime.now(pytz.utc)
         if job.start is not None:
             return json_abort(CONFLICT, reason='Scanning Job already started')
-        if db.get_current_scanjob(job.scanner_id, datetime.now()) is not None:
+        if db.get_current_scanjob(job.scanner_id, now) is not None:
             return json_abort(CONFLICT, reason='Scanner busy')
-        db.update_scanjob(job._replace(start=datetime.now()))
+        db.update_scanjob(job._replace(start=now))
         return '', OK
 
 

--- a/scanomatic/ui_server/scan_jobs_api.py
+++ b/scanomatic/ui_server/scan_jobs_api.py
@@ -107,7 +107,7 @@ class ScanJobStartController(Resource):
         now = datetime.now(pytz.utc)
         if job.start is not None:
             return json_abort(CONFLICT, reason='Scanning Job already started')
-        if db.get_current_scanjob(job.scanner_id, now) is not None:
+        if db.has_current_scanjob(job.scanner_id, now):
             return json_abort(CONFLICT, reason='Scanner busy')
         db.update_scanjob(job._replace(start=now))
         return '', OK

--- a/scanomatic/ui_server/scan_jobs_api.py
+++ b/scanomatic/ui_server/scan_jobs_api.py
@@ -105,11 +105,11 @@ class ScanJobStartController(Resource):
         except ScanJobUnknownError:
             raise NotFound
         now = datetime.now(pytz.utc)
-        if job.start is not None:
+        if job.start_time is not None:
             return json_abort(CONFLICT, reason='Scanning Job already started')
         if db.has_current_scanjob(job.scanner_id, now):
             return json_abort(CONFLICT, reason='Scanner busy')
-        db.update_scanjob(job._replace(start=now))
+        db.update_scanjob(job._replace(start_time=now))
         return '', OK
 
 

--- a/scanomatic/ui_server/scan_jobs_api.py
+++ b/scanomatic/ui_server/scan_jobs_api.py
@@ -103,9 +103,11 @@ class ScanJobStartController(Resource):
             job = db.get_scanjob(scanjobid)
         except ScanJobUnknownError:
             raise NotFound
-        db.update_scanjob(job._replace(start=datetime.now()))
         if job.start is not None:
-            return '', CONFLICT
+            return json_abort(CONFLICT, reason='Scanning Job already started')
+        if db.get_current_scanjob(job.scanner_id, datetime.now()) is not None:
+            return json_abort(CONFLICT, reason='Scanner busy')
+        db.update_scanjob(job._replace(start=datetime.now()))
         return '', OK
 
 

--- a/scanomatic/ui_server/serialization.py
+++ b/scanomatic/ui_server/serialization.py
@@ -10,7 +10,7 @@ def job2json(job):
         'interval': job.interval.total_seconds(),
         'scannerId': job.scanner_id,
     }
-    if job.start is not None:
-        assert is_utc(job.start)
-        obj['start'] = job.start.strftime('%Y-%m-%dT%H:%M:%SZ')
+    if job.start_time is not None:
+        assert is_utc(job.start_time)
+        obj['startTime'] = job.start_time.strftime('%Y-%m-%dT%H:%M:%SZ')
     return obj

--- a/tests/unit/io/test_scanning_store.py
+++ b/tests/unit/io/test_scanning_store.py
@@ -143,7 +143,7 @@ class TestExistsJobWith:
             'identifier', 'Hello') is False
 
 
-class TestGetCurrentJob:
+class TestCurrentScanJob:
     SCANNERID = "9a8486a6f9cb11e7ac660050b68338ac"
 
     @pytest.fixture
@@ -185,7 +185,7 @@ class TestGetCurrentJob:
         (datetime(1985, 10, 26, 1, 20, tzinfo=utc), 'Bar'),
         (datetime(1985, 10, 26, 1, 35, tzinfo=utc), 'Baz'),
     ])
-    def test_has_active_job(self, store, t, jobname):
+    def test_get_current_scanjob_with_active_job(self, store, t, jobname):
         job = store.get_current_scanjob(self.SCANNERID, t)
         assert job is not None and job.name == jobname
 
@@ -194,6 +194,16 @@ class TestGetCurrentJob:
         datetime(1985, 10, 26, 1, 25, tzinfo=utc),
         datetime(1985, 10, 26, 1, 40, tzinfo=utc),
     ])
-    def test_no_active_job(self, store, t):
+    def test_get_current_scanjob_with_no_active_job(self, store, t):
         job = store.get_current_scanjob(self.SCANNERID, t)
         assert job is None
+
+    @pytest.mark.parametrize('t, expected', [
+        (datetime(1985, 10, 26, 1, 15, tzinfo=utc), False),
+        (datetime(1985, 10, 26, 1, 20, tzinfo=utc), True),
+        (datetime(1985, 10, 26, 1, 25, tzinfo=utc), False),
+        (datetime(1985, 10, 26, 1, 35, tzinfo=utc), True),
+        (datetime(1985, 10, 26, 1, 40, tzinfo=utc), False),
+    ])
+    def test_has_current_scanjob(self, store, t, expected):
+        assert store.has_current_scanjob(self.SCANNERID, t) is expected

--- a/tests/unit/io/test_scanning_store.py
+++ b/tests/unit/io/test_scanning_store.py
@@ -161,7 +161,7 @@ class TestCurrentScanJob:
             duration=timedelta(minutes=1),
             interval=timedelta(seconds=5),
             scanner_id=self.SCANNERID,
-            start=datetime(1985, 10, 26, 1, 20, tzinfo=utc)
+            start_time=datetime(1985, 10, 26, 1, 20, tzinfo=utc)
         ))
         scanning_store.add_scanjob(ScanJob(
             identifier='3',
@@ -169,7 +169,7 @@ class TestCurrentScanJob:
             duration=timedelta(minutes=1),
             interval=timedelta(seconds=5),
             scanner_id=self.SCANNERID,
-            start=datetime(1985, 10, 26, 1, 35, tzinfo=utc)
+            start_time=datetime(1985, 10, 26, 1, 35, tzinfo=utc)
         ))
         scanning_store.add_scanjob(ScanJob(
             identifier='4',
@@ -177,7 +177,7 @@ class TestCurrentScanJob:
             duration=timedelta(minutes=30),
             interval=timedelta(seconds=5),
             scanner_id='otherscanner',
-            start=datetime(1985, 10, 26, 1, 20, tzinfo=utc)
+            start_time=datetime(1985, 10, 26, 1, 20, tzinfo=utc)
         ))
         return scanning_store
 

--- a/tests/unit/io/test_scanning_store.py
+++ b/tests/unit/io/test_scanning_store.py
@@ -91,6 +91,35 @@ class TestGetJobs:
         assert len(scanning_store.get_all_scanjobs()) == 2
 
 
+class TestGetScanjob:
+    def test_existing_job(self, scanning_store):
+        scanning_store.add_scanjob(JOB1)
+        assert scanning_store.get_scanjob(JOB1.identifier) == JOB1
+
+    def test_unknown_job(self, scanning_store):
+        scanning_store.add_scanjob(JOB1)
+        with pytest.raises(ScanJobUnknownError):
+            scanning_store.get_scanjob('unknown')
+
+
+class TestUpdateScanjob:
+    def test_update_existing(self, scanning_store):
+        scanning_store.add_scanjob(JOB1)
+        updated_scanjob = ScanJob(
+            identifier=JOB1.identifier,
+            name="Bye",
+            duration=JOB1.duration,
+            interval=JOB1.interval,
+            scanner_id=JOB1.scanner_id,
+        )
+        scanning_store.update_scanjob(updated_scanjob)
+        assert scanning_store.get_scanjob(JOB1.identifier) == updated_scanjob
+
+    def test_update_unknown(self, scanning_store):
+        with pytest.raises(ScanJobUnknownError):
+            scanning_store.update_scanjob(JOB1)
+
+
 class TestGetJobIds:
     def test_has_the_ids(self, scanning_store):
         scanning_store.add_scanjob(JOB1)

--- a/tests/unit/models/test_scanjob.py
+++ b/tests/unit/models/test_scanjob.py
@@ -15,16 +15,16 @@ class TestInit:
             duration=timedelta(days=3),
             interval=timedelta(minutes=5),
             scanner_id='yyyy',
-            start=datetime(1985, 10, 26, 1, 20, tzinfo=utc),
+            start_time=datetime(1985, 10, 26, 1, 20, tzinfo=utc),
         )
         assert job.identifier == 'xxxx'
         assert job.name == 'Unknown'
         assert job.duration == timedelta(days=3)
         assert job.interval == timedelta(minutes=5)
         assert job.scanner_id == 'yyyy'
-        assert job.start == datetime(1985, 10, 26, 1, 20, tzinfo=utc)
+        assert job.start_time == datetime(1985, 10, 26, 1, 20, tzinfo=utc)
 
-    def test_init_without_start(self):
+    def test_init_without_start_time(self):
         job = ScanJob(
             identifier='xxxx',
             name='Unknown',
@@ -32,13 +32,13 @@ class TestInit:
             interval=timedelta(minutes=5),
             scanner_id='yyyy',
         )
-        assert job.start is None
+        assert job.start_time is None
 
-    @pytest.mark.parametrize('start', [
+    @pytest.mark.parametrize('start_time', [
         ('xxx',),
         (datetime(1985, 10, 26, 1, 20),),
     ])
-    def test_init_bad_start(self, start):
+    def test_init_bad_start_time(self, start_time):
         with pytest.raises(ValueError):
             ScanJob(
                 identifier='xxxx',
@@ -46,7 +46,7 @@ class TestInit:
                 duration=timedelta(days=3),
                 interval=timedelta(minutes=5),
                 scanner_id='yyyy',
-                start=start,
+                start_time=start_time,
             )
 
 
@@ -69,7 +69,7 @@ class TestIsActive:
             duration=timedelta(minutes=1),
             interval=timedelta(seconds=5),
             scanner_id='yyyy',
-            start=datetime(1985, 10, 26, 1, 20, tzinfo=utc)
+            start_time=datetime(1985, 10, 26, 1, 20, tzinfo=utc)
         )
 
     @pytest.mark.parametrize('now', [

--- a/tests/unit/ui_server/test_scan_jobs_api.py
+++ b/tests/unit/ui_server/test_scan_jobs_api.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import
-import pytest
+from httplib import BAD_REQUEST, CONFLICT, OK, CREATED, NOT_FOUND
 import json
 from types import MethodType
+import uuid
+
 from flask import Flask
-from httplib import BAD_REQUEST, CONFLICT, OK, CREATED
+import freezegun
+import pytest
 
 from scanomatic.ui_server.ui_server import add_configs
 from scanomatic.io.paths import Paths
@@ -52,9 +55,23 @@ class TestScanJobs:
         response.status_code == OK
         assert response.json == []
 
+    def test_get_unknown_job(self, test_app):
+        response = test_app.get(self.URI + '/unknown')
+        assert response.status_code == NOT_FOUND
+
     def test_add_job(self, test_app, job):
         response = test_app.post_json(self.URI, job)
         assert response.status_code == CREATED
+        jobid = response.json['jobId']
+        response2 = test_app.get(self.URI + '/' + jobid)
+        assert response2.status_code == OK
+        assert response2.json == {
+            'identifier': jobid,
+            'name': job['name'],
+            'interval': job['interval'],
+            'duration': job['duration'],
+            'scannerId': job['scannerId'],
+        }
 
     def test_sereval_identical_job_names_fails(self, test_app, job):
         response = test_app.post_json(self.URI, job)
@@ -119,3 +136,38 @@ class TestScanJobs:
                 'scannerId': job['scannerId'],
             }
         ]
+
+
+class TestStartScanJob:
+    URI = '/api/scan-jobs/{id}/start'
+
+    @pytest.fixture
+    def jobid(self, test_app):
+        response = test_app.post_json('/api/scan-jobs', {
+            'name': uuid.uuid1().hex,
+            'scannerId': '9a8486a6f9cb11e7ac660050b68338ac',
+            'interval': 500,
+            'duration': 86400,
+        })
+        assert response.status_code == CREATED
+        return response.json['jobId']
+
+    def test_start_existing_job(self, test_app, jobid):
+        with freezegun.freeze_time('1985-10-26 01:20', tz_offset=0):
+            response = test_app.post(self.URI.format(id=jobid))
+        assert response.status_code == OK
+        job = test_app.get('/api/scan-jobs/' + jobid).json
+        return job['start'] == '1985-10-26T01:20:00'
+
+    def test_already_started(self, test_app, jobid):
+        with freezegun.freeze_time('1985-10-26 01:20', tz_offset=0):
+            test_app.post(self.URI.format(id=jobid))
+        with freezegun.freeze_time('1985-10-26 01:21', tz_offset=0):
+            response = test_app.post(self.URI.format(id=jobid))
+        assert response.status_code == CONFLICT
+        job = test_app.get('/api/scan-jobs/' + jobid).json
+        return job['start'] == '1985-10-26T01:20:00'
+
+    def test_unknown_job(self, test_app):
+        response = test_app.post(self.URI.format(id='unknown'))
+        assert response.status_code == NOT_FOUND

--- a/tests/unit/ui_server/test_scan_jobs_api.py
+++ b/tests/unit/ui_server/test_scan_jobs_api.py
@@ -157,7 +157,7 @@ class TestStartScanJob:
             response = test_app.post(self.URI.format(id=jobid))
         assert response.status_code == OK
         job = test_app.get('/api/scan-jobs/' + jobid).json
-        return job['start'] == '1985-10-26T01:20:00Z'
+        return job['startTime'] == '1985-10-26T01:20:00Z'
 
     def test_already_started(self, test_app):
         jobid = self.create_scanjob(test_app)
@@ -167,7 +167,7 @@ class TestStartScanJob:
             response = test_app.post(self.URI.format(id=jobid))
         assert response.status_code == CONFLICT
         job = test_app.get('/api/scan-jobs/' + jobid).json
-        assert job['start'] == '1985-10-26T01:20:00Z'
+        assert job['startTime'] == '1985-10-26T01:20:00Z'
 
     def test_unknown_job(self, test_app):
         response = test_app.post(self.URI.format(id='unknown'))

--- a/tests/unit/ui_server/test_scan_jobs_api.py
+++ b/tests/unit/ui_server/test_scan_jobs_api.py
@@ -157,7 +157,7 @@ class TestStartScanJob:
             response = test_app.post(self.URI.format(id=jobid))
         assert response.status_code == OK
         job = test_app.get('/api/scan-jobs/' + jobid).json
-        return job['start'] == '1985-10-26T01:20:00'
+        return job['start'] == '1985-10-26T01:20:00Z'
 
     def test_already_started(self, test_app):
         jobid = self.create_scanjob(test_app)
@@ -167,7 +167,7 @@ class TestStartScanJob:
             response = test_app.post(self.URI.format(id=jobid))
         assert response.status_code == CONFLICT
         job = test_app.get('/api/scan-jobs/' + jobid).json
-        assert job['start'] == '1985-10-26T01:20:00'
+        assert job['start'] == '1985-10-26T01:20:00Z'
 
     def test_unknown_job(self, test_app):
         response = test_app.post(self.URI.format(id='unknown'))

--- a/tests/unit/ui_server/test_scanners_api.py
+++ b/tests/unit/ui_server/test_scanners_api.py
@@ -96,7 +96,7 @@ class TestGetScannerJob(object):
             duration=timedelta(days=3),
             interval=timedelta(minutes=5),
             scanner_id='yyyy',
-            start=datetime(1985, 10, 26, 1, 20, tzinfo=utc),
+            start_time=datetime(1985, 10, 26, 1, 20, tzinfo=utc),
         )
         response = client.get(self.URI)
         assert response.status_code == OK
@@ -106,6 +106,6 @@ class TestGetScannerJob(object):
             'duration': 259200,
             'interval': 300,
             'scannerId': 'yyyy',
-            'start': '1985-10-26T01:20:00Z',
+            'startTime': '1985-10-26T01:20:00Z',
         }
         pass

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 [testenv]
 deps =
     -rrequirements.txt
+    freezegun
     mock
     pytest
     pytest-cov


### PR DESCRIPTION
Add the following endpoints:
- `GET /api/scan-jobs/$id`: get a single scanjob by id
- `POST /api/scan-jobs/$id/start`: start a scanjob

In REST slang the first would be a document resource and the second a controller resource.

I'm a bit unhappy with the "start" controller having the same name as the "start" (time) field but I'm not sure it's really a problem. I can rename the field if someone thing it's going to cause issues.

This somewhat encroaches on a future task (start job when button is clicked), but I need it to write tests using the scanjob API.