### PR TITLE
Make better use of the docker cache when building the ui

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM node:4 as npmbuilder
-COPY scanomatic/ui_server_data /src/scanomatic/ui_server_data
+RUN mkdir /src
+WORKDIR /src
+
 COPY package.json /src
+RUN npm install
+
+COPY scanomatic/ui_server_data /src/scanomatic/ui_server_data
 COPY webpack.config.js /src
 COPY .babelrc /src
-WORKDIR /src
-RUN npm install
 RUN npm run build
+
+
 
 FROM ubuntu:16.04
 RUN apt update && apt -y install python-pip
@@ -28,4 +33,3 @@ RUN chmod +x /entrypoint.sh
 ENV PGPASSFILE=/etc/scanomatic/pgpass
 ENTRYPOINT ["/entrypoint.sh"]
 CMD scan-o-matic --no-browser
-


### PR DESCRIPTION
installing package is expensive: make sure we only do it when necessary.