### PR TITLE
Expose scanner metrics to prometheus

### DIFF
--- a/scanomatic/scanning/update_scanner_status.py
+++ b/scanomatic/scanning/update_scanner_status.py
@@ -64,11 +64,12 @@ def update_scanner_status(
         images_to_send=images_to_send,
     )
     db.add_scanner_status(scanner_id, status)
-    SCANNER_CURRENT_JOBS.labels(scanner=scanner_id).set(job is not None)
-    SCANNER_QUEUED_UPLOADS.labels(scanner=scanner_id).set(images_to_send)
-    SCANNER_START_TIME.labels(scanner=scanner_id).set(timestamp(start_time))
-    SCANNER_LAST_STATUS_UPDATE_TIME.labels(scanner=scanner_id).set_to_current_time()
-    SCANNER_STATUS_UPDATES.labels(scanner=scanner_id).inc()
+    labels = {'scanner': scanner_id}
+    SCANNER_CURRENT_JOBS.labels(**labels).set(job is not None)
+    SCANNER_QUEUED_UPLOADS.labels(**labels).set(images_to_send)
+    SCANNER_START_TIME.labels(**labels).set(timestamp(start_time))
+    SCANNER_LAST_STATUS_UPDATE_TIME.labels(**labels).set_to_current_time()
+    SCANNER_STATUS_UPDATES.labels(**labels).inc()
     return UpdateScannerStatusResult(new_scanner=new_scanner)
 
 

--- a/scanomatic/scanning/update_scanner_status.py
+++ b/scanomatic/scanning/update_scanner_status.py
@@ -2,12 +2,41 @@ from __future__ import absolute_import
 from collections import namedtuple
 from datetime import datetime
 
+from prometheus_client import Gauge, Counter
 import pytz
 
 from scanomatic.io.scanning_store import DuplicateNameError
 from scanomatic.models.scanner import Scanner
 from scanomatic.models.scannerstatus import ScannerStatus
+from scanomatic.util.datetime import timestamp
 from scanomatic.util.generic_name import get_generic_name
+
+
+SCANNER_CURRENT_JOBS = Gauge(
+    'scanner_current_jobs',
+    'Number of job currently executed',
+    ['scanner']
+)
+SCANNER_QUEUED_UPLOADS = Gauge(
+    'scanner_queued_uploads',
+    'Number of images queued for upload',
+    ['scanner']
+)
+SCANNER_START_TIME = Gauge(
+    'scanner_start_time_seconds',
+    'Start time of the daemon since unix epoch in seconds',
+    ['scanner']
+)
+SCANNER_LAST_STATUS_UPDATE_TIME = Gauge(
+    'scanner_last_status_update_time_seconds',
+    'Number of seconds since unix epoch for the last status update',
+    ['scanner']
+)
+SCANNER_STATUS_UPDATES = Counter(
+    'scanner_status_updates_total',
+    'Number of status updates',
+    ['scanner']
+)
 
 
 def UpdateScannerStatusError(Exception):
@@ -35,6 +64,11 @@ def update_scanner_status(
         images_to_send=images_to_send,
     )
     db.add_scanner_status(scanner_id, status)
+    SCANNER_CURRENT_JOBS.labels(scanner=scanner_id).set(job is not None)
+    SCANNER_QUEUED_UPLOADS.labels(scanner=scanner_id).set(images_to_send)
+    SCANNER_START_TIME.labels(scanner=scanner_id).set(timestamp(start_time))
+    SCANNER_LAST_STATUS_UPDATE_TIME.labels(scanner=scanner_id).set_to_current_time()
+    SCANNER_STATUS_UPDATES.labels(scanner=scanner_id).inc()
     return UpdateScannerStatusResult(new_scanner=new_scanner)
 
 

--- a/scanomatic/util/datetime.py
+++ b/scanomatic/util/datetime.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import pytz
 
@@ -9,3 +9,8 @@ def is_utc(dt):
         dt.tzinfo is not None
         and dt.tzinfo.utcoffset(dt) == dt.tzinfo.dst(dt) == timedelta(0)
     )
+
+
+def timestamp(dt):
+    epoch = datetime(1970, 1, 1, tzinfo=pytz.utc)
+    return (dt - epoch).total_seconds()

--- a/tests/unit/scanning/test_update_scanner_status.py
+++ b/tests/unit/scanning/test_update_scanner_status.py
@@ -1,0 +1,52 @@
+from __future__ import absolute_import
+from datetime import datetime
+from uuid import uuid4
+
+from freezegun import freeze_time
+import mock
+from prometheus_client import REGISTRY
+import pytest
+from pytz import utc
+
+from scanomatic.scanning.update_scanner_status import update_scanner_status
+
+
+@pytest.fixture
+def scanner():
+    return uuid4().hex
+
+
+@pytest.fixture
+def update():
+    return {
+        'job': 'job007',
+        'images_to_send': 5,
+        'next_scheduled_scan': datetime(1985, 10, 26, 1, 35, tzinfo=utc),
+        'start_time': datetime(1985, 10, 26, 1, 20, tzinfo=utc),
+    }
+
+
+@pytest.fixture
+def db():
+    return mock.MagicMock()
+
+
+class TestMetrics:
+    @pytest.mark.parametrize('job, value', [('job001', 1), (None, 0)])
+    def test_scanner_current_jobs(self, db, scanner, update, job, value):
+        update['job'] = job
+        update_scanner_status(db, scanner, **update)
+        assert REGISTRY.get_sample_value(
+            'scanner_current_jobs', labels={'scanner': scanner}) == value
+
+    @pytest.mark.parametrize('metric, value', [
+        ('scanner_queued_uploads', 5),
+        ('scanner_start_time_seconds', 499137600.0),
+        ('scanner_last_status_update_time_seconds', 499137660.0),
+        ('scanner_status_updates_total', 1),
+    ])
+    def test_other_metrics(self, db, scanner, update, metric, value):
+        with freeze_time(datetime(1985, 10, 26, 1, 21, tzinfo=utc)):
+            update_scanner_status(db, scanner, **update)
+        assert REGISTRY.get_sample_value(
+            metric, labels={'scanner': scanner}) == value

--- a/tests/unit/util/test_datetime.py
+++ b/tests/unit/util/test_datetime.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, tzinfo
 import pytest
 from pytz import utc, timezone
 
-from scanomatic.util.datetime import is_utc
+from scanomatic.util.datetime import is_utc, timestamp
 
 
 class CustomUTC(tzinfo):
@@ -43,3 +43,11 @@ class TestIsUtc:
     ])
     def test_not_utc(self, date):
         assert not is_utc(date)
+
+
+@pytest.mark.parametrize('dt, seconds', [
+    (datetime(1970, 1, 1, tzinfo=utc), 0),
+    (datetime(1985, 10, 26, 1, 20, tzinfo=utc), 499137600.0),
+])
+def test_timestamp(dt, seconds):
+    assert timestamp(dt) == seconds


### PR DESCRIPTION
Expose the following metrics to prometheus: `scanner_current_jobs`, `'scanner_queued_uploads`, `scanner_start_time_seconds`, `scanner_last_status_update_time_seconds`, `scanner_status_updates_total`. Each has a `scanner` label with the scanner id.

Some notes:
- Having a label with the scanner id sort-of goes againts prometheus instrumentation best practices as it's an unbounded dimension, at least in theory. But since those are important, it might be worth the extra disk usage. And it's not like we'll have millions of scanners...
- For somewhat similar reason, I added tests for the scanner metrics whereas we usually don't do that.
- The metrics don't expire: even if a scanner goes offline, scanomatic will expose the last value as long as it is not restarted. This means that prometheus built-in staleness detection will not work and one needs to look at an other metrics to see if the scanner is still alive (`scanner_last_status_update_time_seconds`). This mimics the behavior of the pushgateway. I'm not sure it's the best way thing to do in this case but it was the simplest to implement 😁 