### PR TITLE
Add one more method to CalibrationStore and proper unit tests for the refactored use-cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         firefox: latest
       before_install:
         - sudo pip install tox
-        - wget -N http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip -P ~/
+        - wget -N http://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip -P ~/
         - unzip ~/chromedriver_linux64.zip -d ~/
         - rm ~/chromedriver_linux64.zip
         - sudo mv -f ~/chromedriver /usr/local/share/

--- a/scanomatic/data_processing/calibration.py
+++ b/scanomatic/data_processing/calibration.py
@@ -495,12 +495,12 @@ def validate_polynomial(slope, p_value, stderr):
     return CalibrationValidation.OK
 
 
-def _collect_all_included_data(store, calibrationid):
+def _collect_all_included_data(store, identifier):
     source_values = []
     source_value_counts = []
     target_value = []
 
-    for measurement in store.get_measurements_for_calibration(calibrationid):
+    for measurement in store.get_measurements_for_calibration(identifier):
         source_value_counts.append(measurement[CCCMeasurement.source_value_counts])
         source_values.append(measurement[CCCMeasurement.source_values])
         target_value.append(measurement[CCCMeasurement.cell_count])

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -48,5 +48,6 @@ def browser(request):
     except Exception as e:
         warnings.warn(str(e))
         driver = request.param()
+    driver.set_page_load_timeout(120)
     yield driver
     driver.close()

--- a/tests/unit/data_processing/test_calibration.py
+++ b/tests/unit/data_processing/test_calibration.py
@@ -958,7 +958,7 @@ def make_calibration(
     else:
         ccc[CellCountCalibration.status] = (
             CalibrationEntryStatus.UnderConstruction
-            )
+        )
     return ccc
 
 

--- a/tests/unit/data_processing/test_calibration.py
+++ b/tests/unit/data_processing/test_calibration.py
@@ -941,38 +941,13 @@ class TestGetAllColonyData:
         assert colonies['target_values'][-1] == 42000000.0
 
 
-class TestAddCCC:
-    def test_valid_ccc(self):
-        store = MagicMock(calibration.CalibrationStore)
-        store.has_calibration_with_id.return_value = False
-        ccc = calibration.get_empty_ccc(store, 'Bogus schmogus', 'Dr Lus')
-        assert calibration.add_ccc(store, ccc) is True
-        store.add_calibration.assert_called_with(ccc)
-
-    def test_none_id(self):
-        store = MagicMock(calibration.CalibrationStore)
-        store.has_calibration_with_id.return_value = False
-        ccc = calibration.get_empty_ccc(store, 'Bogus schmogus', 'Dr Lus')
-        ccc[CellCountCalibration.identifier] = None
-        assert calibration.add_ccc(store, ccc) is False
-        store.add_calibration.assert_not_called()
-
-    def test_duplicate_id(self):
-        store = MagicMock(calibration.CalibrationStore)
-        store.has_calibration_with_id.return_value = False
-        ccc = calibration.get_empty_ccc(store, 'Bogus schmogus', 'Dr Lus')
-        store.has_calibration_with_id.return_value = True
-        calibration.add_ccc(store, ccc)
-        assert store.add_calibration.called_with(ccc)
-
-
 def make_calibration(
     identifier='ccc000',
     polynomial=None,
     access_token='password',
     active=False,
 ):
-    ccc = ccc_data.get_empty_ccc_entry(identifier, 'S. Kombuchae', 'xyz 1987')
+    ccc = ccc_data.get_empty_ccc_entry(identifier, 'Bogus schmogus', 'Dr Lus')
     if polynomial is not None:
         ccc[CellCountCalibration.polynomial] = (
             ccc_data.get_polynomal_entry(len(polynomial) - 1, polynomial)
@@ -985,6 +960,29 @@ def make_calibration(
             CalibrationEntryStatus.UnderConstruction
             )
     return ccc
+
+
+class TestAddCCC:
+    def test_valid_ccc(self):
+        store = MagicMock(calibration.CalibrationStore)
+        store.has_calibration_with_id.return_value = False
+        ccc = make_calibration()
+        assert calibration.add_ccc(store, ccc) is True
+        store.add_calibration.assert_called_with(ccc)
+
+    def test_none_id(self):
+        store = MagicMock(calibration.CalibrationStore)
+        store.has_calibration_with_id.return_value = False
+        ccc = make_calibration(identifier=None)
+        assert calibration.add_ccc(store, ccc) is False
+        store.add_calibration.assert_not_called()
+
+    def test_duplicate_id(self):
+        store = MagicMock(calibration.CalibrationStore)
+        store.has_calibration_with_id.return_value = True
+        ccc = make_calibration()
+        calibration.add_ccc(store, ccc)
+        assert store.add_calibration.called_with(ccc)
 
 
 class TestActivateCCC:

--- a/tests/unit/data_processing/test_calibration.py
+++ b/tests/unit/data_processing/test_calibration.py
@@ -981,8 +981,8 @@ class TestAddCCC:
         store = MagicMock(calibration.CalibrationStore)
         store.has_calibration_with_id.return_value = True
         ccc = make_calibration()
-        calibration.add_ccc(store, ccc)
-        assert store.add_calibration.called_with(ccc)
+        assert not calibration.add_ccc(store, ccc)
+        store.add_calibration.assert_not_called()
 
 
 class TestActivateCCC:


### PR DESCRIPTION
- Add a method to `CalibrationStore` to get all the measurements for a CCC.
- Add unit tests to the refactored use cases (`add_ccc`, `activate`ccc`, `delete_ccc` and `construct_polynomial`) that mock the calibration store.