### PR TITLE
Split travis build in two stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,58 @@
-language: python
-python:
-    - "2.7"
+language: generic
+sudo: required # Needed for chrome: https://github.com/travis-ci/travis-ci/issues/8836
+dist: trusty
 
-services:
-  - docker
-
-addons:
-  apt:
-    packages:
-      - docker-ce
-      - postgresql
-      - python-numpy
-      - python-scipy
-      - python-matplotlib
-  chrome: stable
-  firefox: latest
-
-before_install:
-    - pip install tox coveralls codecov
-    - gem install coveralls-lcov
-    - wget -N http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip -P ~/
-    - unzip ~/chromedriver_linux64.zip -d ~/
-    - rm ~/chromedriver_linux64.zip
-    - sudo mv -f ~/chromedriver /usr/local/share/
-    - sudo chmod +x /usr/local/share/chromedriver
-    - sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
-    - wget -O- 'https://github.com/mozilla/geckodriver/releases/download/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz' | sudo tar -C /usr/local/bin -xz
-    - npm install
-before_script:
-    - export DISPLAY=':99.0'
-    - sh -e /etc/init.d/xvfb start
-    - sleep 3
-script:
-    - npm test
-    - docker-compose --verbose build --no-cache --force-rm
-    - tox
-after_success:
-    - codecov
-    - coveralls-lcov -v -n scanomatic/ui_server_data/coverage/report-lcov/lcov.info > js-coverage.json
-    - coveralls --merge=js-coverage.json
-    - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] ; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; docker-compose push; fi
-    - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] ; then curl "https://jenkins.molflow.com/buildByToken/buildWithParameters?job=INFRA&token=${JENKINS_TOKEN}"; fi
+jobs:
+  include:
+    - node_js: "6"
+      addons:
+        chrome: stable
+      before_install:
+        - npm install
+        - npm install codecov
+      script:
+        - xvfb-run npm test
+      after_success:
+        - ./node_modules/.bin/codecov
+    - python: "2.7"
+      addons:
+        apt:
+          packages:
+            - postgresql
+            - python-numpy
+            - python-scipy
+            - python-matplotlib
+      before_install:
+         - sudo pip install tox codecov
+      script:
+         - tox -e py27
+      after_success:
+         - codecov
+    - stage: "Docker build & system tests"
+      python: "2.7"
+      services: ["docker"]
+      addons:
+        apt:
+          packages:
+            - docker-ce
+        chrome: stable
+        firefox: latest
+      before_install:
+        - sudo pip install tox
+        - wget -N http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip -P ~/
+        - unzip ~/chromedriver_linux64.zip -d ~/
+        - rm ~/chromedriver_linux64.zip
+        - sudo mv -f ~/chromedriver /usr/local/share/
+        - sudo chmod +x /usr/local/share/chromedriver
+        - sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
+        - wget -O- 'https://github.com/mozilla/geckodriver/releases/download/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz' | sudo tar -C /usr/local/bin -xz
+      before_script:
+        - export DISPLAY=':99.0'
+        - sh -e /etc/init.d/xvfb start
+        - sleep 3
+      script:
+        - docker-compose build
+        - tox -e system-tests
+      after_success:
+        - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] ; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; docker-compose push; fi
+        - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] ; then curl "https://jenkins.molflow.com/buildByToken/buildWithParameters?job=INFRA&token=${JENKINS_TOKEN}"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ jobs:
             - python-scipy
             - python-matplotlib
       before_install:
-         - sudo pip install tox codecov
+        - sudo pip install tox codecov
       script:
-         - tox -e py27
+        - tox -e py27
       after_success:
-         - codecov
+        - codecov
     - stage: "Docker build & system tests"
       python: "2.7"
       services: ["docker"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py27, system-tests
 skipsdist = true
 
 [testenv]
@@ -10,12 +10,22 @@ deps =
     mock
     pytest
     pytest-cov
-    pytest-docker
     pytest-flask
     pytest-postgresql
-    selenium
 setenv =
     SCANOMATIC_DATA = {toxinidir}/data/
+commands =
+    pytest \
+        --cov scanomatic --cov scripts --cov-report xml --cov-branch \
+        tests/unit tests/integration {posargs}
+
+[testenv:system-tests]
+deps =
+    pytest
+    pytest-docker
+    requests
+    selenium
+setenv =
     PATH=$PATH:/usr/lib/chromium-browser/
     LD_LIBRARY_PATH=/usr/lib/chromium-browser
 whitelist_externals =
@@ -23,7 +33,4 @@ whitelist_externals =
 passenv =
     DISPLAY
 commands =
-    pytest \
-        --cov scanomatic --cov scripts --cov-report xml --cov-branch \
-        --junitxml result.xml --ignore dev \
-        {posargs}
+    pytest tests/system {posargs}


### PR DESCRIPTION
This uses a beta feature on travis that allows splitting a build in
successive stages. (https://docs.travis-ci.com/user/build-stages/)

The build is split in two stages: first the (white box) tests, then
docker build and system tests.

Moreover, the tests are divided in two jobs: one running the python
tests and one running the javascript tests.

Given the overhead of setting up jobs on travis, dividing the build
doesn't really give us any speed boost but it makes it much nicer to
look at the result and allow restarting a single job.

On the other hand, the last thing I did was to remove the extra option
to `docker-compose build` and in the last two builds it went twice as
fast.  That's not a lot of data points but it'd be cool if it were to be
true :pray:

Some other relevant changes:
- this disables coveralls, since it isn't capable of merging coverage
  reports from the different jobs (js and python tests).
- to make tox a bit faster I put the system tests in a separate test
  environment in tox.  That reduces the number of unnecessary
  dependencies that are going to be installed.  I'm not sure it's a huge
  gain but it also makes it easier to run only unit/integration tests
  locally (that's `tox -e py27`, simply running `tox` will still run
  everything)