### PR TITLE
Run system tests with firefox only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,16 +35,9 @@ jobs:
         apt:
           packages:
             - docker-ce
-        chrome: stable
         firefox: latest
       before_install:
         - sudo pip install tox
-        - wget -N http://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip -P ~/
-        - unzip ~/chromedriver_linux64.zip -d ~/
-        - rm ~/chromedriver_linux64.zip
-        - sudo mv -f ~/chromedriver /usr/local/share/
-        - sudo chmod +x /usr/local/share/chromedriver
-        - sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
         - wget -O- 'https://github.com/mozilla/geckodriver/releases/download/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz' | sudo tar -C /usr/local/bin -xz
       before_script:
         - export DISPLAY=':99.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
         - sleep 3
       script:
         - docker-compose build
-        - tox -e system-tests
+        - tox -e system-tests -- --browser firefox
       after_success:
         - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] ; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; docker-compose push; fi
         - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] ; then curl "https://jenkins.molflow.com/buildByToken/buildWithParameters?job=INFRA&token=${JENKINS_TOKEN}"; fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,12 @@ def pytest_addoption(parser):
         default=False,
         help="skip tests marked as slow"
     )
+    parser.addoption(
+        '--browser',
+        action='store',
+        choices=['firefox', 'chrome'],
+        default='firefox',
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -37,17 +37,14 @@ def scanomatic(docker_ip, docker_services):
     return url
 
 
-@pytest.fixture(
-    'function',
-    ids=['chrome', 'firefox'],
-    params=[webdriver.Chrome, webdriver.Firefox],
-)
+@pytest.fixture()
 def browser(request):
-    try:
-        driver = request.param()
-    except Exception as e:
-        warnings.warn(str(e))
-        driver = request.param()
-    driver.set_page_load_timeout(120)
+    browser = request.config.getoption('--browser')
+    if browser == 'firefox':
+        driver = webdriver.Firefox()
+    elif browser == 'chrome':
+        driver = webdriver.Chrome()
+    else:
+        raise ValueError('Unknown browser {}'.format(browser))
     yield driver
     driver.close()


### PR DESCRIPTION
This makes the browser used in system tests a command line option and runs with firefox in travis.

