### PR TITLE
Calibrationstore interface extraction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         firefox: latest
       before_install:
         - sudo pip install tox
-        - wget -N http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip -P ~/
+        - wget -N http://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip -P ~/
         - unzip ~/chromedriver_linux64.zip -d ~/
         - rm ~/chromedriver_linux64.zip
         - sudo mv -f ~/chromedriver /usr/local/share/

--- a/scanomatic/io/ccc_data.py
+++ b/scanomatic/io/ccc_data.py
@@ -200,15 +200,10 @@ def validate_polynomial_format(polynomial):
         raise ValueError(err.message)
 
 
-def _get_new_image_identifier(ccc):
-
-    return "CalibIm_{0}".format(len(ccc[CellCountCalibration.images]))
-
-
-def get_empty_image_entry(ccc):
+def get_empty_image_entry(identifier):
 
     return {
-        CCCImage.identifier: _get_new_image_identifier(ccc),
+        CCCImage.identifier: identifier,
         CCCImage.plates: {},
         CCCImage.grayscale_name: None,
         CCCImage.grayscale_source_values: None,

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -48,5 +48,6 @@ def browser(request):
     except Exception as e:
         warnings.warn(str(e))
         driver = request.param()
+    driver.set_page_load_timeout(120)
     yield driver
     driver.close()

--- a/tests/unit/data_processing/test_calibration.py
+++ b/tests/unit/data_processing/test_calibration.py
@@ -958,7 +958,7 @@ def make_calibration(
     else:
         ccc[CellCountCalibration.status] = (
             CalibrationEntryStatus.UnderConstruction
-            )
+        )
     return ccc
 
 

--- a/tests/unit/data_processing/test_calibration.py
+++ b/tests/unit/data_processing/test_calibration.py
@@ -941,38 +941,13 @@ class TestGetAllColonyData:
         assert colonies['target_values'][-1] == 42000000.0
 
 
-class TestAddCCC:
-    def test_valid_ccc(self):
-        store = MagicMock(calibration.CalibrationStore)
-        store.has_calibration_with_id.return_value = False
-        ccc = calibration.get_empty_ccc(store, 'Bogus schmogus', 'Dr Lus')
-        assert calibration.add_ccc(store, ccc) is True
-        store.add_calibration.assert_called_with(ccc)
-
-    def test_none_id(self):
-        store = MagicMock(calibration.CalibrationStore)
-        store.has_calibration_with_id.return_value = False
-        ccc = calibration.get_empty_ccc(store, 'Bogus schmogus', 'Dr Lus')
-        ccc[CellCountCalibration.identifier] = None
-        assert calibration.add_ccc(store, ccc) is False
-        store.add_calibration.assert_not_called()
-
-    def test_duplicate_id(self):
-        store = MagicMock(calibration.CalibrationStore)
-        store.has_calibration_with_id.return_value = False
-        ccc = calibration.get_empty_ccc(store, 'Bogus schmogus', 'Dr Lus')
-        store.has_calibration_with_id.return_value = True
-        calibration.add_ccc(store, ccc)
-        assert store.add_calibration.called_with(ccc)
-
-
 def make_calibration(
     identifier='ccc000',
     polynomial=None,
     access_token='password',
     active=False,
 ):
-    ccc = ccc_data.get_empty_ccc_entry(identifier, 'S. Kombuchae', 'xyz 1987')
+    ccc = ccc_data.get_empty_ccc_entry(identifier, 'Bogus schmogus', 'Dr Lus')
     if polynomial is not None:
         ccc[CellCountCalibration.polynomial] = (
             ccc_data.get_polynomal_entry(len(polynomial) - 1, polynomial)
@@ -985,6 +960,29 @@ def make_calibration(
             CalibrationEntryStatus.UnderConstruction
             )
     return ccc
+
+
+class TestAddCCC:
+    def test_valid_ccc(self):
+        store = MagicMock(calibration.CalibrationStore)
+        store.has_calibration_with_id.return_value = False
+        ccc = make_calibration()
+        assert calibration.add_ccc(store, ccc) is True
+        store.add_calibration.assert_called_with(ccc)
+
+    def test_none_id(self):
+        store = MagicMock(calibration.CalibrationStore)
+        store.has_calibration_with_id.return_value = False
+        ccc = make_calibration(identifier=None)
+        assert calibration.add_ccc(store, ccc) is False
+        store.add_calibration.assert_not_called()
+
+    def test_duplicate_id(self):
+        store = MagicMock(calibration.CalibrationStore)
+        store.has_calibration_with_id.return_value = True
+        ccc = make_calibration()
+        calibration.add_ccc(store, ccc)
+        assert store.add_calibration.called_with(ccc)
 
 
 class TestActivateCCC:

--- a/tests/unit/data_processing/test_calibration.py
+++ b/tests/unit/data_processing/test_calibration.py
@@ -981,8 +981,8 @@ class TestAddCCC:
         store = MagicMock(calibration.CalibrationStore)
         store.has_calibration_with_id.return_value = True
         ccc = make_calibration()
-        calibration.add_ccc(store, ccc)
-        assert store.add_calibration.called_with(ccc)
+        assert not calibration.add_ccc(store, ccc)
+        store.add_calibration.assert_not_called()
 
 
 class TestActivateCCC:


### PR DESCRIPTION
I think I have almost extracted a sufficient interface from `calibration.py` to put in a separate module that only deals with storing and retrieving data. The only thing remaining is adding measurements. The plan is then to implement this module using the database.
(Note: that's only the data that was in the `.ccc` file. Images and numpy arrays are still saved in files and not included in the `CalibrationStore` interface.)

I have manually tested creating and activating a "hanna" calibration with this.

The interface has become larger that I wanted to. I might be able to simplify it a by refactoring the way calibration works but that will require changing the API and the client code so I'll save it for later.
I could also split in stores for the different "types" (i.e. calibrations, images, plates and measurements). But that will be a lot of stores to pass around. Opinions welcome :smile: 

This is based on #314 and #315, so you might want to review only 20e440e.