### PR TITLE
Change the name of image files

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,7 @@ enum34
 flask
 flask-restful
 flask_cors
+future
 matplotlib
 numpy
 odfpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ flask-cors==3.0.2
 flask-restful==0.3.6
 flask==0.12.1
 functools32==3.2.3.post2  # via matplotlib
+future==0.16.0
 itsdangerous==0.24        # via flask
 jinja2==2.9.6             # via flask
 markupsafe==1.0           # via jinja2

--- a/scanomatic/io/imagestore.py
+++ b/scanomatic/io/imagestore.py
@@ -32,10 +32,6 @@ class ImageStore(object):
             raise ImageNotFoundError
 
     def _mk_image_path(self, scan):
-        epoch = datetime(1970, 1, 1, tzinfo=pytz.utc)
-        timestamp = (scan.start_time - epoch).total_seconds()
         dirname = scan.scanjob_id
-        filename = '{jobid}_{timestamp:.0f}.tiff'.format(
-            jobid=scan.scanjob_id, timestamp=timestamp,
-        )
+        filename = '{}.tiff'.format(scan.id)
         return os.path.join(self._path, dirname, filename)

--- a/scanomatic/ui_server/scans_api.py
+++ b/scanomatic/ui_server/scans_api.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 import httplib as HTTPStatus
 from io import BytesIO
-from uuid import uuid1
 
 from flask import Blueprint, current_app, send_file
 from flask_restful import Api, Resource, reqparse, inputs
@@ -13,6 +12,7 @@ from .general import json_abort
 from .serialization import scan2json
 from scanomatic.io.scanning_store import ScanJobUnknownError, UnknownIdError
 from scanomatic.models.scan import Scan
+from scanomatic.util.scanid import generate_scan_id
 
 
 class ScanCollection(Resource):
@@ -58,14 +58,14 @@ class ScanCollection(Resource):
         )
         args = parser.parse_args(strict=True)
         try:
-            db.get_scanjob(args.scanjob_id)
+            scanjob = db.get_scanjob(args.scanjob_id)
         except ScanJobUnknownError:
             return json_abort(
                 HTTPStatus.BAD_REQUEST,
                 message='Unknown scan job',
             )
         scan = Scan(
-            id=uuid1().hex,
+            id=generate_scan_id(scanjob, args.start_time),
             start_time=args.start_time,
             end_time=args.end_time,
             digest=args.digest,

--- a/scanomatic/util/scanid.py
+++ b/scanomatic/util/scanid.py
@@ -1,0 +1,11 @@
+def generate_scan_id(scanjob, scantime):
+    scan_timedelta = (scantime - scanjob.start_time)
+    scan_index = round(
+        scan_timedelta.total_seconds()
+        / scanjob.interval.total_seconds()
+    )
+    return '{jobid}_{index:04.0f}_{timedelta:.4f}'.format(
+        jobid=scanjob.identifier,
+        timedelta=scan_timedelta.total_seconds(),
+        index=scan_index,
+    )

--- a/scanomatic/util/scanid.py
+++ b/scanomatic/util/scanid.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import, division
+from builtins import round
+
+
 def generate_scan_id(scanjob, scantime):
     scan_timedelta = (scantime - scanjob.start_time)
     scan_index = round(

--- a/tests/integration/api/test_scans.py
+++ b/tests/integration/api/test_scans.py
@@ -12,7 +12,9 @@ def existing_scanjob_id(apiclient):
     scannerid = '9a8486a6f9cb11e7ac660050b68338ac'
     response = apiclient.create_scan_job(scannerid)
     assert response.status_code == HTTPStatus.CREATED
-    return response.json['identifier']
+    scanjobid = response.json['identifier']
+    assert apiclient.start_scan_job(scanjobid).status_code == HTTPStatus.OK
+    return scanjobid
 
 
 @pytest.fixture

--- a/tests/unit/io/test_imagestore.py
+++ b/tests/unit/io/test_imagestore.py
@@ -20,22 +20,23 @@ def scan():
 
 
 @pytest.fixture
-def filename():
-    return 'bbbb_499137600.tiff'
-
-
-@pytest.fixture
 def imagestore(tmpdir):
     return ImageStore(str(tmpdir))
 
 
 class TestPutImage:
-    def test_directory_exists(self, imagestore, tmpdir, scan):
+    def test_file_content(self, imagestore, tmpdir, scan):
         scanjobdir = tmpdir.mkdir('bbbb')
         imagestore.put(b'I am an image', scan)
-        imagepath = scanjobdir.join('bbbb_499137600.tiff')
-        assert imagepath in scanjobdir.listdir()
-        assert imagepath.read() == 'I am an image'
+        files = scanjobdir.listdir()
+        assert len(files) == 1
+        assert files[0].read() == 'I am an image'
+
+    def test_file_name(self, imagestore, tmpdir, scan):
+        scanjobdir = tmpdir.mkdir('bbbb')
+        imagepath = scanjobdir.join('aaaa.tiff')
+        imagestore.put(b'I am an image', scan)
+        assert scanjobdir.listdir() == [imagepath]
 
     def test_create_directory(self, imagestore, tmpdir, scan):
         imagestore.put(b'I am an image', scan)
@@ -44,7 +45,7 @@ class TestPutImage:
 
 class TestGetImage:
     def test_existing_image(self, imagestore, tmpdir, scan):
-        imagepath = tmpdir.mkdir('bbbb').join('bbbb_499137600.tiff')
+        imagepath = tmpdir.mkdir('bbbb').join('aaaa.tiff')
         with imagepath.open('wb') as f:
             f.write(b'I am an image')
         image = imagestore.get(scan)

--- a/tests/unit/util/test_scanid.py
+++ b/tests/unit/util/test_scanid.py
@@ -3,8 +3,8 @@ from datetime import datetime, timedelta
 import pytest
 from pytz import utc
 
-from scanomatic.scanning import generate_scan_id
 from scanomatic.models.scanjob import ScanJob
+from scanomatic.util.scanid import generate_scan_id
 
 
 @pytest.fixture

--- a/tests/unit/util/test_scanid.py
+++ b/tests/unit/util/test_scanid.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from datetime import datetime, timedelta
 
 import pytest
@@ -21,7 +22,7 @@ def scanjob():
 
 @pytest.mark.parametrize('delay, scanid', [
     (timedelta(minutes=0), 'j00b_0000_0.0000'),
-    (timedelta(minutes=10), 'j00b_0001_600.0000'),
+    (timedelta(minutes=10), 'j00b_0000_600.0000'),
     (timedelta(minutes=15), 'j00b_0001_900.0000'),
     (timedelta(minutes=20), 'j00b_0001_1200.0000'),
     (timedelta(minutes=25), 'j00b_0001_1500.0000'),

--- a/tests/unit/util/test_scanid.py
+++ b/tests/unit/util/test_scanid.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta
+
+import pytest
+from pytz import utc
+
+from scanomatic.scanning import generate_scan_id
+from scanomatic.models.scanjob import ScanJob
+
+
+@pytest.fixture
+def scanjob():
+    return ScanJob(
+        identifier='j00b',
+        name="The Job",
+        duration=timedelta(days=1),
+        interval=timedelta(minutes=20),
+        scanner_id="9a8486a6f9cb11e7ac660050b68338ac",
+        start_time=datetime(1985, 10, 26, 1, 20, tzinfo=utc),
+    )
+
+
+@pytest.mark.parametrize('delay, scanid', [
+    (timedelta(minutes=0), 'j00b_0000_0.0000'),
+    (timedelta(minutes=10), 'j00b_0001_600.0000'),
+    (timedelta(minutes=15), 'j00b_0001_900.0000'),
+    (timedelta(minutes=20), 'j00b_0001_1200.0000'),
+    (timedelta(minutes=25), 'j00b_0001_1500.0000'),
+    (timedelta(minutes=30), 'j00b_0002_1800.0000'),
+    (timedelta(minutes=35), 'j00b_0002_2100.0000'),
+])
+def test_scan_id(scanjob, delay, scanid):
+    scantime = scanjob.start_time + delay
+    assert generate_scan_id(scanjob, scantime) == scanid


### PR DESCRIPTION
Refactor the way scan are stored:
- instead of generating a complex filename, `ImageStore` just uses `<jobid>/<scanid>.tiff`
- generate identifiers for scans that match the old image filename format (`<jobid>_<index>_<delta>`).

There is two advantages to doing it this way:
- the filename matches the id in API calls
- it should be more maintainable: we can change the way filenames (and ids) are generated without needing to rename all existing images.