### PR TITLE
Copy only what's necessary to build the ui in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:4 as npmbuilder
-COPY . /src
+COPY scanomatic/ui_server_data /src/scanomatic/ui_server_data
+COPY package.json /src
+COPY webpack.config.js /src
+COPY .babelrc /src
 WORKDIR /src
 RUN npm install
 RUN npm run build


### PR DESCRIPTION
This makes it faster to rebuild the image by not rebuilding the ui if no ui file has changed.