### PR TITLE
Start scan series labels and more

### DIFF
--- a/scanomatic/ui_server_data/js/specs/components/ScanningJobPanel.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/ScanningJobPanel.spec.jsx
@@ -367,6 +367,10 @@ describe('duration2milliseconds', () => {
         expect(duration2milliseconds({ minutes: 1, hours: 1, days: 1 }))
             .toEqual(90060000);
     });
+
+    it('should return 0 if no duration', () => {
+        expect(duration2milliseconds()).toEqual(0);
+    });
 });
 
 describe('getProgress', () => {

--- a/scanomatic/ui_server_data/js/specs/components/ScanningJobPanel.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/ScanningJobPanel.spec.jsx
@@ -13,6 +13,7 @@ describe('<ScanningJobPanel />', () => {
         duration: { days: 3, hours: 2, minutes: 51 },
         interval: 13,
         scannerId: 'hoho',
+        status: 'Planned',
         onStartJob,
     };
 
@@ -54,115 +55,265 @@ describe('<ScanningJobPanel />', () => {
         expect(panel.prop('id')).toEqual(`job-${props.identifier}`);
     });
 
-    it('should render a job-start button', () => {
-        const wrapper = shallow(<ScanningJobPanel {...props} scanner={scanner} />);
-        const btn = wrapper.find('button.job-start');
-        expect(btn.exists()).toBeTruthy();
-        expect(btn.text()).toContain('Start');
-        expect(btn.find('span.glyphicon-play').exists()).toBeTruthy();
-    });
-
-    it('should disable job-start button if scanner unknown', () => {
-        const wrapper = shallow(<ScanningJobPanel
-            {...props}
-            scanner={null}
-        />);
-        const btn = wrapper.find('button.job-start');
-        expect(btn.prop('disabled')).toBeTruthy();
-        expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
-    });
-
-    it('should disable job-start button if scanner offline', () => {
-        const wrapper = shallow(<ScanningJobPanel
-            {...props}
-            scanner={scannerOffline}
-        />);
-        const btn = wrapper.find('button.job-start');
-        expect(btn.prop('disabled')).toBeTruthy();
-        expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
-    });
-
-    it('should disable job-start button if scanner ownded', () => {
-        const wrapper = shallow(<ScanningJobPanel
-            {...props}
-            scanner={scannerOccupied}
-        />);
-        const btn = wrapper.find('button.job-start');
-        expect(btn.prop('disabled')).toBeTruthy();
-        expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
-    });
-
-    it('should not render a start button if job is starting', () => {
-        const wrapper = shallow(<ScanningJobPanel {...props} disableStart />);
-        const btn = wrapper.find('button.job-start');
-        expect(btn.exists()).toBeFalsy();
-    });
-
-    it('should not render a start button if job has started', () => {
-        const wrapper = shallow(<ScanningJobPanel
-            {...props}
-            startTime="1980-03-23T13:00:00Z"
-        />);
-        const btn = wrapper.find('button.job-start');
-        expect(btn.exists()).toBeFalsy();
-    });
-
-    it('should render the description', () => {
-        const wrapper = shallow(<ScanningJobPanel {...props} />);
-        const desc = wrapper.find('div.job-description');
-        expect(desc.exists()).toBeTruthy();
-    });
-
-    it('should render the interval', () => {
-        const wrapper = shallow(<ScanningJobPanel {...props} />);
-        const desc = wrapper.find('div.job-description');
-        expect(desc.text()).toContain('Scan every 13 minutes');
-    });
-
-    it('should render a link to the compile page', () => {
-        const wrapper = shallow(<ScanningJobPanel {...props} />);
-        const link = wrapper
-            .find('[href="/compile?projectdirectory=root/job0000"]');
-        expect(link.exists()).toBe(true);
-        expect(link.text()).toEqual('Compile project');
-    });
-
-    it('should render a link to the qc page', () => {
-        const wrapper = shallow(<ScanningJobPanel {...props} />);
-        const link = wrapper
-            .find('[href="/qc_norm?analysisdirectory=job0000/analysis&project=Omnibus"]');
-        expect(link.exists()).toBe(true);
-        expect(link.text()).toEqual('QC project');
-    });
-
-    describe('Scan verb', () => {
-        it('should say Scan if not started', () => {
+    describe('Status Planned', () => {
+        it('should render a status label', () => {
             const wrapper = shallow(<ScanningJobPanel {...props} />);
-            const desc = wrapper.find('div.job-description');
-            expect(desc.text()).toContain('Scan every');
+            const heading = wrapper.find('div.panel-heading');
+            const label = heading.find('.label-default');
+            expect(label.exists()).toBeTruthy();
+            expect(label.text()).toEqual('Planned');
         });
 
-        it('should say Scanning if started', () => {
+        it('should render a job-start button', () => {
+            const wrapper = shallow(<ScanningJobPanel {...props} scanner={scanner} />);
+            const btn = wrapper.find('button.job-start');
+            expect(btn.exists()).toBeTruthy();
+            expect(btn.text()).toContain('Start');
+            expect(btn.find('span.glyphicon-play').exists()).toBeTruthy();
+        });
+
+        it('should disable job-start button if scanner unknown', () => {
             const wrapper = shallow(<ScanningJobPanel
                 {...props}
-                startTime="1980-03-23T13:00:00Z"
+                scanner={null}
             />);
-            const desc = wrapper.find('div.job-description');
-            expect(desc.text()).toContain('Scanning every');
+            const btn = wrapper.find('button.job-start');
+            expect(btn.prop('disabled')).toBeTruthy();
+            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
         });
 
-        it('should say Scanning if starting', () => {
+        it('should disable job-start button if scanner offline', () => {
+            const wrapper = shallow(<ScanningJobPanel
+                {...props}
+                scanner={scannerOffline}
+            />);
+            const btn = wrapper.find('button.job-start');
+            expect(btn.prop('disabled')).toBeTruthy();
+            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
+        });
+
+        it('should disable job-start button if scanner ownded', () => {
+            const wrapper = shallow(<ScanningJobPanel
+                {...props}
+                scanner={scannerOccupied}
+            />);
+            const btn = wrapper.find('button.job-start');
+            expect(btn.prop('disabled')).toBeTruthy();
+            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
+        });
+
+        it('should not render a start button if job is starting', () => {
             const wrapper = shallow(<ScanningJobPanel {...props} disableStart />);
-            const desc = wrapper.find('div.job-description');
-            expect(desc.text()).toContain('Scanning every');
+            const btn = wrapper.find('button.job-start');
+            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
+        });
+
+        it('should not render a link to the compile page', () => {
+            const wrapper = shallow(<ScanningJobPanel {...props} />);
+            const link = wrapper
+                .find('[href="/compile?projectdirectory=root/job0000"]');
+            expect(link.exists()).toBeFalsy();
+        });
+
+        it('should not render a link to the qc page', () => {
+            const wrapper = shallow(<ScanningJobPanel {...props} />);
+            const link = wrapper
+                .find('[href="/qc_norm?analysisdirectory=job0000/analysis&project=Omnibus"]');
+            expect(link.exists()).toBeFalsy();
+        });
+
+        it('should say scanning frequency', () => {
+            const wrapper = shallow(<ScanningJobPanel {...props} />);
+            const desc = wrapper.find('tr.job-interval');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Frequency');
+            expect(desc.find('td').at(1).text()).toEqual('Scan every 13 minutes');
+        });
+
+        describe('scanner', () => {
+            it('should have a table row', () => {
+                const wrapper = shallow(<ScanningJobPanel {...props} />);
+                const desc = wrapper.find('tr.job-scanner');
+                expect(desc.exists()).toBeTruthy();
+                expect(desc.find('td').at(0).text()).toEqual('Scanner');
+            });
+
+            it('should render the scanner retrieving scanner status', () => {
+                const wrapper = shallow(<ScanningJobPanel {...props} />);
+                const desc = wrapper.find('tr.job-scanner');
+                expect(desc.find('td').at(1).text()).toEqual('Retrieving scanner status...');
+            });
+
+            it('should render the scanner offline', () => {
+                const wrapper = shallow(<ScanningJobPanel
+                    {...props}
+                    scanner={scannerOffline}
+                />);
+                const desc = wrapper.find('tr.job-scanner');
+                expect(desc.find('td').at(1).text()).toEqual('Consule (offline, free)');
+            });
+
+            it('should render the scanner occupied', () => {
+                const wrapper = shallow(<ScanningJobPanel
+                    {...props}
+                    scanner={scannerOccupied}
+                />);
+                const desc = wrapper.find('tr.job-scanner');
+                expect(desc.find('td').at(1).text()).toEqual('Consule (online, occupied)');
+            });
+        });
+    });
+
+    describe('Status Running', () => {
+        let wrapper;
+
+        beforeEach(() => {
+            jasmine.clock().install();
+            jasmine.clock().mockDate(new Date('1980-03-24T13:00:00Z'));
+            wrapper = shallow(<ScanningJobPanel
+                {...props}
+                startTime="1980-03-23T13:00:00Z"
+                status="Running"
+            />);
+        });
+
+        afterEach(() => {
+            jasmine.clock().uninstall();
+        });
+
+        it('should render a status label', () => {
+            const heading = wrapper.find('div.panel-heading');
+            const label = heading.find('.label-info');
+            expect(label.exists()).toBeTruthy();
+            expect(label.text()).toEqual('Running');
+        });
+
+        it('should not render a start button', () => {
+            const btn = wrapper.find('button.job-start');
+            expect(btn.exists()).toBeFalsy();
+        });
+
+        it('should not render a link to the compile page', () => {
+            const link = wrapper
+                .find('[href="/compile?projectdirectory=root/job0000"]');
+            expect(link.exists()).toBeFalsy();
+        });
+
+        it('should not render a link to the qc page', () => {
+            const link = wrapper
+                .find('[href="/qc_norm?analysisdirectory=job0000/analysis&project=Omnibus"]');
+            expect(link.exists()).toBeFalsy();
+        });
+
+        it('should say when a job was started', () => {
+            const desc = wrapper.find('tr.job-start');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Started');
+            expect(desc.find('td').at(1).text()).toEqual(`${new Date('1980-03-23T13:00:00Z')}`);
+        });
+
+        it('should say when a job will end', () => {
+            const desc = wrapper.find('tr.job-end');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Will end');
+            expect(desc.find('td').at(1).text()).toEqual('Wed Mar 26 1980 16:51:00 GMT+0100 (CET)');
+        });
+
+        it('should say scanning frequency', () => {
+            const desc = wrapper.find('tr.job-interval');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Frequency');
+            expect(desc.find('td').at(1).text()).toEqual('Scanning every 13 minutes');
+        });
+
+        describe('Progress bar', () => {
+            it('should render a progress bar', () => {
+                const progress = wrapper.find('.progress');
+                expect(progress.exists()).toBeTruthy();
+            });
+
+            it('should have the progressbar display the progress', () => {
+                const progressbar = wrapper.find('.progress-bar');
+                expect(progressbar.prop('style').width).toEqual('32.1%');
+            });
+
+            it('should have the progressbar display the progress as text', () => {
+                const progressbar = wrapper.find('.progress-bar');
+                expect(progressbar.render().text()).toEqual('32.1%');
+            });
+        });
+
+        it('should have also show scanner info', () => {
+            const desc = wrapper.find('tr.job-scanner');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Scanner');
+        });
+    });
+
+    describe('Status Completed', () => {
+        let wrapper;
+        beforeEach(() => {
+            wrapper = shallow(<ScanningJobPanel
+                {...props}
+                startTime="1980-03-23T13:00:00Z"
+                status="Completed"
+            />);
+        });
+
+        it('should render a status label', () => {
+            const heading = wrapper.find('div.panel-heading');
+            const label = heading.find('.label-success');
+            expect(label.exists()).toBeTruthy();
+            expect(label.text()).toEqual('Completed');
+        });
+
+        it('should render a link to the compile page', () => {
+            const link = wrapper
+                .find('[href="/compile?projectdirectory=root/job0000"]');
+            expect(link.exists()).toBeTruthy();
+            expect(link.text()).toEqual('Compile project');
+        });
+
+        it('should render a link to the qc page', () => {
+            const link = wrapper
+                .find('[href="/qc_norm?analysisdirectory=job0000/analysis&project=Omnibus"]');
+            expect(link.exists()).toBeTruthy();
+            expect(link.text()).toEqual('QC project');
+        });
+
+        it('should not show scanner info', () => {
+            const desc = wrapper.find('tr.job-scanner');
+            expect(desc.exists()).toBeFalsy();
+        });
+
+        it('should say when a job was started', () => {
+            const desc = wrapper.find('tr.job-start');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Started');
+            expect(desc.find('td').at(1).text()).toEqual('Sun Mar 23 1980 14:00:00 GMT+0100 (CET)');
+        });
+
+        it('should say when a job ended', () => {
+            const desc = wrapper.find('tr.job-end');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Ended');
+            expect(desc.find('td').at(1).text()).toEqual('Wed Mar 26 1980 16:51:00 GMT+0100 (CET)');
+        });
+
+        it('should say scanning frequency', () => {
+            const desc = wrapper.find('tr.job-interval');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Frequency');
+            expect(desc.find('td').at(1).text()).toEqual('Scanned every 13 minutes');
         });
     });
 
     describe('duration', () => {
         it('should render the duration', () => {
             const wrapper = shallow(<ScanningJobPanel {...props} />);
-            const desc = wrapper.find('div.job-description');
-            expect(desc.text()).toContain('for 3 days 2 hours 51 minutes.');
+            const desc = wrapper.find('tr.job-duration');
+            expect(desc.find('td').at(0).text()).toEqual('Duration');
+            expect(desc.find('td').at(1).text()).toEqual('3 days 2 hours 51 minutes');
         });
 
         it('should skip days if zero', () => {
@@ -170,61 +321,26 @@ describe('<ScanningJobPanel />', () => {
                 {...props}
                 duration={{ days: 0, hours: 2, minutes: 51 }}
             />);
-            const desc = wrapper.find('div.job-description');
-            expect(desc.text()).toContain('for 2 hours 51 minutes.');
+            const desc = wrapper.find('tr.job-duration');
+            expect(desc.find('td').at(1).text()).toEqual('2 hours 51 minutes');
         });
 
-        it('should skip days if zero', () => {
+        it('should skip hours if zero', () => {
             const wrapper = shallow(<ScanningJobPanel
                 {...props}
                 duration={{ days: 2, hours: 0, minutes: 51 }}
             />);
             const desc = wrapper.find('div.job-description');
-            expect(desc.text()).toContain('for 2 days 51 minutes.');
+            expect(desc.find('td').at(1).text()).toEqual('2 days 51 minutes');
         });
 
-        it('should skip days if zero', () => {
+        it('should skip minues if zero', () => {
             const wrapper = shallow(<ScanningJobPanel
                 {...props}
                 duration={{ days: 3, hours: 2, minutes: 0 }}
             />);
             const desc = wrapper.find('div.job-description');
-            expect(desc.text()).toContain('for 3 days 2 hours.');
+            expect(desc.find('td').at(1).text()).toEqual('3 days 2 hours');
         });
-    });
-
-    describe('scanner', () => {
-        it('should render the scanner retrieving scanner status', () => {
-            const wrapper = shallow(<ScanningJobPanel {...props} />);
-            const desc = wrapper.find('div.scanner-status');
-            expect(desc.text()).toContain('Retrieving scanner status...');
-        });
-
-        it('should render the scanner offline', () => {
-            const wrapper = shallow(<ScanningJobPanel
-                {...props}
-                scanner={scannerOffline}
-            />);
-            const desc = wrapper.find('div.scanner-status');
-            expect(desc.text()).toContain('Using scanner Consule (offline, free).');
-        });
-
-        it('should render the scanner occupied', () => {
-            const wrapper = shallow(<ScanningJobPanel
-                {...props}
-                scanner={scannerOccupied}
-            />);
-            const desc = wrapper.find('div.scanner-status');
-            expect(desc.text()).toContain('Using scanner Consule (online, occupied).');
-        });
-    });
-
-    it('should say when a job was started', () => {
-        const wrapper = shallow(<ScanningJobPanel
-            {...props}
-            startTime="1980-03-23T13:00:00Z"
-        />);
-        const desc = wrapper.find('div.job-status');
-        expect(desc.text()).toContain('Started at 1980-03-23T13:00:00Z.');
     });
 });

--- a/scanomatic/ui_server_data/js/specs/components/ScanningRoot.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/ScanningRoot.spec.jsx
@@ -147,6 +147,7 @@ describe('getStatus', () => {
 });
 
 describe('jobSorter', () => {
+    const job0 = { status: 'Planned' };
     const job1 = { status: 'Planned' };
     const job2 = {
         status: 'Running',
@@ -176,6 +177,7 @@ describe('jobSorter', () => {
         expect([job1, job2, job4].sort(jobSorter)).toEqual([job1, job2, job4]);
         expect([job2, job1, job4].sort(jobSorter)).toEqual([job1, job2, job4]);
         expect([job4, job1, job2].sort(jobSorter)).toEqual([job1, job2, job4]);
+        expect([job0, job1].sort(jobSorter)).toEqual([job0, job1]);
     });
 
     it('should sort running jobs so first to complete comes first', () => {

--- a/scanomatic/ui_server_data/js/specs/components/ScanningRoot.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/ScanningRoot.spec.jsx
@@ -177,7 +177,7 @@ describe('jobSorter', () => {
         expect([job2, job3].sort(jobSorter)).toEqual([job3, job2]);
     });
 
-    it('should sort completed jobs so first started comes first', () => {
-        expect([job4, job5].sort(jobSorter)).toEqual([job5, job4]);
+    it('should sort completed jobs so first started comes last', () => {
+        expect([job5, job4].sort(jobSorter)).toEqual([job4, job5]);
     });
 });

--- a/scanomatic/ui_server_data/js/specs/components/ScanningRoot.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/ScanningRoot.spec.jsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import './enzyme-setup';
-import ScanningRoot from '../../src/components/ScanningRoot';
+import ScanningRoot, { getStatus, jobSorter } from '../../src/components/ScanningRoot';
 
 
 describe('<ScanningRoot />', () => {
@@ -49,7 +49,7 @@ describe('<ScanningRoot />', () => {
 
     describe('showing existing jobs', () => {
         const jobs = [
-            { name: 'A' },
+            { name: 'A', duration: { days: 0, hours: 1, minutes: 3 }, startTime: new Date('1867-03-01T06:33:12.000Z') },
             { name: 'B' },
         ];
 
@@ -71,22 +71,31 @@ describe('<ScanningRoot />', () => {
         it('passes jobs-data to <ScanningJobPanel />:s', () => {
             const wrapper = shallow(<ScanningRoot {...props} jobs={jobs} />);
             const jobPanels = wrapper.find('ScanningJobPanel');
-            expect(jobPanels.first().prop('name')).toEqual('A');
-            expect(jobPanels.last().prop('name')).toEqual('B');
+            expect(jobPanels.last().prop('name')).toEqual('A');
+            expect(jobPanels.first().prop('name')).toEqual('B');
         });
 
         it('couples start callback with job (first)', () => {
             const wrapper = shallow(<ScanningRoot {...props} jobs={jobs} />);
             const jobPanels = wrapper.find('ScanningJobPanel');
-            jobPanels.first().prop('onStartJob')();
-            expect(onStartJob).toHaveBeenCalledWith(jobs[0]);
+            jobPanels.last().prop('onStartJob')();
+            expect(onStartJob)
+                .toHaveBeenCalledWith(Object.assign({}, jobs[0], { status: 'Completed' }));
         });
 
         it('couples start callback with job (last)', () => {
             const wrapper = shallow(<ScanningRoot {...props} jobs={jobs} />);
             const jobPanels = wrapper.find('ScanningJobPanel');
-            jobPanels.last().prop('onStartJob')();
-            expect(onStartJob).toHaveBeenCalledWith(jobs[1]);
+            jobPanels.first().prop('onStartJob')();
+            expect(onStartJob)
+                .toHaveBeenCalledWith(Object.assign({}, jobs[1], { status: 'Planned' }));
+        });
+
+        it('should add statuses to the jobs', () => {
+            const wrapper = shallow(<ScanningRoot {...props} jobs={jobs} />);
+            const jobPanels = wrapper.find('ScanningJobPanel');
+            expect(jobPanels.first().prop('status')).toEqual('Planned');
+            expect(jobPanels.last().prop('status')).toEqual('Completed');
         });
     });
 
@@ -112,5 +121,63 @@ describe('<ScanningRoot />', () => {
             const btn = wrapper.find('button.new-job');
             expect(btn.prop('disabled')).toBeTruthy();
         });
+    });
+});
+
+describe('getStatus', () => {
+    it('Returns Planned if not startTime', () => {
+        expect(getStatus()).toEqual('Planned');
+    });
+
+    it('Returns completed if startTime and endTime is less than now', () => {
+        expect(getStatus(
+            new Date('1710-05-13T06:33:12.000Z'),
+            new Date('1999-12-24T06:33:12.000Z'),
+            new Date('2023-04-02T06:33:12.000Z'),
+        )).toEqual('Completed');
+    });
+
+    it('Returns completed if startTime and endTime is less than now', () => {
+        expect(getStatus(
+            new Date('1710-05-13T06:33:12.000Z'),
+            new Date('2023-04-02T06:33:12.000Z'),
+            new Date('1999-12-24T06:33:12.000Z'),
+        )).toEqual('Running');
+    });
+});
+
+describe('jobSorter', () => {
+    const job1 = { status: 'Planned' };
+    const job2 = {
+        status: 'Running',
+        startTime: new Date('1710-05-13T06:33:12.000Z'),
+        endTime: new Date('2023-04-02T06:33:12.000Z'),
+    };
+    const job3 = {
+        status: 'Running',
+        startTime: new Date('1710-05-13T06:33:12.000Z'),
+        endTime: new Date('1999-12-24T06:33:12.000Z'),
+    };
+    const job4 = {
+        status: 'Completed',
+        startTime: new Date('1999-12-24T06:33:12.000Z'),
+        endTime: new Date('2023-04-02T06:33:12.000Z'),
+    };
+    const job5 = {
+        status: 'Completed',
+        startTime: new Date('1710-05-13T06:33:12.000Z'),
+        endTime: new Date('2023-04-02T06:33:12.000Z'),
+    };
+
+    it('should put jobs in Planned, Running, Completed order', () => {
+        expect([job2, job4, job1].sort(jobSorter)).toEqual([job1, job2, job4]);
+    });
+
+    it('should sort running jobs so first to complete comes first', () => {
+        expect([job2, job3].sort(jobSorter)).toEqual([job3, job2]);
+    });
+
+    it('should sort completed jobs so first started comes first', () => {
+        expect([job4, job5].sort(jobSorter)).toEqual([job5, job4]);
     });
 });

--- a/scanomatic/ui_server_data/js/specs/components/ScanningRoot.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/ScanningRoot.spec.jsx
@@ -171,6 +171,11 @@ describe('jobSorter', () => {
 
     it('should put jobs in Planned, Running, Completed order', () => {
         expect([job2, job4, job1].sort(jobSorter)).toEqual([job1, job2, job4]);
+        expect([job4, job2, job1].sort(jobSorter)).toEqual([job1, job2, job4]);
+        expect([job1, job4, job2].sort(jobSorter)).toEqual([job1, job2, job4]);
+        expect([job1, job2, job4].sort(jobSorter)).toEqual([job1, job2, job4]);
+        expect([job2, job1, job4].sort(jobSorter)).toEqual([job1, job2, job4]);
+        expect([job4, job1, job2].sort(jobSorter)).toEqual([job1, job2, job4]);
     });
 
     it('should sort running jobs so first to complete comes first', () => {

--- a/scanomatic/ui_server_data/js/specs/containers/ScanningRootContainer.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/containers/ScanningRootContainer.spec.jsx
@@ -157,6 +157,15 @@ describe('<ScanningRootContainer />', () => {
                     Object.assign({}, job2, { startTime: null, endTime: null }),
                 ]);
             });
+
+            it('should make an error if starting job not known', () => {
+                const wrapper = shallow(<ScanningRootContainer />);
+                const unstarted = Object.assign({}, job, { startTime: null, endTime: null, identifier: 'whoami' });
+                wrapper.prop('onStartJob')(unstarted);
+                wrapper.update();
+                expect(wrapper.prop('error')).toEqual(`UI lost job '${job.name}'`);
+                expect(wrapper.prop('jobs')[0].disableStart).toBeFalsy();
+            });
         });
 
         describe('Start Job resolving', () => {

--- a/scanomatic/ui_server_data/js/specs/containers/ScanningRootContainer.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/containers/ScanningRootContainer.spec.jsx
@@ -10,6 +10,7 @@ import FakePromise from '../helpers/FakePromise';
 
 describe('<ScanningRootContainer />', () => {
     const job = {
+        identifier: 'job1iamindeed',
         name: 'Test',
         scannerId: 'aha',
         duration: {
@@ -18,6 +19,17 @@ describe('<ScanningRootContainer />', () => {
             minutes: 777,
         },
         interval: 8888,
+    };
+    const job2 = {
+        identifier: 'job2iamevenmore',
+        name: 'Test2',
+        scannerId: 'ahab',
+        duration: {
+            days: 5,
+            hours: 6,
+            minutes: 77,
+        },
+        interval: 88888,
     };
     const scanner = {
         name: 'Kassad',
@@ -99,7 +111,7 @@ describe('<ScanningRootContainer />', () => {
     describe('Jobs and Scanners request resolving', () => {
         beforeEach(() => {
             spyOn(API, 'getScanningJobs').and
-                .returnValue(FakePromise.resolve([job]));
+                .returnValue(FakePromise.resolve([job, job2]));
             spyOn(helpers, 'getScannersWithOwned').and
                 .returnValue(FakePromise.resolve([scanner]));
         });
@@ -107,7 +119,10 @@ describe('<ScanningRootContainer />', () => {
         it('should pass updated jobs', () => {
             const wrapper = shallow(<ScanningRootContainer />);
             expect(wrapper.prop('jobs'))
-                .toEqual([Object.assign({}, job, { startTime: null, endTime: null })]);
+                .toEqual([
+                    Object.assign({}, job, { startTime: null, endTime: null }),
+                    Object.assign({}, job2, { startTime: null, endTime: null }),
+                ]);
         });
 
         it('should pass updated scanners', () => {
@@ -137,7 +152,10 @@ describe('<ScanningRootContainer />', () => {
                 wrapper.update();
                 const startingJob = Object.assign({}, unstarted);
                 startingJob.disableStart = true;
-                expect(wrapper.prop('jobs')).toEqual([startingJob]);
+                expect(wrapper.prop('jobs')).toEqual([
+                    startingJob,
+                    Object.assign({}, job2, { startTime: null, endTime: null }),
+                ]);
             });
         });
 

--- a/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
@@ -55,10 +55,17 @@ export default function ScanningJobPanel(props) {
             </div>
         );
     }
+    let labelStyle = 'label label-default';
+    if (props.status === 'Running') {
+        labelStyle = 'label label-info';
+    } else if (props.status === 'Completed') {
+        labelStyle = 'label label-success';
+    }
     return (
         <div className="panel panel-default job-listing" id={`job-${props.identifier}`}>
             <div className="panel-heading">
                 <h3 className="panel-title">{props.name}</h3>
+                <span className={labelStyle}>{props.status}</span>
             </div>
             {showStart}
             <div className="job-description">
@@ -85,6 +92,7 @@ ScanningJobPanel.propTypes = {
         minutes: PropTypes.number.isRequired,
     }).isRequired,
     scanner: SoMPropTypes.scannerType,
+    status: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     interval: PropTypes.number.isRequired,
     startTime: PropTypes.string,

--- a/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
@@ -4,6 +4,19 @@ import React from 'react';
 
 import SoMPropTypes from '../prop-types';
 
+export function duration2milliseconds(duration) {
+    if (duration) {
+        return (duration.minutes * 60000) + (duration.hours * 3600000) + (duration.days * 86400000);
+    }
+    return 0;
+}
+
+export function getProgress(job) {
+    const duration = duration2milliseconds(job.duration);
+    const progress = new Date() - new Date(job.startTime);
+    return Math.min(1, progress / duration) * 100;
+}
+
 export default function ScanningJobPanel(props) {
     const duration = [];
     if (props.duration.days > 0) {
@@ -17,43 +30,110 @@ export default function ScanningJobPanel(props) {
     }
     const { scanner } = props;
     let showStart = null;
-    let scanVerb = 'Scan';
-    if (props.disableStart || props.startTime) {
-        scanVerb = 'Scanning';
-    } else if (!scanner || scanner.owned || !scanner.power) {
+    let status = null;
+    const jobDuration = (
+        <tr>
+            <td>Duration</td>
+            <td>{duration.join(' ')}</td>
+        </tr>
+    );
+    let scanFrequency;
+    if (props.status === 'Running') {
+        const progress = getProgress(props).toFixed(1);
+        status = (
+            <div className="progress">
+                <div
+                    className="progress-bar"
+                    role="progressbar"
+                    aria-valuenow={progress}
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                    style={{ minWidth: '4em', width: `${progress}%` }}
+                >
+                    {progress}%
+                </div>
+            </div>
+        );
+        scanFrequency = (
+            <tr>
+                <td>Frequency</td>
+                <td>Scanning every {props.interval} minutes</td>
+            </tr>
+        );
+    } else if (props.status === 'Completed') {
+        scanFrequency = (
+            <tr>
+                <td>Frequency</td>
+                <td>Scanned every {props.interval} minutes</td>
+            </tr>
+        );
+    } else if (props.disableStart || !scanner || scanner.owned || !scanner.power) {
+        scanFrequency = (
+            <tr>
+                <td>Frequency</td>
+                <td>Scan every {props.interval} minutes</td>
+            </tr>
+        );
         showStart = (
             <button type="button" className="btn btn-lg job-start" disabled>
                 <span className="glyphicon glyphicon-ban-circle" /> Start
             </button>
         );
     } else {
+        scanFrequency = (
+            <tr>
+                <td>Frequency</td>
+                <td>Scan every {props.interval} minutes</td>
+            </tr>
+        );
         showStart = (
             <button type="button" className="btn btn-lg job-start" onClick={props.onStartJob} >
                 <span className="glyphicon glyphicon-play" /> Start
             </button>
         );
     }
-    let jobStatus = null;
-    if (props.startTime) {
-        jobStatus = (
-            <div className="job-status">
-                Started at {props.startTime}.
-            </div>
-        );
-    }
-    let scannerStatus = null;
-    if (scanner) {
-        scannerStatus = (
-            <div className="scanner-status">
-                Using scanner <b>{scanner.name}</b> ({scanner.power ? 'online' : 'offline'}, {scanner.owned ? 'occupied' : 'free'}).
-            </div>
+    let jobScanner;
+    if (props.status === 'Completed') {
+        jobScanner = null;
+    } else if (scanner) {
+        jobScanner = (
+            <tr>
+                <td>Scanner</td>
+                <td>{scanner.name} ({scanner.power ? 'online' : 'offline'}, {scanner.owned ? 'occupied' : 'free'})</td>
+            </tr>
         );
     } else {
-        scannerStatus = (
-            <div className="scanner-status">
-                Retrieving scanner status...
-            </div>
+        jobScanner = (
+            <tr>
+                <td>Scanner</td>
+                <td>Retrieving scanner status...</td>
+            </tr>
         );
+    }
+    let jobStart;
+    let jobEnd;
+    if (props.startTime) {
+        jobStart = (
+            <tr>
+                <td>Started</td>
+                <td>{`${new Date(props.startTime)}`}</td>
+            </tr>
+        );
+        if (props.status === 'Completed') {
+            jobEnd = (
+                <tr>
+                    <td>Ended</td>
+                    <td>{`${new Date(new Date(props.startTime) - -duration2milliseconds(props.duration))}`}</td>
+                </tr>
+            );
+        } else {
+            jobEnd = (
+                <tr>
+                    <td>Will end</td>
+                    <td>{`${new Date(new Date(props.startTime) - -duration2milliseconds(props.duration))}`}</td>
+                </tr>
+            );
+        }
     }
     let labelStyle = 'label label-default';
     if (props.status === 'Running') {
@@ -69,9 +149,16 @@ export default function ScanningJobPanel(props) {
             </div>
             {showStart}
             <div className="job-description">
-                {scanVerb} every {props.interval} minutes for {duration.join(' ')}.
-                {scannerStatus}
-                {jobStatus}
+                {status}
+                <table className="table job-stats">
+                    <tbody>
+                        {jobDuration}
+                        {scanFrequency}
+                        {jobScanner}
+                        {jobStart}
+                        {jobEnd}
+                    </tbody>
+                </table>
             </div>
             <div className="text-right">
                 <a href={`/compile?projectdirectory=root/${props.identifier}`}>

--- a/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
@@ -127,21 +127,21 @@ export default function ScanningJobPanel(props) {
         jobStart = (
             <tr className="job-info job-start">
                 <td>Started</td>
-                <td>{`${new Date(props.startTime)}`}</td>
+                <td>{`${props.startTime}`}</td>
             </tr>
         );
         if (props.status === 'Completed') {
             jobEnd = (
                 <tr className="job-info job-end">
                     <td>Ended</td>
-                    <td>{`${new Date(new Date(props.startTime) - -duration2milliseconds(props.duration))}`}</td>
+                    <td>{`${props.endTime}`}</td>
                 </tr>
             );
         } else {
             jobEnd = (
                 <tr className="job-info job-end">
                     <td>Will end</td>
-                    <td>{`${new Date(new Date(props.startTime) - -duration2milliseconds(props.duration))}`}</td>
+                    <td>{`${props.endTime}`}</td>
                 </tr>
             );
         }
@@ -186,7 +186,8 @@ ScanningJobPanel.propTypes = {
     status: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     interval: PropTypes.number.isRequired,
-    startTime: PropTypes.string,
+    startTime: PropTypes.instanceOf(Date),
+    endTime: PropTypes.instanceOf(Date),
     onStartJob: PropTypes.func.isRequired,
     disableStart: PropTypes.bool,
     identifier: PropTypes.string.isRequired,
@@ -195,5 +196,6 @@ ScanningJobPanel.propTypes = {
 ScanningJobPanel.defaultProps = {
     scanner: null,
     startTime: null,
+    endTime: null,
     disableStart: false,
 };

--- a/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
@@ -6,7 +6,8 @@ import SoMPropTypes from '../prop-types';
 
 export function duration2milliseconds(duration) {
     if (duration) {
-        return (duration.minutes * 60000) + (duration.hours * 3600000) + (duration.days * 86400000);
+        const date = new Date(0);
+        return date.setUTCHours((duration.days * 24) + duration.hours, duration.minutes);
     }
     return 0;
 }

--- a/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
@@ -31,13 +31,8 @@ export default function ScanningJobPanel(props) {
     const { scanner } = props;
     let showStart = null;
     let status = null;
-    const jobDuration = (
-        <tr>
-            <td>Duration</td>
-            <td>{duration.join(' ')}</td>
-        </tr>
-    );
     let scanFrequency;
+    let links;
     if (props.status === 'Running') {
         const progress = getProgress(props).toFixed(1);
         status = (
@@ -55,21 +50,31 @@ export default function ScanningJobPanel(props) {
             </div>
         );
         scanFrequency = (
-            <tr>
+            <tr className="job-info job-interval">
                 <td>Frequency</td>
                 <td>Scanning every {props.interval} minutes</td>
             </tr>
         );
     } else if (props.status === 'Completed') {
         scanFrequency = (
-            <tr>
+            <tr className="job-info job-interval">
                 <td>Frequency</td>
                 <td>Scanned every {props.interval} minutes</td>
             </tr>
         );
+        links = (
+            <div className="text-right job-links">
+                <a href={`/compile?projectdirectory=root/${props.identifier}`}>
+                    Compile project
+                </a>
+                <a href={`/qc_norm?analysisdirectory=${encodeURI(props.identifier)}/analysis&project=${encodeURI(props.name)}`}>
+                    QC project
+                </a>
+            </div>
+        );
     } else if (props.disableStart || !scanner || scanner.owned || !scanner.power) {
         scanFrequency = (
-            <tr>
+            <tr className="job-info job-interval">
                 <td>Frequency</td>
                 <td>Scan every {props.interval} minutes</td>
             </tr>
@@ -81,7 +86,7 @@ export default function ScanningJobPanel(props) {
         );
     } else {
         scanFrequency = (
-            <tr>
+            <tr className="job-info job-interval">
                 <td>Frequency</td>
                 <td>Scan every {props.interval} minutes</td>
             </tr>
@@ -92,19 +97,25 @@ export default function ScanningJobPanel(props) {
             </button>
         );
     }
+    const jobDuration = (
+        <tr className="job-info job-duration">
+            <td>Duration</td>
+            <td>{duration.join(' ')}</td>
+        </tr>
+    );
     let jobScanner;
     if (props.status === 'Completed') {
         jobScanner = null;
     } else if (scanner) {
         jobScanner = (
-            <tr>
+            <tr className="job-info job-scanner">
                 <td>Scanner</td>
                 <td>{scanner.name} ({scanner.power ? 'online' : 'offline'}, {scanner.owned ? 'occupied' : 'free'})</td>
             </tr>
         );
     } else {
         jobScanner = (
-            <tr>
+            <tr className="job-info job-scanner">
                 <td>Scanner</td>
                 <td>Retrieving scanner status...</td>
             </tr>
@@ -114,21 +125,21 @@ export default function ScanningJobPanel(props) {
     let jobEnd;
     if (props.startTime) {
         jobStart = (
-            <tr>
+            <tr className="job-info job-start">
                 <td>Started</td>
                 <td>{`${new Date(props.startTime)}`}</td>
             </tr>
         );
         if (props.status === 'Completed') {
             jobEnd = (
-                <tr>
+                <tr className="job-info job-end">
                     <td>Ended</td>
                     <td>{`${new Date(new Date(props.startTime) - -duration2milliseconds(props.duration))}`}</td>
                 </tr>
             );
         } else {
             jobEnd = (
-                <tr>
+                <tr className="job-info job-end">
                     <td>Will end</td>
                     <td>{`${new Date(new Date(props.startTime) - -duration2milliseconds(props.duration))}`}</td>
                 </tr>
@@ -160,14 +171,7 @@ export default function ScanningJobPanel(props) {
                     </tbody>
                 </table>
             </div>
-            <div className="text-right">
-                <a href={`/compile?projectdirectory=root/${props.identifier}`}>
-                    Compile project
-                </a>
-                <a href={`/qc_norm?analysisdirectory=${encodeURI(props.identifier)}/analysis&project=${encodeURI(props.name)}`}>
-                    QC project
-                </a>
-            </div>
+            {links}
         </div>
     );
 }

--- a/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
@@ -2,14 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import NewScanningJobContainer from '../containers/NewScanningJobContainer';
 import SoMPropTypes from '../prop-types';
-import ScanningJobPanel from './ScanningJobPanel';
-
-export function duration2milliseconds(duration) {
-    if (duration) {
-        return (duration.minutes * 60000) + (duration.hours * 3600000) + (duration.days * 86400000);
-    }
-    return 0;
-}
+import ScanningJobPanel, { duration2milliseconds } from './ScanningJobPanel';
 
 export function getStatus(startTime, duration, now) {
     const endTime = new Date(startTime) - -duration2milliseconds(duration);
@@ -17,14 +10,11 @@ export function getStatus(startTime, duration, now) {
         return 'Planned';
     } else if (endTime > now - 0) {
         return 'Running';
-    } else if (endTime > now - 3600000) {
-        return 'Completed';
     }
-    return null;
+    return 'Completed';
 }
 
 export function jobSorter(a, b) {
-    console.log(a, b);
     if (a.status === 'Planned' && b.status !== 'Planned') {
         return -1;
     } else if (b.status === 'Planned' && a.status !== 'Planned') {
@@ -72,7 +62,7 @@ export default function ScanningRoot(props) {
             });
         jobList = (
             <div className="jobs-list">
-                {jobs.sort(jobSorter)}
+                {jobs}
             </div>
         );
     }

--- a/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
@@ -4,6 +4,46 @@ import NewScanningJobContainer from '../containers/NewScanningJobContainer';
 import SoMPropTypes from '../prop-types';
 import ScanningJobPanel from './ScanningJobPanel';
 
+export function duration2milliseconds(duration) {
+    if (duration) {
+        return (duration.minutes * 60000) + (duration.hours * 3600000) + (duration.days * 86400000);
+    }
+    return 0;
+}
+
+export function getStatus(startTime, duration, now) {
+    const endTime = new Date(startTime) - -duration2milliseconds(duration);
+    if (!startTime) {
+        return 'Planned';
+    } else if (endTime > now - 0) {
+        return 'Running';
+    } else if (endTime > now - 3600000) {
+        return 'Completed';
+    }
+    return null;
+}
+
+export function jobSorter(a, b) {
+    console.log(a, b);
+    if (a.status === 'Planned' && b.status !== 'Planned') {
+        return -1;
+    } else if (b.status === 'Planned' && a.status !== 'Planned') {
+        return 1;
+    } else if (a.status === 'Planned') {
+        return 0;
+    } else if (a.status === 'Running' && b.status === 'Running') {
+        return new Date(a.startTime) - new Date(b.startTime);
+    } else if (a.status === 'Running') {
+        return -1;
+    } else if (b.status === 'Running') {
+        return 1;
+    }
+    return (
+        (new Date(b.startTime) - -duration2milliseconds(b.duration)) -
+        (new Date(a.startTime) - -duration2milliseconds(a.duration))
+    );
+}
+
 export default function ScanningRoot(props) {
     const { onStartJob } = props;
     let newJob = null;
@@ -16,18 +56,23 @@ export default function ScanningRoot(props) {
     let jobList = null;
     if (!newJob) {
         const jobs = [];
-        props.jobs.forEach((job) => {
-            const scanner = props.scanners.filter(s => s.identifier === job.scannerId)[0];
-            jobs.push(<ScanningJobPanel
-                onStartJob={() => onStartJob(job)}
-                key={job.name}
-                scanner={scanner}
-                {...job}
-            />);
-        });
+        const now = new Date();
+        props.jobs
+            .map(job => Object.assign({ status: getStatus(job.startTime, job.duration, now) }, job))
+            .filter(job => job.status)
+            .sort(jobSorter)
+            .forEach((job) => {
+                const scanner = props.scanners.filter(s => s.identifier === job.scannerId)[0];
+                jobs.push(<ScanningJobPanel
+                    onStartJob={() => onStartJob(job)}
+                    key={job.name}
+                    scanner={scanner}
+                    {...job}
+                />);
+            });
         jobList = (
             <div className="jobs-list">
-                {jobs}
+                {jobs.sort(jobSorter)}
             </div>
         );
     }

--- a/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
@@ -27,7 +27,7 @@ export function jobSorter(a, b) {
     } else if (b.status === 'Running') {
         return 1;
     }
-    return a.startTime - b.startTime;
+    return b.startTime - a.startTime;
 }
 
 export default function ScanningRoot(props) {

--- a/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
@@ -2,13 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import NewScanningJobContainer from '../containers/NewScanningJobContainer';
 import SoMPropTypes from '../prop-types';
-import ScanningJobPanel, { duration2milliseconds } from './ScanningJobPanel';
+import ScanningJobPanel from './ScanningJobPanel';
 
-export function getStatus(startTime, duration, now) {
-    const endTime = new Date(startTime) - -duration2milliseconds(duration);
+export function getStatus(startTime, endTime, now) {
     if (!startTime) {
         return 'Planned';
-    } else if (endTime > now - 0) {
+    } else if (endTime > now) {
         return 'Running';
     }
     return 'Completed';
@@ -22,16 +21,13 @@ export function jobSorter(a, b) {
     } else if (a.status === 'Planned') {
         return 0;
     } else if (a.status === 'Running' && b.status === 'Running') {
-        return new Date(a.startTime) - new Date(b.startTime);
+        return a.endTime - b.endTime;
     } else if (a.status === 'Running') {
         return -1;
     } else if (b.status === 'Running') {
         return 1;
     }
-    return (
-        (new Date(b.startTime) - -duration2milliseconds(b.duration)) -
-        (new Date(a.startTime) - -duration2milliseconds(a.duration))
-    );
+    return a.startTime - b.startTime;
 }
 
 export default function ScanningRoot(props) {
@@ -48,7 +44,7 @@ export default function ScanningRoot(props) {
         const jobs = [];
         const now = new Date();
         props.jobs
-            .map(job => Object.assign({ status: getStatus(job.startTime, job.duration, now) }, job))
+            .map(job => Object.assign({ status: getStatus(job.startTime, job.endTime, now) }, job))
             .filter(job => job.status)
             .sort(jobSorter)
             .forEach((job) => {

--- a/scanomatic/ui_server_data/js/src/containers/ScanningRootContainer.jsx
+++ b/scanomatic/ui_server_data/js/src/containers/ScanningRootContainer.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { getScanningJobs, startScanningJob } from '../api';
 import { getScannersWithOwned } from '../helpers';
 import ScanningRoot from '../components/ScanningRoot';
+import { duration2milliseconds } from '../components/ScanningJobPanel';
 
 
 export default class ScanningRootContainer extends React.Component {
@@ -29,7 +30,14 @@ export default class ScanningRootContainer extends React.Component {
             setTimeout(() => this.getJobStatusRequests(true), 10000);
         }
         getScanningJobs()
-            .then(jobs => this.setState({ jobs }))
+            .then(jobs => this.setState({
+                jobs: jobs.map(job => Object.assign({}, job, {
+                    startTime: job.startTime ? new Date(job.startTime) : null,
+                    endTime: job.startTime ?
+                        new Date(new Date(job.startTime) - -duration2milliseconds(job.duration)) :
+                        null,
+                })),
+            }))
             .catch(reason => this.setState({ error: `Error requesting jobs: ${reason}` }));
 
         getScannersWithOwned()
@@ -57,10 +65,18 @@ export default class ScanningRootContainer extends React.Component {
 
     handleStartJob(job) {
         const { jobs } = this.state;
-        const jobInQuestion = jobs.filter(j => j.identifier === job.identifier);
-        if (jobInQuestion.length === 1) {
-            jobInQuestion.disableStart = true;
-            this.setState({ jobs });
+        const newJobs = [];
+        let foundJob = false;
+        jobs.forEach((j) => {
+            if (j.identifier === job.identifier) {
+                newJobs.push(Object.assign({}, j, { disableStart: true }));
+                foundJob = true;
+            } else {
+                newJobs.push(job);
+            }
+        });
+        if (foundJob) {
+            this.setState({ jobs: newJobs });
         } else {
             this.setState({ error: `UI lost job '${job.name}'` });
             return;

--- a/scanomatic/ui_server_data/js/src/containers/ScanningRootContainer.jsx
+++ b/scanomatic/ui_server_data/js/src/containers/ScanningRootContainer.jsx
@@ -21,10 +21,13 @@ export default class ScanningRootContainer extends React.Component {
     }
 
     componentDidMount() {
-        this.getJobStatusRequests();
+        this.getJobStatusRequests(true);
     }
 
-    getJobStatusRequests() {
+    getJobStatusRequests(monitor) {
+        if (monitor) {
+            setTimeout(() => this.getJobStatusRequests(true), 10000);
+        }
         getScanningJobs()
             .then(jobs => this.setState({ jobs }))
             .catch(reason => this.setState({ error: `Error requesting jobs: ${reason}` }));

--- a/scanomatic/ui_server_data/js/src/containers/ScanningRootContainer.jsx
+++ b/scanomatic/ui_server_data/js/src/containers/ScanningRootContainer.jsx
@@ -63,13 +63,13 @@ export default class ScanningRootContainer extends React.Component {
         this.setState({ newJob: true });
     }
 
-    handleStartJob(job) {
+    handleStartJob(startingJob) {
         const { jobs } = this.state;
         const newJobs = [];
         let foundJob = false;
-        jobs.forEach((j) => {
-            if (j.identifier === job.identifier) {
-                newJobs.push(Object.assign({}, j, { disableStart: true }));
+        jobs.forEach((job) => {
+            if (job.identifier === startingJob.identifier) {
+                newJobs.push(Object.assign({}, job, { disableStart: true }));
                 foundJob = true;
             } else {
                 newJobs.push(job);
@@ -78,11 +78,11 @@ export default class ScanningRootContainer extends React.Component {
         if (foundJob) {
             this.setState({ jobs: newJobs });
         } else {
-            this.setState({ error: `UI lost job '${job.name}'` });
+            this.setState({ error: `UI lost job '${startingJob.name}'` });
             return;
         }
 
-        startScanningJob(job)
+        startScanningJob(startingJob)
             .then(() => {
                 this.getJobsStatus();
             })

--- a/scanomatic/ui_server_data/style/experiment.css
+++ b/scanomatic/ui_server_data/style/experiment.css
@@ -20,7 +20,7 @@ div.panel button {
   font-weight: bold;
 }
 
-div.panel-heading .label {
+.panel-heading .label {
   float: right;
 }
 

--- a/scanomatic/ui_server_data/style/experiment.css
+++ b/scanomatic/ui_server_data/style/experiment.css
@@ -17,6 +17,7 @@ div.panel button {
 
 div.panel-heading h3 {
   display: inline-block;
+  font-weight: bold;
 }
 
 div.panel-heading .label {
@@ -37,7 +38,14 @@ button.new-job {
   vertical-align: middle;
 }
 
-.job-status {
-  display: inline-block;
-  font-weight: bold;
+.job-description .progress {
+  margin-bottom: 0;
+}
+
+table.job-stats {
+  margin: 0.5em 0 0 0;
+}
+
+table.job-stats tr td:first-child {
+  background-color: #f5f5f5;
 }

--- a/scanomatic/ui_server_data/style/experiment.css
+++ b/scanomatic/ui_server_data/style/experiment.css
@@ -15,6 +15,14 @@ div.panel button {
   margin: 0.25em;
 }
 
+div.panel-heading h3 {
+  display: inline-block;
+}
+
+div.panel-heading .label {
+  float: right;
+}
+
 button.new-job {
   display: inline-block;
   margin-bottom: 0.5em;

--- a/scanomatic/ui_server_data/style/experiment.css
+++ b/scanomatic/ui_server_data/style/experiment.css
@@ -15,7 +15,7 @@ div.panel button {
   margin: 0.25em;
 }
 
-div.panel-heading h3 {
+.panel-title {
   display: inline-block;
   font-weight: bold;
 }

--- a/tests/system/test_scanjob.py
+++ b/tests/system/test_scanjob.py
@@ -5,6 +5,7 @@ import requests
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from time import sleep
 
 
 def test_compile_with_given_directory(scanomatic, browser):
@@ -15,6 +16,7 @@ def test_compile_with_given_directory(scanomatic, browser):
     start_scanjob(scanomatic, scanjobid)
     post_scan(scanomatic, scanjobid)
 
+    sleep(2)
     browser.get(scanomatic + '/experiment')
     browser.find_element_by_id('job-' + scanjobid).find_element_by_link_text(
         "Compile project".format(scanjobname)
@@ -32,6 +34,7 @@ def test_qc_with_given_directory(scanomatic, browser):
     scannerid = create_scanner(scanomatic)
     scanjobid = create_scanjob(scanomatic, scannerid, scanjobname)
 
+    sleep(2)
     browser.get(scanomatic + '/experiment')
     browser.find_element_by_id('job-' + scanjobid).find_element_by_link_text(
         "QC project".format(scanjobname)
@@ -63,7 +66,7 @@ def create_scanjob(scanomatic, scannerid, name):
         json={
             'name': name,
             'interval': 300,
-            'duration': 3600,
+            'duration': 1,
             'scannerId': scannerid,
         },
     )

--- a/tests/system/test_scanjob.py
+++ b/tests/system/test_scanjob.py
@@ -33,6 +33,7 @@ def test_qc_with_given_directory(scanomatic, browser):
 
     scannerid = create_scanner(scanomatic)
     scanjobid = create_scanjob(scanomatic, scannerid, scanjobname)
+    start_scanjob(scanomatic, scanjobid)
 
     sleep(2)
     browser.get(scanomatic + '/experiment')


### PR DESCRIPTION
- Adds some nice category labels to jobs.
- Adds a progress bar to running jobs
- Remakes the info about the job in to a nice table
- Adds sorting of jobs by category and then running by reverse chronological completion date and completed by reverse chronological started date.
- Makes the page live update every 10s
![screenshot from 2018-03-14 11-12-49](https://user-images.githubusercontent.com/8041100/37396264-afa7f9f2-2778-11e8-876c-bda1fec275e9.png)
