### PR TITLE
Refactor ScanningStore interface

### DIFF
--- a/scanomatic/io/scanning_store.py
+++ b/scanomatic/io/scanning_store.py
@@ -1,17 +1,12 @@
 from __future__ import absolute_import
+from collections import defaultdict
 from datetime import datetime
-import os
 import pytz
 
+from scanomatic.models.scan import Scan
+from scanomatic.models.scanjob import ScanJob
 from scanomatic.models.scanner import Scanner
-
-
-class ScanJobCollisionError(ValueError):
-    pass
-
-
-class ScanJobUnknownError(ValueError):
-    pass
+from scanomatic.models.scannerstatus import ScannerStatus
 
 
 class DuplicateIdError(ValueError):
@@ -23,133 +18,93 @@ class DuplicateNameError(ValueError):
 
 
 class UnknownIdError(ValueError):
-    pass
+    def __init__(self, klass, identifier):
+        super(UnknownIdError, self).__init__()
+        self._klass = klass
+        self._identifier = identifier
+
+    def __str__(self):
+        return 'Unknown {} id: {}'.format(
+            self._klass.__name__, self._identifier
+        )
 
 
 class ScanningStore:
     def __init__(self):
-        self._scanners = {}
-        self._scanner_statuses = {scanner: [] for scanner in self._scanners}
-        self._scanjobs = {}
-        self._scans = {}
+        self._stores = {
+            Scan: {},
+            ScanJob: {},
+            Scanner: {},
+            ScannerStatus: defaultdict(list),
+        }
 
-    def has_scanner(self, identifier):
-        return identifier in self._scanners
-
-    def get_scanner(self, identifier):
+    def _get_store(self, klass):
         try:
-            return self._scanners[identifier]
+            return self._stores[klass]
         except KeyError:
-            raise UnknownIdError
+            raise TypeError('No store for object type {}'.format(klass))
 
-    def get_scanner_by_name(self, name):
-        scanners = [
-            self._scanners[scanner] for scanner in self._scanners
-            if self._scanners[scanner].name == name
-        ]
-        if len(scanners) > 1:
-            raise DuplicateNameError(
-                "Duplicate name '{}' in scanner list".format(name)
-            )
-        elif len(scanners) == 0:
-            return None
-        else:
-            return scanners[0]
-
-    def add_scanner(self, scanner):
-        if self.has_scanner(scanner.identifier):
-            raise DuplicateIdError(
-                "Cannot add duplicate scanner with id '{}'".format(
-                    scanner.identifier)
-            )
-        elif self.get_scanner_by_name(scanner.name) is not None:
+    def add(self, item):
+        store = self._get_store(type(item))
+        if item.identifier in store:
+            raise DuplicateIdError(type(item), item.identifier)
+        if type(item) is Scanner and self.exists(Scanner, name=item.name):
             raise DuplicateNameError(
                 "Cannot add duplicate scanner with name '{}'".format(
-                    scanner.name)
+                    item.name)
             )
-        self._scanners[scanner.identifier] = scanner
-        self._scanner_statuses[scanner.identifier] = []
+        if type(item) is Scan and not self.exists(ScanJob, item.scanjob_id):
+            raise UnknownIdError(ScanJob, item.scanjob_id)
+        self._get_store(type(item))[item.identifier] = item
 
-    def get_free_scanners(self):
-        return [
-            scanner for scanner in self._scanners.values()
-            if self.has_current_scanjob(
-                scanner.identifier,
-                datetime.now(pytz.utc)
-            ) is False
-        ]
-
-    def get_all_scanners(self):
-        return list(self._scanners.values())
-
-    def add_scanjob(self, job):
-        if job.identifier in self._scanjobs:
-            raise ScanJobCollisionError(
-                "{} already used".format(job.identifier)
-            )
-        self._scanjobs[job.identifier] = job
-
-    def remove_scanjob(self, identifier):
-        if identifier in self._scanjobs:
-            del self._scanjobs[identifier]
-        else:
-            raise ScanJobUnknownError(
-                "{} is not a known job".format(identifier)
-            )
-
-    def get_scanjob(self, identifier):
+    def get(self, klass, id_):
         try:
-            return self._scanjobs[identifier]
+            return self._get_store(klass)[id_]
         except KeyError:
-            raise ScanJobUnknownError(identifier)
+            raise UnknownIdError(klass, id_)
 
-    def update_scanjob(self, job):
-        if job.identifier not in self._scanjobs:
-            raise ScanJobUnknownError(job.identifier)
-        self._scanjobs[job.identifier] = job
+    def find(self, klass, **constraints):
+        store = self._get_store(klass)
+        for item in store.values():
+            for key in constraints:
+                if getattr(item, key) != constraints[key]:
+                    break
+            else:
+                yield item
 
-    def get_all_scanjobs(self):
-        return list(self._scanjobs.values())
-
-    def get_scanjob_ids(self):
-        return list(self._scanjobs.keys())
-
-    def exists_scanjob_with(self, key, value):
-        for job in self._scanjobs.values():
-            if getattr(job, key) == value:
-                return True
+    def exists(self, klass, identifier=None, **constraints):
+        if identifier is not None:
+            return identifier in self._get_store(klass)
+        for item in self.find(klass, **constraints):
+            return True
         return False
 
+    def update(self, item):
+        if not self.exists(type(item), item.identifier):
+            raise UnknownIdError(type(item), item.identifier)
+        self._get_store(type(item))[item.identifier] = item
+
+    def get_free_scanners(self):
+        for scanner in self.find(Scanner):
+            if not self.has_current_scanjob(
+                scanner.identifier,
+                datetime.now(pytz.utc)
+            ):
+                yield scanner
+
     def get_current_scanjob(self, scanner_id, timepoint):
-        for job in self._scanjobs.values():
-            if job.scanner_id == scanner_id and job.is_active(timepoint):
+        for job in self.find(ScanJob, scanner_id=scanner_id):
+            if job.is_active(timepoint):
                 return job
 
     def has_current_scanjob(self, scanner_id, timepoint):
         return self.get_current_scanjob(scanner_id, timepoint) is not None
 
-    def add_scan(self, scan):
-        if scan.scanjob_id not in self._scanjobs:
-            raise ScanJobUnknownError
-        if scan.id in self._scans:
-            raise DuplicateIdError
-        self._scans[scan.id] = scan
-
-    def get_scans(self):
-        for item in self._scans.values():
-            yield item
-
-    def get_scan(self, scanid):
-        try:
-            return self._scans[scanid]
-        except KeyError:
-            raise UnknownIdError
-
     def get_scanner_status_list(self, scanner_id):
-        try:
-            return self._scanner_statuses[scanner_id]
-        except KeyError:
-            raise UnknownIdError
+        if self.exists(Scanner, scanner_id):
+            return self._get_store(ScannerStatus)[scanner_id]
+        else:
+            raise UnknownIdError(Scanner, scanner_id)
 
     def get_latest_scanner_status(self, scanner_id):
         try:

--- a/scanomatic/io/scanning_store.py
+++ b/scanomatic/io/scanning_store.py
@@ -84,14 +84,6 @@ class ScanningStore:
             raise UnknownIdError(type(item), item.identifier)
         self._get_store(type(item))[item.identifier] = item
 
-    def get_free_scanners(self):
-        for scanner in self.find(Scanner):
-            if not self.has_current_scanjob(
-                scanner.identifier,
-                datetime.now(pytz.utc)
-            ):
-                yield scanner
-
     def get_current_scanjob(self, scanner_id, timepoint):
         for job in self.find(ScanJob, scanner_id=scanner_id):
             if job.is_active(timepoint):

--- a/scanomatic/io/scanning_store.py
+++ b/scanomatic/io/scanning_store.py
@@ -45,17 +45,18 @@ class ScanningStore:
             raise TypeError('No store for object type {}'.format(klass))
 
     def add(self, item):
-        store = self._get_store(type(item))
+        klass = type(item)
+        store = self._get_store(klass)
         if item.identifier in store:
-            raise DuplicateIdError(type(item), item.identifier)
-        if type(item) is Scanner and self.exists(Scanner, name=item.name):
+            raise DuplicateIdError(klass, item.identifier)
+        if klass is Scanner and self.exists(Scanner, name=item.name):
             raise DuplicateNameError(
                 "Cannot add duplicate scanner with name '{}'".format(
                     item.name)
             )
-        if type(item) is Scan and not self.exists(ScanJob, item.scanjob_id):
+        if klass is Scan and not self.exists(ScanJob, item.scanjob_id):
             raise UnknownIdError(ScanJob, item.scanjob_id)
-        self._get_store(type(item))[item.identifier] = item
+        store[item.identifier] = item
 
     def get(self, klass, id_):
         try:
@@ -74,7 +75,7 @@ class ScanningStore:
 
     def exists(self, klass, identifier=None, **constraints):
         if identifier is not None:
-            return identifier in self._get_store(klass)
+            constraints['identifier'] = identifier
         for item in self.find(klass, **constraints):
             return True
         return False

--- a/scanomatic/models/scan.py
+++ b/scanomatic/models/scan.py
@@ -1,5 +1,11 @@
 from collections import namedtuple
 
-Scan = namedtuple('Scan', [
+ScanBase = namedtuple('ScanBase', [
     'id', 'scanjob_id', 'start_time', 'end_time', 'digest',
 ])
+
+
+class Scan(ScanBase):
+    @property
+    def identifier(self):
+        return self.id

--- a/scanomatic/scanning/update_scanner_status.py
+++ b/scanomatic/scanning/update_scanner_status.py
@@ -62,7 +62,7 @@ def update_scanner_status(
     images_to_send,
     devices,
 ):
-    if not db.has_scanner(scanner_id):
+    if not db.exists(Scanner, scanner_id):
         _add_scanner(db, scanner_id)
         new_scanner = True
     else:
@@ -90,7 +90,7 @@ def update_scanner_status(
 def _add_scanner(db, scanner_id):
     try:
         name = get_generic_name()
-        db.add_scanner(Scanner(name, scanner_id))
+        db.add(Scanner(name, scanner_id))
     except DuplicateNameError:
         UpdateScannerStatusError(
             "Failed to create scanner, please try again",

--- a/scanomatic/ui_server/scanners_api.py
+++ b/scanomatic/ui_server/scanners_api.py
@@ -12,6 +12,7 @@ from .serialization import job2json, scanner_status2json, scanner2json
 from scanomatic.scanning.update_scanner_status import (
     update_scanner_status, UpdateScannerStatusError,
 )
+from scanomatic.models.scanner import Scanner
 
 blueprint = Blueprint("scanners_api", __name__)
 SCANNER_TIMEOUT = timedelta(minutes=5)
@@ -35,7 +36,7 @@ def scanners_get():
     scanning_store = current_app.config['scanning_store']
     scanners = (
         scanning_store.get_free_scanners() if get_free else
-        scanning_store.get_all_scanners()
+        scanning_store.find(Scanner)
     )
     return jsonify([
         scanner2json(
@@ -49,9 +50,9 @@ def scanners_get():
 def scanner_get(scanner):
     scanning_store = current_app.config['scanning_store']
 
-    if scanning_store.has_scanner(scanner):
+    if scanning_store.exists(Scanner, scanner):
         return jsonify(scanner2json(
-            scanning_store.get_scanner(scanner),
+            scanning_store.get(Scanner, scanner),
             _scanner_is_online(scanner, scanning_store)
         ))
 
@@ -100,7 +101,7 @@ def scanner_status_update(scanner):
 def scanner_status_get(scanner):
     scanning_store = current_app.config['scanning_store']
 
-    if scanning_store.has_scanner(scanner):
+    if scanning_store.exists(Scanner, scanner):
         status = scanning_store.get_latest_scanner_status(scanner)
 
         if status is None:
@@ -115,7 +116,7 @@ def scanner_status_get(scanner):
 class ScannerJob(Resource):
     def get(self, scannerid):
         db = current_app.config['scanning_store']
-        if not db.has_scanner(scannerid):
+        if not db.exists(Scanner, scannerid):
             raise NotFound
         job = db.get_current_scanjob(scannerid, datetime.now(pytz.utc))
         if job:

--- a/scanomatic/ui_server/scanners_api.py
+++ b/scanomatic/ui_server/scanners_api.py
@@ -32,12 +32,8 @@ def _scanner_is_online(scanner_id, scanning_store):
 
 @blueprint.route("", methods=['GET'])
 def scanners_get():
-    get_free = request.args.get('free', False)
     scanning_store = current_app.config['scanning_store']
-    scanners = (
-        scanning_store.get_free_scanners() if get_free else
-        scanning_store.find(Scanner)
-    )
+    scanners = scanning_store.find(Scanner)
     return jsonify([
         scanner2json(
             scanner,

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -20,10 +20,10 @@ def app(tmpdir):
     app.register_blueprint(scan_jobs_api.blueprint, url_prefix="/scan-jobs")
     app.register_blueprint(scans_api.blueprint, url_prefix="/scans")
     app.config['scanning_store'] = ScanningStore()
-    app.config['scanning_store'].add_scanner(
+    app.config['scanning_store'].add(
         Scanner('Scanner one', '9a8486a6f9cb11e7ac660050b68338ac')
     )
-    app.config['scanning_store'].add_scanner(
+    app.config['scanning_store'].add(
         Scanner('Scanner two', '350986224086888954')
     )
     app.config['imagestore'] = ImageStore(str(tmpdir))

--- a/tests/integration/api/test_scanners.py
+++ b/tests/integration/api/test_scanners.py
@@ -55,15 +55,6 @@ class TestScannerStatus:
             for scanner in [self.SCANNER_TWO, self.SCANNER_ONE]
         )
 
-    def test_get_free_scanners(self, client):
-        response = client.get(self.URI + '?free=1')
-        assert response.status_code == HTTPStatus.OK
-        assert len(response.json) == 2
-        assert all(
-            scanner in response.json
-            for scanner in [self.SCANNER_TWO, self.SCANNER_ONE]
-        )
-
     def test_get_scanner(self, client):
         response = client.get(self.URI + "/9a8486a6f9cb11e7ac660050b68338ac")
         assert response.status_code == HTTPStatus.OK

--- a/tests/unit/io/test_scanning_store.py
+++ b/tests/unit/io/test_scanning_store.py
@@ -77,8 +77,9 @@ class TestScanners:
             scanning_store.add(scanner)
 
     def test_get_scanner(self, scanning_store):
-        assert scanning_store.get(
-            Scanner, '9a8486a6f9cb11e7ac660050b68338ac') == SCANNER_ONE
+        assert (
+            scanning_store.get(Scanner, SCANNER_ONE.identifier) == SCANNER_ONE
+        )
 
     def test_no_get_scanner_by_unknown_id(self, scanning_store):
         with pytest.raises(UnknownIdError):

--- a/tests/unit/io/test_scanning_store.py
+++ b/tests/unit/io/test_scanning_store.py
@@ -61,16 +61,6 @@ class TestScanners:
     def test_getting_scanner(self, scanning_store, scanner):
         assert scanning_store.get(Scanner, scanner.identifier) == scanner
 
-    def test_get_free(self, scanning_store):
-        assert set(scanning_store.get_free_scanners()) == {
-            SCANNER_ONE, SCANNER_TWO,
-        }
-
-    def test_get_all(self, scanning_store):
-        assert set(scanning_store.find(Scanner)) == {
-            SCANNER_ONE, SCANNER_TWO,
-        }
-
     def test_add_scanner(self, scanning_store):
         scanner = Scanner("Deep Thought", "42")
         scanning_store.add(scanner)


### PR DESCRIPTION
Remove duplication and simplify ScanningStore:
- `add_x(somex)` ➡ `add(somex)`
- `get_x(id)` ➡ `get(X, id)`
- `get_all_x()` ➡ `find(X)`
- `update_x(somex)` ➡ `update(somex)`
- `has_x(...)` ➡ `exists(X, ...)`
- etc.

Remove `get_free_scanners` and corresponding API parameter.

Methods for more specific queries/updates still exists (e.g. `get_current_job`).