### PR TITLE
Publish test coverage to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
   firefox: latest
 
 before_install:
-    - pip install tox coveralls
+    - pip install tox coveralls codecov
     - gem install coveralls-lcov
     - wget -N http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip -P ~/
     - unzip ~/chromedriver_linux64.zip -d ~/
@@ -34,6 +34,8 @@ script:
     - npm test
     - docker-compose --verbose build --no-cache --force-rm
     - tox
+after_script:
+    - codecov
 
 after_success:
     - coveralls-lcov -v -n scanomatic/ui_server_data/coverage/report-lcov/lcov.info > js-coverage.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,8 @@ script:
     - npm test
     - docker-compose --verbose build --no-cache --force-rm
     - tox
-after_script:
-    - codecov
-
 after_success:
+    - codecov
     - coveralls-lcov -v -n scanomatic/ui_server_data/coverage/report-lcov/lcov.info > js-coverage.json
     - coveralls --merge=js-coverage.json
     - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] ; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; docker-compose push; fi

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,6 @@ passenv =
     DISPLAY
 commands =
     pytest \
-        --cov scanomatic --cov scripts --cov-report xml \
+        --cov scanomatic --cov scripts --cov-report xml --cov-branch \
         --junitxml result.xml --ignore dev \
         {posargs}


### PR DESCRIPTION
This sends test coverage to codecov.io in addition to coveralls.

codecov.io has the ability to merge reports for a given build, which coveralls doesn't. This means we can divide the travis job in parts that can be run in parallel and be restarted individually (hopefully) and still have a unified coverage report.

My plan is to have both for some time, to build a baseline in codecov.io, before removing coveralls.