### PR TITLE
Remove `__CCC` global

### DIFF
--- a/scanomatic/data_processing/calibration.py
+++ b/scanomatic/data_processing/calibration.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from collections import namedtuple
 from enum import Enum
 from itertools import izip

--- a/scanomatic/data_processing/calibration.py
+++ b/scanomatic/data_processing/calibration.py
@@ -1,28 +1,27 @@
-import numpy as np
+from collections import namedtuple
 from enum import Enum
 from itertools import izip
-from scipy.optimize import leastsq
-from scipy.stats import linregress
 import re
 from uuid import uuid1
-from collections import namedtuple
 
+import numpy as np
+from scipy.optimize import leastsq
+from scipy.stats import linregress
 
 from scanomatic.generics.maths import mid50_mean
+from scanomatic.image_analysis.first_pass_image import FixtureImage
+from scanomatic.image_analysis.image_basics import (
+    Image_Transpose, load_image_to_numpy
+)
+from scanomatic.io.ccc_data import (
+    CalibrationEntryStatus, CCCImage, CCCMeasurement, CCCPlate, CCCPolynomial,
+    CellCountCalibration, get_empty_ccc_entry, get_empty_image_entry,
+    get_polynomal_entry, load_cccs, save_ccc, validate_polynomial_format
+)
+from scanomatic.io.fixtures import Fixtures
 from scanomatic.io.logger import Logger
 from scanomatic.io.paths import Paths
-from scanomatic.io.fixtures import Fixtures
-from scanomatic.image_analysis.image_basics import (
-    load_image_to_numpy, Image_Transpose)
-from scanomatic.image_analysis.first_pass_image import FixtureImage
-from scanomatic.io.ccc_data import (
-    CCCImage, CCCPlate, CCCPolynomial, CCCMeasurement, CellCountCalibration,
-    CalibrationEntryStatus, get_empty_ccc_entry, load_cccs,
-    get_polynomal_entry, get_empty_image_entry, save_ccc,
-    validate_polynomial_format,
-)
 
-__CCC = {}
 _logger = Logger("CCC")
 
 CalibrationData = namedtuple(
@@ -52,11 +51,11 @@ class CalibrationValidation(Enum):
     BadData = 4
 
 
-def _ccc_edit_validator(identifier, **kwargs):
+def _ccc_edit_validator(store, identifier, **kwargs):
 
-    if identifier in __CCC:
+    if identifier in store:
 
-        ccc = __CCC[identifier]
+        ccc = store[identifier]
 
         if ("access_token" in kwargs and
                 ccc[CellCountCalibration.edit_access_token] ==
@@ -92,40 +91,40 @@ def _ccc_edit_validator(identifier, **kwargs):
 
 def _validate_ccc_edit_request(f):
 
-    def wrapped(identifier, *args, **kwargs):
+    def wrapped(store, identifier, *args, **kwargs):
 
-        if _ccc_edit_validator(identifier, **kwargs):
+        if _ccc_edit_validator(store, identifier, **kwargs):
             del kwargs["access_token"]
-            return f(identifier, *args, **kwargs)
+            return f(store, identifier, *args, **kwargs)
 
     return wrapped
 
 
 @_validate_ccc_edit_request
-def is_valid_edit_request(identifier):
+def is_valid_edit_request(store, identifier):
     return True
 
 
-def get_empty_ccc(species, reference):
-    ccc_id = _get_ccc_identifier(species, reference)
+def get_empty_ccc(store, species, reference):
+    ccc_id = _get_ccc_identifier(store, species, reference)
     if ccc_id is None:
         return None
     return get_empty_ccc_entry(ccc_id, species, reference)
 
 
-def _get_ccc_identifier(species, reference):
+def _get_ccc_identifier(store, species, reference):
 
     if not species or not reference:
         return None
 
-    if any(True for ccc in __CCC.itervalues() if
+    if any(True for ccc in store.itervalues() if
            ccc[CellCountCalibration.species] == species and
            ccc[CellCountCalibration.reference] == reference):
         return None
 
     candidate = re.sub(r'[^A-Z]', r'', species.upper())[:6]
 
-    while any(True for ccc in __CCC.itervalues()
+    while any(True for ccc in store.itervalues()
               if ccc[CellCountCalibration.identifier] == candidate):
 
         candidate += "qwxz"[np.random.randint(0, 4)]
@@ -133,9 +132,10 @@ def _get_ccc_identifier(species, reference):
     return candidate
 
 
-def _insert_default_ccc():
+def _insert_default_ccc(store):
 
     ccc = get_empty_ccc(
+        store,
         species='S. cerevisiae',
         reference='Zackrisson et. al. 2016',
     )
@@ -148,59 +148,41 @@ def _insert_default_ccc():
     ccc[CellCountCalibration.edit_access_token] = None
     ccc[CellCountCalibration.status] = CalibrationEntryStatus.Active
 
-    __CCC[ccc[CellCountCalibration.identifier]] = ccc
+    store[ccc[CellCountCalibration.identifier]] = ccc
 
 
-def reload_cccs():
-
-    __CCC.clear()
-    _insert_default_ccc()
-
-    for ccc in load_cccs():
-        if ccc[CellCountCalibration.identifier] in __CCC:
-
-            _logger.error(
-                "Duplicated identifier {0} is not allowed!".format(
-                    ccc[CellCountCalibration.identifier])
-            )
-
-        else:
-
-            __CCC[ccc[CellCountCalibration.identifier]] = ccc
-
-
-def get_active_cccs():
+def get_active_cccs(store):
 
     return {
-        identifier: ccc for identifier, ccc in __CCC.iteritems()
+        identifier: ccc for identifier, ccc in store.iteritems()
         if ccc[CellCountCalibration.status] == CalibrationEntryStatus.Active}
 
 
-def get_polynomial_coefficients_from_ccc(identifier):
+def get_polynomial_coefficients_from_ccc(store, identifier):
 
-    ccc = __CCC[identifier]
+    ccc = store[identifier]
     if ccc[CellCountCalibration.status] != CalibrationEntryStatus.Active:
         raise KeyError
 
     return ccc[CellCountCalibration.polynomial][CCCPolynomial.coefficients]
 
 
-def get_under_construction_cccs():
+def get_under_construction_cccs(store):
 
     return {
-        identifier: ccc for identifier, ccc in __CCC.iteritems()
+        identifier: ccc for identifier, ccc in store.iteritems()
         if ccc[CellCountCalibration.status] ==
         CalibrationEntryStatus.UnderConstruction}
 
 
-def add_ccc(ccc):
+def add_ccc(store, ccc):
 
     if (ccc[CellCountCalibration.identifier] and
-            ccc[CellCountCalibration.identifier] not in __CCC):
+            ccc[CellCountCalibration.identifier] not in store):
 
-        __CCC[ccc[CellCountCalibration.identifier]] = ccc
+        store[ccc[CellCountCalibration.identifier]] = ccc
 
-        save_ccc_to_disk(ccc)
+        save_ccc_to_disk(store, ccc)
         return True
 
     else:
@@ -225,9 +207,9 @@ def has_valid_polynomial(ccc):
 
 
 @_validate_ccc_edit_request
-def activate_ccc(identifier):
+def activate_ccc(store, identifier):
 
-    ccc = __CCC[identifier]
+    ccc = store[identifier]
     try:
         has_valid_polynomial(ccc)
     except ActivationError:
@@ -236,53 +218,53 @@ def activate_ccc(identifier):
     ccc[CellCountCalibration.status] = CalibrationEntryStatus.Active
     ccc[CellCountCalibration.edit_access_token] = uuid1().hex
 
-    return save_ccc_to_disk(ccc)
+    return save_ccc_to_disk(store, ccc)
 
 
 @_validate_ccc_edit_request
-def delete_ccc(identifier):
+def delete_ccc(store, identifier):
 
-    ccc = __CCC[identifier]
+    ccc = store[identifier]
 
     ccc[CellCountCalibration.status] = CalibrationEntryStatus.Deleted
     ccc[CellCountCalibration.edit_access_token] = uuid1().hex
 
-    return save_ccc_to_disk(ccc)
+    return save_ccc_to_disk(store, ccc)
 
 
-def save_ccc_to_disk(ccc):
+def save_ccc_to_disk(store, ccc):
 
-    if ccc[CellCountCalibration.identifier] in __CCC:
+    if ccc[CellCountCalibration.identifier] in store:
 
         return save_ccc(ccc)
 
     else:
 
         _logger.error("Unknown CCC identifier {0} ({1})".format(
-            ccc[CellCountCalibration.identifier], __CCC.keys()))
+            ccc[CellCountCalibration.identifier], store.keys()))
         return False
 
 
 @_validate_ccc_edit_request
-def add_image_to_ccc(identifier, image):
+def add_image_to_ccc(store, identifier, image):
 
-    ccc = __CCC[identifier]
+    ccc = store[identifier]
     im_json = get_empty_image_entry(ccc)
     im_identifier = im_json[CCCImage.identifier]
     image.save(Paths().ccc_image_pattern.format(identifier, im_identifier))
 
     ccc[CellCountCalibration.images].append(im_json)
-    if not save_ccc_to_disk(ccc):
+    if not save_ccc_to_disk(store, ccc):
         return False
 
     return im_identifier
 
 
-def get_image_identifiers_in_ccc(identifier):
+def get_image_identifiers_in_ccc(store, identifier):
 
-    if identifier in __CCC:
+    if identifier in store:
 
-        ccc = __CCC[identifier]
+        ccc = store[identifier]
 
         return [
             im_json[CCCImage.identifier] for im_json in
@@ -293,10 +275,9 @@ def get_image_identifiers_in_ccc(identifier):
 
 
 @_validate_ccc_edit_request
-def set_image_info(identifier, image_identifier, **kwargs):
-
-    ccc = __CCC[identifier]
-    im_json = get_image_json_from_ccc(identifier, image_identifier)
+def set_image_info(store, identifier, image_identifier, **kwargs):
+    ccc = store[identifier]
+    im_json = get_image_json_from_ccc(store, identifier, image_identifier)
 
     for key in kwargs:
 
@@ -309,16 +290,16 @@ def set_image_info(identifier, image_identifier, **kwargs):
             _logger.error("{0} is not a known property of images".format(key))
             return False
 
-    return save_ccc_to_disk(ccc)
+    return save_ccc_to_disk(store, ccc)
 
 
 @_validate_ccc_edit_request
 def set_plate_grid_info(
-        identifier, image_identifier, plate,
+        store, identifier, image_identifier, plate,
         grid_shape=None, grid_cell_size=None, **kwargs):
 
-    ccc = __CCC[identifier]
-    im_json = get_image_json_from_ccc(identifier, image_identifier)
+    ccc = store[identifier]
+    im_json = get_image_json_from_ccc(store, identifier, image_identifier)
     if plate in im_json[CCCImage.plates]:
         plate_json = im_json[CCCImage.plates][plate]
         if plate_json[CCCPlate.compressed_ccc_data]:
@@ -334,14 +315,14 @@ def set_plate_grid_info(
     plate_json[CCCPlate.grid_cell_size] = grid_cell_size
     plate_json[CCCPlate.grid_shape] = grid_shape
 
-    return save_ccc_to_disk(ccc)
+    return save_ccc_to_disk(store, ccc)
 
 
-def get_image_json_from_ccc(identifier, image_identifier):
+def get_image_json_from_ccc(store, identifier, image_identifier):
 
-    if identifier in __CCC:
+    if identifier in store:
 
-        ccc = __CCC[identifier]
+        ccc = store[identifier]
 
         for im_json in ccc[CellCountCalibration.images]:
 
@@ -351,9 +332,9 @@ def get_image_json_from_ccc(identifier, image_identifier):
     return None
 
 
-def get_local_fixture_for_image(identifier, image_identifier):
+def get_local_fixture_for_image(store, identifier, image_identifier):
 
-    im_json = get_image_json_from_ccc(identifier, image_identifier)
+    im_json = get_image_json_from_ccc(store, identifier, image_identifier)
     if im_json is None:
         return None
 
@@ -379,7 +360,8 @@ def get_local_fixture_for_image(identifier, image_identifier):
 
 @_validate_ccc_edit_request
 def save_image_slices(
-        identifier, image_identifier, grayscale_slice=None, plate_slices=None):
+        store, identifier, image_identifier, grayscale_slice=None,
+        plate_slices=None):
 
     im = load_image_to_numpy(
         Paths().ccc_image_pattern.format(identifier, image_identifier),
@@ -453,9 +435,9 @@ def get_plate_slice(
 
 
 @_validate_ccc_edit_request
-def transform_plate_slice(identifier, image_identifier, plate_id):
+def transform_plate_slice(store, identifier, image_identifier, plate_id):
 
-    im_json = get_image_json_from_ccc(identifier, image_identifier)
+    im_json = get_image_json_from_ccc(store, identifier, image_identifier)
     if not im_json:
         _logger.error(
             "CCC {0} Image {1} has not been setup, you must first add the image before working on it.".format(
@@ -502,10 +484,10 @@ def transform_plate_slice(identifier, image_identifier, plate_id):
 
 @_validate_ccc_edit_request
 def set_colony_compressed_data(
-        identifier, image_identifier, plate_id, x, y, cell_count,
+        store, identifier, image_identifier, plate_id, x, y, cell_count,
         image, blob_filter, background_filter):
 
-    ccc = __CCC[identifier]
+    ccc = store[identifier]
     background = mid50_mean(image[background_filter].ravel())
     if np.isnan(background):
         _logger.error(
@@ -523,7 +505,7 @@ def set_colony_compressed_data(
             "Counting mismatch between compressed format and blob filter")
         return False
 
-    image_data = get_image_json_from_ccc(identifier, image_identifier)
+    image_data = get_image_json_from_ccc(store, identifier, image_identifier)
     plate = image_data[CCCImage.plates][plate_id]
 
     plate[CCCPlate.compressed_ccc_data][(x, y)] = {
@@ -532,7 +514,7 @@ def set_colony_compressed_data(
         CCCMeasurement.cell_count: cell_count,
     }
 
-    return save_ccc_to_disk(ccc)
+    return save_ccc_to_disk(store, ccc)
 
 
 def calculate_sizes(data, poly):
@@ -668,9 +650,9 @@ def calculate_polynomial(data_store, degree=5):
 
 
 @_validate_ccc_edit_request
-def construct_polynomial(identifier, power):
+def construct_polynomial(store, identifier, power):
 
-    ccc = __CCC[identifier]
+    ccc = store[identifier]
     data_store = _collect_all_included_data(ccc)
     try:
         poly_coeffs = calculate_polynomial(data_store, power).tolist()
@@ -691,7 +673,7 @@ def construct_polynomial(identifier, power):
             power, poly_coeffs,
         )
 
-        if not save_ccc_to_disk(ccc):
+        if not save_ccc_to_disk(store, ccc):
             return False
 
     return {
@@ -708,8 +690,8 @@ def construct_polynomial(identifier, power):
     }
 
 
-def get_all_colony_data(identifier):
-    ccc = __CCC[identifier]
+def get_all_colony_data(store, identifier):
+    ccc = store[identifier]
     data_store = _collect_all_included_data(ccc)
     if data_store.source_values:
         min_values = min(min(vector) for vector in data_store.source_values)
@@ -733,5 +715,37 @@ def get_all_colony_data(identifier):
     }
 
 
-if not __CCC:
-    reload_cccs()
+class CalibrationStore(object):
+    def __init__(self):
+        self._CCC = {}
+        self._reload_cccs()
+
+    def _reload_cccs(self):
+        self._CCC.clear()
+        _insert_default_ccc(self._CCC)
+        for ccc in load_cccs():
+            if ccc[CellCountCalibration.identifier] in self._CCC:
+                _logger.error(
+                    "Duplicated identifier {0} is not allowed!".format(
+                        ccc[CellCountCalibration.identifier])
+                )
+            else:
+                self._CCC[ccc[CellCountCalibration.identifier]] = ccc
+
+    def keys(self):
+        return self._CCC.keys()
+
+    def itervalues(self):
+        return self._CCC.itervalues()
+
+    def __iter__(self):
+        return iter(self._CCC)
+
+    def __getitem__(self, key):
+        return self._CCC[key]
+
+    def __setitem__(self, key, value):
+        self._CCC[key] = value
+
+    def iteritems(self):
+        return self._CCC.iteritems()

--- a/scanomatic/io/ccc_data.py
+++ b/scanomatic/io/ccc_data.py
@@ -67,6 +67,8 @@ Data structure for CCC-jsons
 }
 
 """
+from __future__ import absolute_import
+
 from enum import Enum
 from glob import iglob
 import json

--- a/scanomatic/io/ccc_data.py
+++ b/scanomatic/io/ccc_data.py
@@ -67,13 +67,13 @@ Data structure for CCC-jsons
 }
 
 """
-from types import StringTypes
 from enum import Enum
-from uuid import uuid1
+from glob import iglob
+import json
 import os
 import re
-import json
-from glob import iglob
+from types import StringTypes
+from uuid import uuid1
 
 from scanomatic.io.logger import Logger
 from scanomatic.io.paths import Paths

--- a/scanomatic/models/factories/analysis_factories.py
+++ b/scanomatic/models/factories/analysis_factories.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 from types import DictType, ListType, StringTypes
 

--- a/scanomatic/models/factories/analysis_factories.py
+++ b/scanomatic/models/factories/analysis_factories.py
@@ -1,10 +1,13 @@
 import os
-from types import StringTypes, ListType, DictType
-from scanomatic.generics.abstract_model_factory import (
-    AbstractModelFactory, rename_setting, email_serializer)
-import scanomatic.models.analysis_model as analysis_model
+from types import DictType, ListType, StringTypes
+
 from scanomatic.data_processing.calibration import (
-    get_polynomial_coefficients_from_ccc, get_active_cccs)
+    CalibrationStore, get_active_cccs, get_polynomial_coefficients_from_ccc
+)
+from scanomatic.generics.abstract_model_factory import (
+    AbstractModelFactory, email_serializer, rename_setting
+)
+import scanomatic.models.analysis_model as analysis_model
 
 
 class GridModelFactory(AbstractModelFactory):
@@ -110,6 +113,7 @@ class AnalysisModelFactory(AbstractModelFactory):
 
             settings['cell_count_calibration'] = \
                 get_polynomial_coefficients_from_ccc(
+                    CalibrationStore(),
                     settings['cell_count_calibration_id'])
 
         return super(cls, AnalysisModelFactory).create(**settings)
@@ -291,7 +295,8 @@ class AnalysisModelFactory(AbstractModelFactory):
 
         :type model: scanomatic.models.scanning_model.AnalysisModel
         """
-        if model.cell_count_calibration_id in get_active_cccs():
+        active_cccs = get_active_cccs(CalibrationStore())
+        if model.cell_count_calibration_id in active_cccs:
             return True
         return model.FIELD_TYPES.cell_count_calibration_id
 

--- a/scanomatic/models/factories/compile_project_factory.py
+++ b/scanomatic/models/factories/compile_project_factory.py
@@ -8,7 +8,9 @@ from scanomatic.models import fixture_models
 from scanomatic.models.factories import fixture_factories
 from scanomatic.io.paths import Paths
 from scanomatic.io.fixtures import Fixtures
-from scanomatic.data_processing.calibration import get_active_cccs
+from scanomatic.data_processing.calibration import (
+    CalibrationStore, get_active_cccs
+)
 
 
 class CompileImageFactory(AbstractModelFactory):
@@ -199,7 +201,9 @@ class CompileProjectFactory(AbstractModelFactory):
 
         :type model: scanomatic.models.scanning_model.ScanningModel
         """
-        if model.cell_count_calibration_id in get_active_cccs():
+        if model.cell_count_calibration_id in get_active_cccs(
+            CalibrationStore()
+        ):
             return True
         return model.FIELD_TYPES.cell_count_calibration
 

--- a/scanomatic/models/factories/scanning_factory.py
+++ b/scanomatic/models/factories/scanning_factory.py
@@ -3,15 +3,19 @@ import re
 import string
 from types import StringTypes
 
+from scanomatic.data_processing.calibration import (
+    CalibrationStore, get_active_cccs
+)
 from scanomatic.generics.abstract_model_factory import (
-    AbstractModelFactory, email_serializer)
-from scanomatic.models.scanning_model import (
-    ScanningModel, ScannerModel, ScanningAuxInfoModel, PlateDescription,
-    CULTURE_SOURCE, PLATE_STORAGE, ScannerOwnerModel)
-import scanomatic.io.fixtures as fixtures
+    AbstractModelFactory, email_serializer
+)
 import scanomatic.io.app_config as app_config
+import scanomatic.io.fixtures as fixtures
 from scanomatic.models.rpc_job_models import RPCjobModel
-from scanomatic.data_processing.calibration import get_active_cccs
+from scanomatic.models.scanning_model import (
+    CULTURE_SOURCE, PLATE_STORAGE, PlateDescription, ScannerModel,
+    ScannerOwnerModel, ScanningAuxInfoModel, ScanningModel
+)
 
 
 class PlateDescriptionFactory(AbstractModelFactory):
@@ -420,7 +424,7 @@ class ScanningModelFactory(AbstractModelFactory):
 
         :type model: scanomatic.models.scanning_model.ScanningModel
         """
-        if model.cell_count_calibration_id in get_active_cccs():
+        if model.cell_count_calibration_id in get_active_cccs(CalibrationStore()):
             return True
         return model.FIELD_TYPES.cell_count_calibration
 

--- a/scanomatic/models/factories/scanning_factory.py
+++ b/scanomatic/models/factories/scanning_factory.py
@@ -424,7 +424,8 @@ class ScanningModelFactory(AbstractModelFactory):
 
         :type model: scanomatic.models.scanning_model.ScanningModel
         """
-        if model.cell_count_calibration_id in get_active_cccs(CalibrationStore()):
+        cccs = get_active_cccs(CalibrationStore())
+        if model.cell_count_calibration_id in cccs:
             return True
         return model.FIELD_TYPES.cell_count_calibration
 

--- a/scanomatic/ui_server/data_api.py
+++ b/scanomatic/ui_server/data_api.py
@@ -9,7 +9,7 @@ from ConfigParser import Error as ConfigError
 
 from scanomatic.data_processing import phenotyper
 from scanomatic.data_processing.calibration import (
-    CalibrationStore, get_polynomial_coefficients_from_ccc)
+    get_polynomial_coefficients_from_ccc)
 
 from scanomatic.io.paths import Paths
 from scanomatic.io.logger import Logger
@@ -49,6 +49,10 @@ from .general import (
 
 
 _logger = Logger("Data API")
+
+
+def getcalibrationstore():
+    return current_app.config['calibrationstore']
 
 
 def _depth(arr, lvl=1):
@@ -804,7 +808,7 @@ def add_routes(app, rpc_client, is_debug_mode):
         gc = GridCell(
             identifier,
             get_polynomial_coefficients_from_ccc(
-                CalibrationStore(), 'default'),
+                getcalibrationstore(), 'default'),
             save_extra_data=False)
 
         gc.source = image.astype(np.float64)
@@ -860,7 +864,7 @@ def add_routes(app, rpc_client, is_debug_mode):
         gc = GridCell(
             identifier,
             get_polynomial_coefficients_from_ccc(
-                CalibrationStore(), 'default'),
+                getcalibrationstore(), 'default'),
             save_extra_data=False)
 
         gc.source = image.astype(np.float64)
@@ -924,7 +928,7 @@ def add_routes(app, rpc_client, is_debug_mode):
         gc.set_new_data_source_space(
             space=VALUES.Cell_Estimates, bg_sub_source=background_filter,
             polynomial_coeffs=get_polynomial_coefficients_from_ccc(
-                CalibrationStore(), 'default')
+                getcalibrationstore(), 'default')
         )
 
         return jsonify(

--- a/scanomatic/ui_server/data_api.py
+++ b/scanomatic/ui_server/data_api.py
@@ -9,7 +9,7 @@ from ConfigParser import Error as ConfigError
 
 from scanomatic.data_processing import phenotyper
 from scanomatic.data_processing.calibration import (
-    get_polynomial_coefficients_from_ccc)
+    CalibrationStore, get_polynomial_coefficients_from_ccc)
 
 from scanomatic.io.paths import Paths
 from scanomatic.io.logger import Logger
@@ -803,7 +803,8 @@ def add_routes(app, rpc_client, is_debug_mode):
 
         gc = GridCell(
             identifier,
-            get_polynomial_coefficients_from_ccc('default'),
+            get_polynomial_coefficients_from_ccc(
+                CalibrationStore(), 'default'),
             save_extra_data=False)
 
         gc.source = image.astype(np.float64)
@@ -858,7 +859,8 @@ def add_routes(app, rpc_client, is_debug_mode):
 
         gc = GridCell(
             identifier,
-            get_polynomial_coefficients_from_ccc('default'),
+            get_polynomial_coefficients_from_ccc(
+                CalibrationStore(), 'default'),
             save_extra_data=False)
 
         gc.source = image.astype(np.float64)
@@ -921,7 +923,9 @@ def add_routes(app, rpc_client, is_debug_mode):
 
         gc.set_new_data_source_space(
             space=VALUES.Cell_Estimates, bg_sub_source=background_filter,
-            polynomial_coeffs=get_polynomial_coefficients_from_ccc('default'))
+            polynomial_coeffs=get_polynomial_coefficients_from_ccc(
+                CalibrationStore(), 'default')
+        )
 
         return jsonify(
             success=True, image=gc.source.tolist(),

--- a/scanomatic/ui_server/ui_server.py
+++ b/scanomatic/ui_server/ui_server.py
@@ -10,6 +10,7 @@ import requests
 from flask import Flask, send_from_directory
 from flask_cors import CORS
 
+from scanomatic.data_processing.calibration import CalibrationStore
 from scanomatic.io.app_config import Config
 from scanomatic.io.logger import Logger
 from scanomatic.io.paths import Paths
@@ -47,6 +48,7 @@ def launch_server(host, port, debug):
     app = Flask("Scan-o-Matic UI", template_folder=Paths().ui_templates)
     prom = Prometheus(app)
     prom.start_server(9999)
+    app.config['calibrationstore'] = CalibrationStore()
     app.config['imagestore'] = ImageStore(Config().paths.projects_root)
     app.config['DATABASE_URL'] = get_database_url()
     database.setup(app)

--- a/tests/unit/data_processing/test_calibration.py
+++ b/tests/unit/data_processing/test_calibration.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from collections import namedtuple
 import json
 import os

--- a/tests/unit/data_processing/test_calibration.py
+++ b/tests/unit/data_processing/test_calibration.py
@@ -509,7 +509,7 @@ class TestGettingActiveCCCs:
         with mock.patch(
             'scanomatic.data_processing.calibration.save_ccc_to_disk',
             return_value=True
-        ) as my_mock:
+        ):
             ccc1 = calibration.get_empty_ccc(store, 'Cylon', 'Boomer')
             self._ccc_id1 = ccc1[calibration.CellCountCalibration.identifier]
             ccc1[calibration.CellCountCalibration.polynomial] = {

--- a/tests/unit/models/factories/test_analysis_factory.py
+++ b/tests/unit/models/factories/test_analysis_factory.py
@@ -1,13 +1,16 @@
 from __future__ import absolute_import
-import pytest
-import mock
-import numpy as np
+
 import os
 
-from scanomatic.models.factories.analysis_factories import AnalysisModelFactory
-from scanomatic.models.analysis_model import AnalysisModel
+import mock
+import numpy as np
+import pytest
+
 from scanomatic.data_processing.calibration import (
-    get_polynomial_coefficients_from_ccc)
+    CalibrationStore, get_polynomial_coefficients_from_ccc
+)
+from scanomatic.models.analysis_model import AnalysisModel
+from scanomatic.models.factories.analysis_factories import AnalysisModelFactory
 
 
 @pytest.fixture(scope='function')
@@ -52,7 +55,8 @@ class TestAnalysisModels:
 
     def test_can_create_using_default_ccc(self, analysis_model):
 
-        default = get_polynomial_coefficients_from_ccc('default')
+        default = get_polynomial_coefficients_from_ccc(
+            CalibrationStore(), 'default')
 
         np.testing.assert_allclose(
             analysis_model.cell_count_calibration, default)


### PR DESCRIPTION
Refactor `scanomatic.data_processing.calibration` to remove the global `__CCC` global.

This doesn't really change the way it works: calibrations are still stored in an in-memory dictionary that is saved to disk explicitly in some of the functions. But instead of being a global dictionary, the calibration store is now encapsulated in a custom class (with dictionary-ish methods), passed to the calibration functions explicitly and referenced from the flask app.

A "store" is also created when needed in the different analysis jobs that used the `calibration` module.  If I understand thing correctly, this has the side benefits that it is no longer necessary to restart the backend when adding a new calibration.