### PR TITLE
Get scanner "owned" property from API

### DIFF
--- a/scanomatic/ui_server_data/js/specs/api.spec.js
+++ b/scanomatic/ui_server_data/js/specs/api.spec.js
@@ -890,4 +890,55 @@ describe('API', () => {
             });
         });
     });
+
+    describe('getScannerJob', () => {
+        const scanJob = {
+            name: 'Some Job',
+            duration: { days: 1, hours: 3, minutes: 5 },
+            interval: 20,
+            scannerId: 'sc4nn3r',
+        };
+        const args = ['sc4nn3r'];
+
+        it('should query the correct URL', () => {
+            API.getScannerJob(...args);
+            expect(mostRecentRequest().url)
+                .toEqual('/api/scanners/sc4nn3r/job');
+        });
+
+        it('should send a GET request', () => {
+            API.getScannerJob(...args);
+            expect(mostRecentRequest().method).toEqual('GET');
+        });
+
+        it('should return a promise that resolves on success', (done) => {
+            API.getScannerJob(...args).then((value) => {
+                expect(value).toEqual(scanJob);
+                done();
+            });
+            mostRecentRequest().respondWith({
+                status: 200, responseText: JSON.stringify(scanJob),
+            });
+        });
+
+        it('should return a promise that resolves if no job', (done) => {
+            API.getScannerJob(...args).then((value) => {
+                expect(value).toBe(null);
+                done();
+            });
+            mostRecentRequest().respondWith({
+                status: 200, responseText: 'null',
+            });
+        });
+
+        it('should return a promise that rejects on error', (done) => {
+            API.getScannerJob(...args).catch((reason) => {
+                expect(reason).toEqual('(+_+)');
+                done();
+            });
+            mostRecentRequest().respondWith({
+                status: 400, responseText: JSON.stringify({ reason: '(+_+)' }),
+            });
+        });
+    });
 });

--- a/scanomatic/ui_server_data/js/specs/containers/ScanningRootContainer.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/containers/ScanningRootContainer.spec.jsx
@@ -1,10 +1,10 @@
-
 import { shallow } from 'enzyme';
 import React from 'react';
 
 import '../components/enzyme-setup';
 import ScanningRootContainer from '../../src/containers/ScanningRootContainer';
 import * as API from '../../src/api';
+import * as helpers from '../../src/helpers';
 import FakePromise from '../helpers/FakePromise';
 
 
@@ -29,7 +29,8 @@ describe('<ScanningRootContainer />', () => {
     describe('Jobs Request doing nothing', () => {
         beforeEach(() => {
             spyOn(API, 'getScanningJobs').and.returnValue(new FakePromise());
-            spyOn(API, 'getScanners').and.returnValue(new FakePromise());
+            spyOn(helpers, 'getScannersWithOwned')
+                .and.returnValue(new FakePromise());
         });
 
         it('should render <ScanningRoot />', () => {
@@ -99,7 +100,7 @@ describe('<ScanningRootContainer />', () => {
         beforeEach(() => {
             spyOn(API, 'getScanningJobs').and
                 .returnValue(FakePromise.resolve([job]));
-            spyOn(API, 'getScanners').and
+            spyOn(helpers, 'getScannersWithOwned').and
                 .returnValue(FakePromise.resolve([scanner]));
         });
 
@@ -162,10 +163,10 @@ describe('<ScanningRootContainer />', () => {
             it('should update jobs', () => {
                 const wrapper = shallow(<ScanningRootContainer />);
                 API.getScanningJobs.calls.reset();
-                API.getScanners.calls.reset();
+                helpers.getScannersWithOwned.calls.reset();
                 wrapper.prop('onStartJob')(job);
                 expect(API.getScanningJobs).toHaveBeenCalled();
-                expect(API.getScanners).toHaveBeenCalled();
+                expect(helpers.getScannersWithOwned).toHaveBeenCalled();
             });
         });
 
@@ -190,7 +191,7 @@ describe('<ScanningRootContainer />', () => {
         beforeEach(() => {
             spyOn(API, 'getScanningJobs').and
                 .returnValue(FakePromise.reject('Fake'));
-            spyOn(API, 'getScanners').and
+            spyOn(helpers, 'getScannersWithOwned').and
                 .returnValue(FakePromise.resolve([scanner]));
         });
 
@@ -210,7 +211,7 @@ describe('<ScanningRootContainer />', () => {
         beforeEach(() => {
             spyOn(API, 'getScanningJobs').and
                 .returnValue(FakePromise.resolve([job]));
-            spyOn(API, 'getScanners').and
+            spyOn(helpers, 'getScannersWithOwned').and
                 .returnValue(FakePromise.reject('Fake'));
         });
 

--- a/scanomatic/ui_server_data/js/specs/helpers.spec.js
+++ b/scanomatic/ui_server_data/js/specs/helpers.spec.js
@@ -3,7 +3,7 @@ import {
     getScannersWithOwned,
     loadImage,
     uploadImage,
-    valueFormatter
+    valueFormatter,
 } from '../src/helpers';
 import testPlateImageURL from './fixtures/testPlate.png';
 import * as API from '../src/api';

--- a/scanomatic/ui_server_data/js/specs/helpers.spec.js
+++ b/scanomatic/ui_server_data/js/specs/helpers.spec.js
@@ -1,4 +1,10 @@
-import { RGBColor, loadImage, uploadImage, valueFormatter } from '../src/helpers';
+import {
+    RGBColor,
+    getScannersWithOwned,
+    loadImage,
+    uploadImage,
+    valueFormatter
+} from '../src/helpers';
 import testPlateImageURL from './fixtures/testPlate.png';
 import * as API from '../src/api';
 
@@ -197,6 +203,65 @@ describe('helpers', () => {
 
         it('works with negative numbers', () => {
             expect(valueFormatter(-320, 1)).toEqual('-3.2 x 10^2');
+        });
+    });
+
+    describe('getScannersWithOwned', () => {
+        const scanners = [
+            {
+                identifier: 'sc4nn3r01',
+                name: 'Scanner 01',
+                owned: false,
+                power: true,
+            },
+            {
+                identifier: 'sc4nn3r02',
+                name: 'Scanner 02',
+                owned: true,
+                power: true,
+            },
+        ];
+
+        const apiScanners = scanners.map(obj => ({
+            identifier: obj.identifier,
+            name: obj.name,
+            power: obj.power,
+        }));
+
+        it('should return a list of scanners on success', (done) => {
+            spyOn(API, 'getScanners')
+                .and.callFake(() => Promise.resolve(apiScanners));
+            spyOn(API, 'getScannerJob')
+                .and.callFake((id) => {
+                    const job = id === 'sc4nn3r02' ? { identifier: 'job0123' } : null;
+                    return Promise.resolve(job);
+                });
+            getScannersWithOwned().then((data) => {
+                expect(data).toEqual(scanners);
+                done();
+            });
+        });
+
+        it('should reject if getScanners rejects', (done) => {
+            const message = 'Sorry, Dave.';
+            spyOn(API, 'getScanners')
+                .and.callFake(() => Promise.reject(message));
+            getScannersWithOwned().catch((error) => {
+                expect(error).toEqual(message);
+                done();
+            });
+        });
+
+        it('should reject if getScannerJob rejects', (done) => {
+            const message = "I'm afraid I can't do that.";
+            spyOn(API, 'getScanners')
+                .and.callFake(() => Promise.resolve(apiScanners));
+            spyOn(API, 'getScannerJob')
+                .and.callFake(() => Promise.reject(message));
+            getScannersWithOwned().catch((error) => {
+                expect(error).toEqual(message);
+                done();
+            });
         });
     });
 });

--- a/scanomatic/ui_server_data/js/src/api.js
+++ b/scanomatic/ui_server_data/js/src/api.js
@@ -292,6 +292,9 @@ export function getScanners() {
             name: scanner.name,
             identifier: scanner.identifier,
             power: scanner.power,
-            owned: !!scanner.owner,
         })));
+}
+
+export function getScannerJob(scannerId) {
+    return API.get(`/api/scanners/${scannerId}/job`);
 }

--- a/scanomatic/ui_server_data/js/src/containers/ScanningRootContainer.jsx
+++ b/scanomatic/ui_server_data/js/src/containers/ScanningRootContainer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { getScanningJobs, getScanners, startScanningJob } from '../api';
+import { getScanningJobs, startScanningJob } from '../api';
+import { getScannersWithOwned } from '../helpers';
 import ScanningRoot from '../components/ScanningRoot';
 
 
@@ -28,7 +29,7 @@ export default class ScanningRootContainer extends React.Component {
             .then(jobs => this.setState({ jobs }))
             .catch(reason => this.setState({ error: `Error requesting jobs: ${reason}` }));
 
-        getScanners()
+        getScannersWithOwned()
             .then(scanners => this.setState({ scanners }))
             .catch(reason => this.setState({ error: `Error requesting scanners: ${reason}` }));
     }

--- a/scanomatic/ui_server_data/js/src/helpers.js
+++ b/scanomatic/ui_server_data/js/src/helpers.js
@@ -226,3 +226,10 @@ export function uploadImage(ccc, file, fixture, token, progress) {
         })
         .then(() => imageId);
 }
+
+export function getScannersWithOwned() {
+    return API.getScanners().then(scanners =>
+        Promise.all(scanners.map(scanner =>
+            API.getScannerJob(scanner.identifier)
+                .then(job => Object.assign(scanner, { owned: job != null })))));
+}


### PR DESCRIPTION
- add function to get scanner job from API
- add helper function that get the list of scanner and their current
jobs from the API and builds a list of scanners with the `owned`
property as expected by the UI.