### PR TITLE
Upgrade chromedriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         firefox: latest
       before_install:
         - sudo pip install tox
-        - wget -N http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip -P ~/
+        - wget -N http://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip -P ~/
         - unzip ~/chromedriver_linux64.zip -d ~/
         - rm ~/chromedriver_linux64.zip
         - sudo mv -f ~/chromedriver /usr/local/share/

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -48,6 +48,6 @@ def browser(request):
     except Exception as e:
         warnings.warn(str(e))
         driver = request.param()
-    driver.set_page_load_timeout(60)
+    driver.set_page_load_timeout(120)
     yield driver
     driver.close()

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -48,5 +48,6 @@ def browser(request):
     except Exception as e:
         warnings.warn(str(e))
         driver = request.param()
+    driver.set_page_load_timeout(60)
     yield driver
     driver.close()


### PR DESCRIPTION
Upgrade the version of chromedriver in travis to 2.36.
This seems to solve the current build failure on master and on #314 but there are now selenium timeout errors on *some* runs.  I tried to increase the page load timeout without much success.

I ran the system tests job for 7c83605 ten times and I got five pass and five fails. On the other hand I didn't get a single *travis* timeout. I'm starting to think that this error is a different manifestation of the same thing that made the test suite hang and travis kill the job before. I don't know how to test this hypothesis though, if someone has an idea? (I did look into the release notes for chromedriver but didn't notice anything relevant).