### PR TITLE
Add CalibrationStore implementatation using the database

### DIFF
--- a/scanomatic/data/calibrationstore.py
+++ b/scanomatic/data/calibrationstore.py
@@ -109,7 +109,7 @@ class CalibrationStore(object):
         )
 
     def update_calibration_image_with_id(self, calibrationid, imageid, values):
-        columns = {
+        updatable = {
             CCCImage.grayscale_name: 'grayscale_name',
             CCCImage.grayscale_source_values: 'grayscale_source_values',
             CCCImage.grayscale_target_values: 'grayscale_target_values',
@@ -117,7 +117,7 @@ class CalibrationStore(object):
             CCCImage.marker_x: 'marker_x',
             CCCImage.marker_y: 'marker_y',
         }
-        values = {columns[key]: value for key, value in values.items()}
+        values = {updatable[key]: value for key, value in values.items()}
         result = self._execute(
             self._images.update().where(
                 sa.and_(

--- a/scanomatic/data/calibrationstore.py
+++ b/scanomatic/data/calibrationstore.py
@@ -1,0 +1,301 @@
+from __future__ import absolute_import
+
+import sqlalchemy as sa
+from sqlalchemy.sql.expression import exists, select
+
+from scanomatic.io.ccc_data import (
+    CalibrationEntryStatus, CCCImage, CCCMeasurement, CCCPlate, CCCPolynomial,
+    CellCountCalibration, get_empty_ccc_entry, get_polynomal_entry
+)
+
+
+def dump_status(status):
+    return {
+        CalibrationEntryStatus.UnderConstruction: 'under construction',
+        CalibrationEntryStatus.Active: 'active',
+        CalibrationEntryStatus.Deleted: 'deleted',
+    }[status]
+
+
+class CalibrationStore(object):
+
+    class IntegrityError(Exception):
+        pass
+
+    def __init__(self, dbconnection, dbmetadata):
+        self._connection = dbconnection
+        self._calibrations = dbmetadata.tables['calibrations']
+        self._images = dbmetadata.tables['calibration_images']
+        self._plates = dbmetadata.tables['calibration_plates']
+        self._measurements = dbmetadata.tables['calibration_measurements']
+
+    def add_calibration(self, calibration):
+        status = dump_status(calibration[CellCountCalibration.status])
+        cccpolynomial = calibration.get(CellCountCalibration.polynomial)
+        if cccpolynomial is not None:
+            coefficients = cccpolynomial.get(CCCPolynomial.coefficients)
+        else:
+            coefficients = None
+        self._execute(
+            self._calibrations.insert().values(
+                id=calibration[CellCountCalibration.identifier],
+                species=calibration[CellCountCalibration.species],
+                reference=calibration[CellCountCalibration.reference],
+                status=status,
+                polynomial=coefficients,
+                edit_access_token=(
+                    calibration[CellCountCalibration.edit_access_token]
+                ),
+            )
+        )
+
+    def get_all_calibrations(self):
+        query = self._calibrations.select().order_by(self._calibrations.c.id)
+        return self._get_calibrations(query)
+
+    def get_calibration_by_id(self, id_):
+        query = self._calibrations.select().where(
+            self._calibrations.c.id == id_
+        )
+        for calibration in self._get_calibrations(query):
+            return calibration
+        else:
+            raise LookupError(id)
+
+    def _get_calibrations(self, query):
+        for row in self._execute(query):
+            calibration = get_empty_ccc_entry(
+                row['id'],
+                row['species'],
+                row['reference'],
+            )
+            calibration[CellCountCalibration.edit_access_token] = (
+                row['edit_access_token']
+            )
+            if row['polynomial'] is not None:
+                coefficients = row['polynomial']
+                power = len(coefficients) - 1
+                calibration[CellCountCalibration.polynomial] = (
+                    get_polynomal_entry(power, coefficients)
+                )
+            calibration[CellCountCalibration.status] = {
+                'active': CalibrationEntryStatus.Active,
+                'under construction': CalibrationEntryStatus.UnderConstruction,
+                'deleted': CalibrationEntryStatus.Deleted,
+            }[row['status']]
+            yield calibration
+
+    def has_calibration_with_id(self, id_):
+        return self._exists(
+            self._calibrations.select().where(self._calibrations.c.id == id_)
+        )
+
+    def set_calibration_polynomial(self, id_, polynomial):
+        if polynomial is not None:
+            coefficients = polynomial.get(CCCPolynomial.coefficients)
+        else:
+            coefficients = None
+        result = self._execute(
+            self._calibrations.update().where(self._calibrations.c.id == id_)
+            .values(polynomial=coefficients)
+        )
+        if result.rowcount == 0:
+            raise LookupError(id_)
+
+    def set_calibration_status(self, id_, status):
+        result = self._execute(
+            self._calibrations.update().where(self._calibrations.c.id == id_)
+            .values(status=dump_status(status))
+        )
+        if result.rowcount == 0:
+            raise LookupError(id_)
+
+    def add_image_to_calibration(self, calibrationid, imageid):
+        self._execute(
+            self._images.insert().values(
+                calibration_id=calibrationid,
+                id=imageid,
+            )
+        )
+
+    def update_calibration_image_with_id(self, calibrationid, imageid, values):
+        columns = {
+            CCCImage.grayscale_name: 'grayscale_name',
+            CCCImage.grayscale_source_values: 'grayscale_source_values',
+            CCCImage.grayscale_target_values: 'grayscale_target_values',
+            CCCImage.fixture: 'fixture',
+            CCCImage.marker_x: 'marker_x',
+            CCCImage.marker_y: 'marker_y',
+        }
+        values = {columns[key]: value for key, value in values.items()}
+        result = self._execute(
+            self._images.update().where(
+                sa.and_(
+                    self._images.c.calibration_id == calibrationid,
+                    self._images.c.id == imageid,
+                )
+            ).values(**values)
+        )
+        if result.rowcount == 0:
+            raise LookupError((calibrationid, imageid))
+
+    def count_images_for_calibration(self, calibrationid):
+        query = (
+            select([sa.func.count()]).select_from(self._images)
+            .where(self._images.c.calibration_id == calibrationid)
+        )
+        return self._execute(query).scalar()
+
+    def get_images_for_calibration(self, calibrationid):
+        query = (
+            self._images.select()
+            .where(self._images.c.calibration_id == calibrationid)
+        )
+        for row in self._execute(query):
+            yield {
+                CCCImage.identifier: row['id'],
+                CCCImage.grayscale_name: row['grayscale_name'],
+                CCCImage.grayscale_source_values:
+                row['grayscale_source_values'],
+                CCCImage.grayscale_target_values:
+                row['grayscale_target_values'],
+                CCCImage.fixture: row['fixture'],
+                CCCImage.marker_x: row['marker_x'],
+                CCCImage.marker_y: row['marker_y'],
+            }
+
+    def has_calibration_image_with_id(self, calibrationid, imageid):
+        return self._exists(
+            self._images.select().where(
+                sa.and_(
+                    self._images.c.id == imageid,
+                    self._images.c.calibration_id == calibrationid,
+                )
+            )
+        )
+
+    def add_plate(self, calibrationid, imageid, plateid, plate):
+        self._execute(
+            self._plates.insert().values(
+                calibration_id=calibrationid,
+                image_id=imageid,
+                id=plateid,
+                grid_cell_height=plate[CCCPlate.grid_cell_size][0],
+                grid_cell_width=plate[CCCPlate.grid_cell_size][1],
+                grid_rows=plate[CCCPlate.grid_shape][0],
+                grid_cols=plate[CCCPlate.grid_shape][1],
+            )
+        )
+
+    def update_plate(self, calibrationid, imageid, plateid, plate):
+        result = self._execute(
+            self._plates.update().where(
+                sa.and_(
+                    self._plates.c.id == plateid,
+                    self._plates.c.calibration_id == calibrationid,
+                    self._plates.c.image_id == imageid,
+                )
+            ).values(
+                grid_cell_height=plate[CCCPlate.grid_cell_size][0],
+                grid_cell_width=plate[CCCPlate.grid_cell_size][1],
+                grid_rows=plate[CCCPlate.grid_shape][0],
+                grid_cols=plate[CCCPlate.grid_shape][1],
+            )
+        )
+        if result.rowcount == 0:
+            raise LookupError((calibrationid, imageid, plateid))
+
+    def get_plate_grid_cell_size(self, calibrationid, imageid, plateid):
+        query = (
+            self._plates.select().where(
+                sa.and_(
+                    self._plates.c.id == plateid,
+                    self._plates.c.calibration_id == calibrationid,
+                    self._plates.c.image_id == imageid,
+                )
+            )
+        )
+        for row in self._execute(query):
+            return (row['grid_cell_height'], row['grid_cell_width'])
+        raise LookupError((calibrationid, imageid, plateid))
+
+    def has_plate_with_id(self, calibrationid, imageid, plateid):
+        return self._exists(
+            self._plates.select().where(
+                sa.and_(
+                    self._plates.c.id == plateid,
+                    self._plates.c.image_id == imageid,
+                    self._plates.c.calibration_id == calibrationid,
+                )
+            )
+        )
+
+    def set_measurement(
+        self, calibrationid, imageid, plateid, col, row, measurement
+    ):
+        where = sa.and_(
+            self._measurements.c.calibration_id == calibrationid,
+            self._measurements.c.image_id == imageid,
+            self._measurements.c.plate_id == plateid,
+            self._measurements.c.row == row,
+            self._measurements.c.col == col,
+        )
+        if self._exists(self._measurements.select().where(where)):
+            self._execute(
+                self._measurements.update().where(where).values(
+                    source_values=measurement[CCCMeasurement.source_values],
+                    source_value_counts=(
+                        measurement[CCCMeasurement.source_value_counts]
+                    ),
+                    cell_count=measurement[CCCMeasurement.cell_count],
+                )
+            )
+        else:
+            self._execute(
+                self._measurements.insert().values(
+                    calibration_id=calibrationid,
+                    image_id=imageid,
+                    plate_id=plateid,
+                    row=row,
+                    col=col,
+                    source_values=measurement[CCCMeasurement.source_values],
+                    source_value_counts=(
+                        measurement[CCCMeasurement.source_value_counts]
+                    ),
+                    cell_count=measurement[CCCMeasurement.cell_count],
+                )
+            )
+
+    def has_measurements_for_plate(self, calibrationid, imageid, plateid):
+        return self._exists(
+            self._measurements.select().where(
+                sa.and_(
+                    self._measurements.c.calibration_id == calibrationid,
+                    self._measurements.c.image_id == imageid,
+                    self._measurements.c.plate_id == plateid,
+                )
+            )
+        )
+
+    def get_measurements_for_calibration(self, calibrationid):
+        query = self._measurements.select().where(
+            self._measurements.c.calibration_id == calibrationid
+        ).order_by(
+            self._measurements.c.image_id, self._measurements.c.plate_id,
+            self._measurements.c.col, self._measurements.c.row
+        )
+        for row in self._execute(query):
+            yield {
+                CCCMeasurement.source_values: row['source_values'],
+                CCCMeasurement.source_value_counts: row['source_value_counts'],
+                CCCMeasurement.cell_count: row['cell_count'],
+            }
+
+    def _execute(self, query):
+        try:
+            return self._connection.execute(query)
+        except sa.exc.IntegrityError as e:
+            raise self.IntegrityError(e)
+
+    def _exists(self, query):
+        return self._connection.execute(exists(query).select()).scalar()

--- a/scanomatic/data/migrations/versions/f9a3e426a0ce_create_calibrations_tables.py
+++ b/scanomatic/data/migrations/versions/f9a3e426a0ce_create_calibrations_tables.py
@@ -38,6 +38,10 @@ def upgrade():
             'species', 'reference',
             name='uq_species_reference'
         ),
+        sa.CheckConstraint(
+            "status <> 'Active' OR polynomial IS NOT NULL",
+            name='calibrations_active_polynomial_check',
+        )
     )
     op.create_table(
         'calibration_images',

--- a/scanomatic/data/migrations/versions/f9a3e426a0ce_create_calibrations_tables.py
+++ b/scanomatic/data/migrations/versions/f9a3e426a0ce_create_calibrations_tables.py
@@ -1,0 +1,111 @@
+"""add calibrations tables
+
+Revision ID: f9a3e426a0ce
+Revises: 7c8828cac5fd
+Create Date: 2018-03-02 16:37:58.808247
+
+"""
+from __future__ import absolute_import
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy.dialects.postgresql as pg
+
+# revision identifiers, used by Alembic.
+revision = 'f9a3e426a0ce'
+down_revision = '7c8828cac5fd'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    calibrations_table = op.create_table(
+        'calibrations',
+        sa.Column('id', sa.Text(), primary_key=True),
+        sa.Column('species', sa.Text(), nullable=False),
+        sa.Column('reference', sa.Text(), nullable=False),
+        sa.Column(
+            'status',
+            sa.Enum(
+                'under construction', 'active', 'deleted',
+                name='calibration_status',
+            ),
+            nullable=False,
+        ),
+        sa.Column('polynomial', pg.ARRAY(sa.Float, dimensions=1)),
+        sa.Column('edit_access_token', sa.Text()),
+        sa.UniqueConstraint(
+            'species', 'reference',
+            name='uq_species_reference'
+        ),
+    )
+    op.create_table(
+        'calibration_images',
+        sa.Column('calibration_id', sa.Text(), primary_key=True),
+        sa.Column('id', sa.Text(), primary_key=True),
+        sa.Column('grayscale_name', sa.Text()),
+        sa.Column(
+            'grayscale_source_values', pg.ARRAY(sa.Float, dimensions=1)),
+        sa.Column(
+            'grayscale_target_values', pg.ARRAY(sa.Float, dimensions=1)),
+        sa.Column('fixture', sa.Text()),
+        sa.Column('marker_x', pg.ARRAY(sa.Float, dimensions=1)),
+        sa.Column('marker_y', pg.ARRAY(sa.Float, dimensions=1)),
+        sa.ForeignKeyConstraint(
+            ['calibration_id'],
+            ['calibrations.id'],
+            name='fk_calibration_images_calibration_key'
+        ),
+    )
+    op.create_table(
+        'calibration_plates',
+        sa.Column('calibration_id', sa.Text(), primary_key=True),
+        sa.Column('image_id', sa.Text(), primary_key=True),
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('grid_cell_width', sa.Float(), nullable=False),
+        sa.Column('grid_cell_height', sa.Float(), nullable=False),
+        sa.Column('grid_rows', sa.Integer(), nullable=False),
+        sa.Column('grid_cols', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['calibration_id', 'image_id'],
+            ['calibration_images.calibration_id', 'calibration_images.id'],
+            name='fk_calibration_plates_image_key',
+        ),
+    )
+    op.create_table(
+        'calibration_measurements',
+        sa.Column('calibration_id', sa.Text(), primary_key=True),
+        sa.Column('image_id', sa.Text(), primary_key=True),
+        sa.Column('plate_id', sa.Integer(), primary_key=True),
+        sa.Column('row', sa.Integer(), primary_key=True),
+        sa.Column('col', sa.Integer(), primary_key=True),
+        sa.Column(
+            'source_values', pg.ARRAY(sa.Float, dimensions=1), nullable=False),
+        sa.Column(
+            'source_value_counts',
+            pg.ARRAY(sa.Integer, dimensions=1),
+            nullable=False),
+        sa.Column('cell_count', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['calibration_id', 'image_id', 'plate_id'],
+            [
+                'calibration_plates.calibration_id',
+                'calibration_plates.image_id',
+                'calibration_plates.id',
+            ],
+            name='fk_calibration_measurements_plate_key',
+        ),
+    )
+    op.bulk_insert(calibrations_table, [{
+        'id': 'default',
+        'species': 'S. cerevisiae',
+        'reference': 'Zackrisson et. al. 2016',
+        'polynomial': [
+            3.379796310880545e-05, 0., 0., 0., 48.99061427688507, 0.
+        ],
+        'status': 'active',
+    }])
+
+
+def downgrade():
+    pass

--- a/scanomatic/data/migrations/versions/f9a3e426a0ce_create_calibrations_tables.py
+++ b/scanomatic/data/migrations/versions/f9a3e426a0ce_create_calibrations_tables.py
@@ -27,7 +27,7 @@ def upgrade():
         sa.Column(
             'status',
             sa.Enum(
-                'under construction', 'active', 'deleted',
+                'Active', 'Deleted', 'UnderConstruction',
                 name='calibration_status',
             ),
             nullable=False,
@@ -103,7 +103,7 @@ def upgrade():
         'polynomial': [
             3.379796310880545e-05, 0., 0., 0., 48.99061427688507, 0.
         ],
-        'status': 'active',
+        'status': 'Active',
     }])
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+
+from scanomatic.io import ccc_data
+from scanomatic.io.ccc_data import CalibrationEntryStatus, CellCountCalibration
+
+
+def make_calibration(
+    identifier='ccc000',
+    species='S. Kombuchae',
+    reference='Anonymous et al., 2020',
+    polynomial=[0, 1, 2, 3, 4, 5],
+    access_token='password',
+    active=False,
+):
+    ccc = ccc_data.get_empty_ccc_entry(identifier, species, reference)
+    if polynomial is not None:
+        ccc[CellCountCalibration.polynomial] = (
+            ccc_data.get_polynomal_entry(len(polynomial) - 1, polynomial)
+        )
+    ccc[CellCountCalibration.edit_access_token] = access_token
+    if active:
+        ccc[CellCountCalibration.status] = CalibrationEntryStatus.Active
+    else:
+        ccc[CellCountCalibration.status] = (
+            CalibrationEntryStatus.UnderConstruction
+        )
+    return ccc

--- a/tests/integration/data/test_calibrationstore.py
+++ b/tests/integration/data/test_calibrationstore.py
@@ -1,0 +1,750 @@
+from __future__ import absolute_import
+
+import pytest
+
+from scanomatic.data.calibrationstore import CalibrationStore
+from scanomatic.io.ccc_data import (
+    CalibrationEntryStatus, CCCImage, CCCMeasurement, CCCPlate,
+    CellCountCalibration, get_empty_ccc_entry, get_polynomal_entry
+)
+from tests.factories import make_calibration
+
+
+@pytest.fixture
+def store(dbconnection, dbmetadata):
+    return CalibrationStore(dbconnection, dbmetadata)
+
+
+def make_plate(grid_shape=(16, 24), grid_cell_size=(52.5, 53.1)):
+    return {
+        CCCPlate.grid_shape: grid_shape,
+        CCCPlate.grid_cell_size: grid_cell_size,
+    }
+
+
+@pytest.fixture
+def calibration01():
+    calibration = get_empty_ccc_entry(
+        'ccc001',
+        'S. Kombuchae',
+        'Anonymous et al., 2020',
+    )
+    calibration[CellCountCalibration.edit_access_token] = 'authorization001'
+    return calibration
+
+
+@pytest.fixture
+def calibration02():
+    calibration = get_empty_ccc_entry(
+        'ccc002',
+        'S. Kefirae',
+        'Anonymous et al., 2020',
+    )
+    calibration[CellCountCalibration.status] = CalibrationEntryStatus.Active
+    calibration[CellCountCalibration.polynomial] = (
+        get_polynomal_entry(3, [0, 1.1, 2.2, 3.3])
+    )
+    calibration[CellCountCalibration.edit_access_token] = None
+    return calibration
+
+
+class TestAddCalibration:
+
+    def test_add_under_construction(self, dbconnection, store):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001',
+                species='S. Kombuchae',
+                reference='Anonymous et al., 2020',
+                active=False,
+                polynomial=None,
+                access_token='authorization001',
+            )
+        )
+        assert (
+            list(
+                dbconnection.execute(
+                    ''' SELECT id, species, reference, status, polynomial,
+                              edit_access_token
+                        FROM calibrations
+                        WHERE id = 'ccc001'
+                    '''
+                )
+            ) == [(
+                'ccc001',
+                'S. Kombuchae',
+                'Anonymous et al., 2020',
+                'under construction',
+                None,
+                'authorization001',
+            )]
+        )
+
+    def test_add_active_calibration(self, dbconnection, store):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001',
+                species='S. Kombuchae',
+                reference='Anonymous et al., 2020',
+                active=True,
+                polynomial=[1, 2, 3],
+                access_token='authorization001',
+            )
+        )
+        assert list(
+            dbconnection.execute(
+                ''' SELECT id, species, reference, status, polynomial,
+                           edit_access_token
+                    FROM calibrations
+                    WHERE id = 'ccc001'
+                '''
+            )
+        ) == [(
+            'ccc001',
+            'S. Kombuchae',
+            'Anonymous et al., 2020',
+            'active',
+            [1, 2, 3],
+            'authorization001',
+        )]
+
+    def test_add_duplicate_id(self, store):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001',
+                species='S. Kombuchae',
+                reference='Anonymous et al., 2020',
+            )
+        )
+        with pytest.raises(CalibrationStore.IntegrityError):
+            store.add_calibration(
+                make_calibration(
+                    identifier='ccc001',
+                    species='S. Kombuchae',
+                    reference='Anonymous et al., 2021',
+                )
+            )
+
+    def test_add_duplicate_species_and_reference(self, store):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001',
+                species='S. Kombuchae',
+                reference='Anonymous et al., 2020',
+            )
+        )
+        with pytest.raises(CalibrationStore.IntegrityError):
+            store.add_calibration(
+                make_calibration(
+                    identifier='ccc002',
+                    species='S. Kombuchae',
+                    reference='Anonymous et al., 2020',
+                )
+            )
+
+
+class TestGetCalibrationById:
+
+    def test_get_under_construction_calibration(self, store):
+        calibration = make_calibration(
+            identifier='ccc001',
+            active=False,
+        )
+        store.add_calibration(calibration)
+        assert store.get_calibration_by_id('ccc001') == calibration
+
+    def test_get_active_calibration(self, store):
+        calibration = make_calibration(
+            identifier='ccc001',
+            active=True,
+            polynomial=[2, 3, 2],
+        )
+        store.add_calibration(calibration)
+        assert store.get_calibration_by_id('ccc001') == calibration
+
+    def test_get_unknown_id(self, store):
+        with pytest.raises(LookupError):
+            store.get_calibration_by_id('unknown')
+
+
+class TestGetAllCalibrations:
+
+    def test_get_all(self, store):
+        calibration1 = make_calibration(
+            identifier='ccc001', species='S. Kombuchae'
+        )
+        calibration2 = make_calibration(
+            identifier='ccc002', species='S. Kefirae'
+        )
+        default = make_calibration(
+            identifier='default',
+            species='S. cerevisiae',
+            reference='Zackrisson et. al. 2016',
+            polynomial=[
+                3.37979631088055e-05, 0.0, 0.0, 0.0, 48.9906142768851, 0.0
+            ],
+            access_token=None,
+            active=True
+        )
+        store.add_calibration(calibration1)
+        store.add_calibration(calibration2)
+        assert list(store.get_all_calibrations()) == [
+            calibration1,
+            calibration2,
+            default,
+        ]
+
+
+class TestHasCalibrationWithId:
+
+    def test_exists(self, store):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        assert store.has_calibration_with_id('ccc001')
+
+    def test_doesnt_exists(self, store):
+        assert not store.has_calibration_with_id('unknown')
+
+
+class TestSetCalibrationPolynomial:
+
+    def test_set(self, store, calibration01, dbconnection):
+        calibration = make_calibration(identifier='ccc001', polynomial=None)
+        store.add_calibration(calibration)
+        polynomial = get_polynomal_entry(1, [1, 2])
+        store.set_calibration_polynomial('ccc001', polynomial)
+        assert list(
+            dbconnection.execute(
+                ''' SELECT polynomial
+                    FROM calibrations
+                    WHERE id='ccc001'
+                '''
+            )
+        ) == [([1, 2],)]
+
+    def test_set_to_none(self, store, calibration01, dbconnection):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001', polynomial=[1, 2, 3]
+            )
+        )
+        store.set_calibration_polynomial('ccc001', None)
+        assert list(
+            dbconnection.execute(
+                ''' SELECT polynomial
+                    FROM calibrations
+                    WHERE id='ccc001'
+                '''
+            )
+        ) == [(None,)]
+
+    def test_set_unknown(self, store):
+        with pytest.raises(LookupError):
+            store.set_calibration_polynomial('unknown', None)
+
+
+class TestSetCalibrationStatus:
+
+    def test_activate(self, store, dbconnection):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001', active=False
+            )
+        )
+        store.set_calibration_status('ccc001', CalibrationEntryStatus.Active)
+        assert list(
+            dbconnection.execute(
+                ''' SELECT status
+                    FROM calibrations
+                    WHERE id='ccc001'
+                '''
+            )
+        ) == [('active',)]
+
+    def test_delete(self, store, dbconnection):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001', active=False
+            )
+        )
+        store.set_calibration_status('ccc001', CalibrationEntryStatus.Deleted)
+        assert list(
+            dbconnection.execute(
+                ''' SELECT status
+                    FROM calibrations
+                    WHERE id='ccc001'
+                '''
+            )
+        ) == [('deleted',)]
+
+    def test_activate_unknown(self, store):
+        with pytest.raises(LookupError):
+            store.set_calibration_status(
+                'unknown', CalibrationEntryStatus.Active
+            )
+
+
+class TestAddImageToCalibration:
+
+    def test_add_image(self, store, dbconnection):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'image001')
+        assert list(
+            dbconnection.execute(
+                ''' SELECT calibration_id, id
+                    FROM calibration_images
+                '''
+            )
+        ) == [('ccc001', 'image001')]
+
+    def test_add_two_images(self, store, dbconnection):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'image001')
+        store.add_image_to_calibration('ccc001', 'image010')
+        assert list(
+            dbconnection.execute(
+                ''' SELECT calibration_id, id
+                    FROM calibration_images
+                '''
+            )
+        ) == [('ccc001', 'image001'), ('ccc001', 'image010')]
+
+    def test_unknown_calibration(self, store):
+        with pytest.raises(CalibrationStore.IntegrityError):
+            store.add_image_to_calibration('ccc001', 'image001')
+
+    def test_duplicate_image_id(self, store):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'image001')
+        with pytest.raises(CalibrationStore.IntegrityError):
+            store.add_image_to_calibration('ccc001', 'image001')
+
+    def test_add_same_id_different_calibration(self, store, dbconnection):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001', species='x'
+            )
+        )
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc002', species='y'
+            )
+        )
+        store.add_image_to_calibration('ccc001', 'image001')
+        store.add_image_to_calibration('ccc002', 'image001')
+        assert list(
+            dbconnection.execute(
+                ''' SELECT calibration_id, id
+                    FROM calibration_images
+                '''
+            )
+        ) == [('ccc001', 'image001'), ('ccc002', 'image001')]
+
+
+class TestUpdateCalibrationImageWithId:
+
+    def test_update(self, store, dbconnection):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.update_calibration_image_with_id(
+            'ccc001', 'img001', {
+                CCCImage.grayscale_name: 'kodak',
+                CCCImage.grayscale_source_values: [1, 2, 3],
+                CCCImage.grayscale_target_values: [4, 5, 6],
+                CCCImage.fixture: 'myFixture',
+                CCCImage.marker_x: [0, 0, 2],
+                CCCImage.marker_y: [1, 0, 1],
+            }
+        )
+        assert list(
+            dbconnection.execute(
+                ''' SELECT grayscale_name, grayscale_source_values,
+                           grayscale_target_values, fixture, marker_x, marker_y
+                    FROM calibration_images
+                '''
+            )
+        ) == [
+            ('kodak', [1, 2, 3], [4, 5, 6], 'myFixture', [0, 0, 2], [1, 0, 1])
+        ]
+
+    def test_unknown(self, store, dbconnection):
+        with pytest.raises(LookupError):
+            store.update_calibration_image_with_id(
+                'ccc001', 'img001', {CCCImage.grayscale_name: 'kodak'}
+            )
+
+
+class TestCountImagesForCalibration:
+
+    def test_no_images(self, store):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        assert store.count_images_for_calibration('ccc001') == 0
+
+    def test_images(self, store):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'image001')
+        store.add_image_to_calibration('ccc001', 'image002')
+        assert store.count_images_for_calibration('ccc001') == 2
+
+    def test_multiple_calibrations(self, store):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001', species='x'
+            )
+        )
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc002', species='y'
+            )
+        )
+        store.add_image_to_calibration('ccc001', 'image001')
+        store.add_image_to_calibration('ccc001', 'image002')
+        store.add_image_to_calibration('ccc002', 'image003')
+        assert store.count_images_for_calibration('ccc001') == 2
+
+
+class TestGetImagesForCalibration:
+
+    def test_get_images(self, store):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001', species='x'
+            )
+        )
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc002', species='y'
+            )
+        )
+        store.add_image_to_calibration('ccc001', 'image001')
+        store.add_image_to_calibration('ccc001', 'image002')
+        store.add_image_to_calibration('ccc002', 'image003')
+        store.update_calibration_image_with_id(
+            'ccc001', 'image001', {
+                CCCImage.grayscale_name: 'kodak',
+                CCCImage.grayscale_source_values: [1, 2, 3],
+                CCCImage.grayscale_target_values: [4, 5, 6],
+                CCCImage.fixture: 'myFixture',
+                CCCImage.marker_x: [0, 0, 2],
+                CCCImage.marker_y: [1, 0, 1],
+            }
+        )
+        assert list(store.get_images_for_calibration('ccc001')) == [{
+            CCCImage.identifier: 'image001',
+            CCCImage.grayscale_name: 'kodak',
+            CCCImage.grayscale_source_values: [1, 2, 3],
+            CCCImage.grayscale_target_values: [4, 5, 6],
+            CCCImage.fixture: 'myFixture',
+            CCCImage.marker_x: [0, 0, 2],
+            CCCImage.marker_y: [1, 0, 1],
+        }, {
+            CCCImage.identifier: 'image002',
+            CCCImage.grayscale_name: None,
+            CCCImage.grayscale_source_values: None,
+            CCCImage.grayscale_target_values: None,
+            CCCImage.fixture: None,
+            CCCImage.marker_x: None,
+            CCCImage.marker_y: None,
+        }]
+
+
+class TestHasCalibrationImageWithId:
+
+    def test_exists(self, store):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'image001')
+        assert store.has_calibration_image_with_id('ccc001', 'image001')
+
+    @pytest.mark.parametrize(
+        'calibrationid, imageid', [
+            ('unknown', 'unknown'),
+            ('unknown', 'image001'),
+            ('ccc001', 'unknown'),
+        ]
+    )
+    def test_doesnt_exists(self, store, calibrationid, imageid):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'image001')
+        assert not store.has_calibration_image_with_id(calibrationid, imageid)
+
+
+class TestAddPlate:
+
+    def test_add(self, store, dbconnection):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.add_plate(
+            'ccc001',
+            'img001',
+            1,
+            make_plate(
+                grid_shape=(16, 24),
+                grid_cell_size=(52.5, 53.1),
+            )
+        )
+        assert list(
+            dbconnection.execute(
+                ''' SELECT calibration_id, image_id, id,
+                           grid_cell_height, grid_cell_width,
+                           grid_rows, grid_cols
+                    FROM calibration_plates
+                '''
+            )
+        ) == [('ccc001', 'img001', 1, 52.5, 53.1, 16, 24)]
+
+    def test_unknown_image(self, store):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        with pytest.raises(CalibrationStore.IntegrityError):
+            store.add_plate('ccc001', 'img001', 1, make_plate())
+
+    def test_duplicate_plate(self, store):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.add_plate('ccc001', 'img001', 1, make_plate())
+        with pytest.raises(CalibrationStore.IntegrityError):
+            store.add_plate('ccc001', 'img001', 1, make_plate())
+
+
+class TestUpdatePlateWithId:
+
+    def test_update(self, store, dbconnection):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.add_plate(
+            'ccc001',
+            'img001',
+            1,
+            make_plate(
+                grid_shape=(16, 24),
+                grid_cell_size=(52.5, 53.1),
+            )
+        )
+        store.add_plate(
+            'ccc001',
+            'img001',
+            2,
+            make_plate(
+                grid_shape=(16, 24),
+                grid_cell_size=(52.5, 53.1),
+            )
+        )
+        store.update_plate(
+            'ccc001', 'img001', 1, {
+                CCCPlate.grid_shape: (12, 32),
+                CCCPlate.grid_cell_size: (128, 256),
+            }
+        )
+        assert list(
+            dbconnection.execute(
+                ''' SELECT calibration_id, image_id, id,
+                           grid_cell_height, grid_cell_width,
+                           grid_rows, grid_cols
+                    FROM calibration_plates
+                    ORDER BY id
+                '''
+            )
+        ) == [
+            ('ccc001', 'img001', 1, 128, 256, 12, 32),
+            ('ccc001', 'img001', 2, 52.5, 53.1, 16, 24),
+        ]
+
+    def test_unknown_plate(self, store):
+        with pytest.raises(LookupError):
+            store.update_plate(
+                'unknown', 'unknown', 1, {
+                    CCCPlate.grid_shape: (12, 32),
+                    CCCPlate.grid_cell_size: (128, 256),
+                }
+            )
+
+
+class TestGetPlateGridCellSize:
+
+    def test_get(self, store):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.add_plate(
+            'ccc001', 'img001', 1, make_plate(
+                grid_cell_size=(52.5, 53.1),
+            )
+        )
+        assert (
+            store.get_plate_grid_cell_size(
+                'ccc001',
+                'img001',
+                1,
+            ) == (52.5, 53.1)
+        )
+
+    def test_unknown_plate(self, store):
+        with pytest.raises(LookupError):
+            store.get_plate_grid_cell_size('ccc001', 'img001', 1)
+
+
+class TestHasPlateWithId:
+
+    def test_exist(self, store):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.add_plate('ccc001', 'img001', 1, make_plate())
+        assert store.has_plate_with_id('ccc001', 'img001', 1)
+
+    @pytest.mark.parametrize(
+        'key', [
+            ('ccc001', 'image001', 0),
+            ('ccc001', 'unknown', 1),
+            ('unknown', 'image001', 1),
+        ]
+    )
+    def test_unknown(self, store, key):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.add_plate('ccc001', 'img001', 1, make_plate())
+        assert not store.has_plate_with_id(*key)
+
+
+class TestSetMeasurement:
+
+    def test_insert(self, store, dbconnection):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.add_plate('ccc001', 'img001', 1, make_plate())
+        store.set_measurement(
+            'ccc001', 'img001', 1, 2, 3, {
+                CCCMeasurement.source_values: [4.1, 5.2, 6.3],
+                CCCMeasurement.source_value_counts: [7, 8, 9],
+                CCCMeasurement.cell_count: 123456,
+            }
+        )
+        assert list(
+            dbconnection.execute(
+                ''' SELECT calibration_id, image_id, plate_id, col, row,
+                           source_values, source_value_counts, cell_count
+                    FROM calibration_measurements
+                '''
+            )
+        ) == [('ccc001', 'img001', 1, 2, 3, [4.1, 5.2, 6.3], [7, 8, 9], 123456)]
+
+    def test_replace(self, store, dbconnection):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.add_plate('ccc001', 'img001', 1, make_plate())
+        store.set_measurement(
+            'ccc001', 'img001', 1, 2, 3, {
+                CCCMeasurement.source_values: [4.1, 5.2, 6.3],
+                CCCMeasurement.source_value_counts: [7, 8, 9],
+                CCCMeasurement.cell_count: 123456,
+            }
+        )
+        store.set_measurement(
+            'ccc001', 'img001', 1, 2, 4, {
+                CCCMeasurement.source_values: [4.1, 5.2, 6.3],
+                CCCMeasurement.source_value_counts: [7, 8, 9],
+                CCCMeasurement.cell_count: 123456,
+            }
+        )
+        store.set_measurement(
+            'ccc001', 'img001', 1, 2, 3, {
+                CCCMeasurement.source_values: [4.4, 5.5, 6.6],
+                CCCMeasurement.source_value_counts: [9, 8, 7],
+                CCCMeasurement.cell_count: 654321,
+            }
+        )
+        assert list(
+            dbconnection.execute(
+                ''' SELECT calibration_id, image_id, plate_id, col, row,
+                           source_values, source_value_counts, cell_count
+                    FROM calibration_measurements
+                    ORDER BY row
+                '''
+            )
+        ) == [
+            ('ccc001', 'img001', 1, 2, 3, [4.4, 5.5, 6.6], [9, 8, 7], 654321),
+            ('ccc001', 'img001', 1, 2, 4, [4.1, 5.2, 6.3], [7, 8, 9], 123456),
+        ]
+
+    def test_unknown_plate(self, store):
+        with pytest.raises(CalibrationStore.IntegrityError):
+            store.set_measurement(
+                'ccc001', 'img001', 1, 2, 3, {
+                    CCCMeasurement.source_values: [4.1, 5.2, 6.3],
+                    CCCMeasurement.source_value_counts: [7, 8, 9],
+                    CCCMeasurement.cell_count: 123456,
+                }
+            )
+
+
+class TestHasMeasurementsForPlate:
+
+    def test_exists(self, store):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.add_plate('ccc001', 'img001', 1, make_plate())
+        store.set_measurement(
+            'ccc001', 'img001', 1, 2, 3, {
+                CCCMeasurement.source_values: [4.1, 5.2, 6.3],
+                CCCMeasurement.source_value_counts: [7, 8, 9],
+                CCCMeasurement.cell_count: 123456,
+            }
+        )
+        assert store.has_measurements_for_plate('ccc001', 'img001', 1)
+
+    @pytest.mark.parametrize(
+        'key', [
+            ('unknown', 'img001', 1),
+            ('ccc001', 'unknown', 1),
+            ('ccc001', 'img001', 0),
+        ]
+    )
+    def test_doesnt_exist(self, store, key):
+        store.add_calibration(make_calibration(identifier='ccc001'))
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.add_plate('ccc001', 'img001', 1, make_plate())
+        store.set_measurement(
+            'ccc001', 'img001', 1, 2, 3, {
+                CCCMeasurement.source_values: [4.1, 5.2, 6.3],
+                CCCMeasurement.source_value_counts: [7, 8, 9],
+                CCCMeasurement.cell_count: 123456,
+            }
+        )
+        assert not store.has_measurements_for_plate(*key)
+
+
+class TestGetMeasurementsForCalibration:
+
+    def test_get(self, store):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001', species='x'
+            )
+        )
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc002', species='y'
+            )
+        )
+        store.add_image_to_calibration('ccc001', 'img001')
+        store.add_image_to_calibration('ccc002', 'img002')
+        store.add_plate('ccc001', 'img001', 1, make_plate())
+        store.add_plate('ccc002', 'img002', 1, make_plate())
+        measurement1 = {
+            CCCMeasurement.source_values: [4.1, 5.2, 6.3],
+            CCCMeasurement.source_value_counts: [7, 8, 9],
+            CCCMeasurement.cell_count: 123456,
+        }
+        measurement2 = {
+            CCCMeasurement.source_values: [7.1, 8.2, 9.3],
+            CCCMeasurement.source_value_counts: [4, 5, 6],
+            CCCMeasurement.cell_count: 4567899,
+        }
+        measurement3 = {
+            CCCMeasurement.source_values: [4.4, 5.5, 6.6],
+            CCCMeasurement.source_value_counts: [9, 8, 7],
+            CCCMeasurement.cell_count: 654321,
+        }
+        store.set_measurement('ccc001', 'img001', 1, 1, 1, measurement1)
+        store.set_measurement('ccc001', 'img001', 1, 1, 2, measurement2)
+        store.set_measurement('ccc002', 'img002', 1, 1, 1, measurement3)
+        assert (
+            list(store.get_measurements_for_calibration('ccc001')) ==
+            [measurement1, measurement2]
+        )

--- a/tests/integration/data/test_calibrationstore.py
+++ b/tests/integration/data/test_calibrationstore.py
@@ -241,13 +241,23 @@ class TestSetCalibrationPolynomial:
         with pytest.raises(LookupError):
             store.set_calibration_polynomial('unknown', None)
 
+    def test_set_to_none_activated_scanjob(self, store, dbconnection):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001', active=True,
+            )
+        )
+        with pytest.raises(store.IntegrityError):
+            store.set_calibration_polynomial('ccc001', None)
+
+
 
 class TestSetCalibrationStatus:
 
     def test_activate(self, store, dbconnection):
         store.add_calibration(
             make_calibration(
-                identifier='ccc001', active=False
+                identifier='ccc001', active=False, polynomial=[1, 2, 3],
             )
         )
         store.set_calibration_status('ccc001', CalibrationEntryStatus.Active)
@@ -280,6 +290,18 @@ class TestSetCalibrationStatus:
         with pytest.raises(LookupError):
             store.set_calibration_status(
                 'unknown', CalibrationEntryStatus.Active
+            )
+
+    def test_activate_without_polynomial(self, store, dbconnection):
+        store.add_calibration(
+            make_calibration(
+                identifier='ccc001', active=False, polynomial=None,
+            )
+        )
+        with pytest.raises(store.IntegrityError):
+            store.set_calibration_status(
+                'ccc001',
+                CalibrationEntryStatus.Active,
             )
 
 

--- a/tests/integration/data/test_calibrationstore.py
+++ b/tests/integration/data/test_calibrationstore.py
@@ -251,7 +251,6 @@ class TestSetCalibrationPolynomial:
             store.set_calibration_polynomial('ccc001', None)
 
 
-
 class TestSetCalibrationStatus:
 
     def test_activate(self, store, dbconnection):
@@ -644,7 +643,9 @@ class TestSetMeasurement:
                     FROM calibration_measurements
                 '''
             )
-        ) == [('ccc001', 'img001', 1, 2, 3, [4.1, 5.2, 6.3], [7, 8, 9], 123456)]
+        ) == [
+            ('ccc001', 'img001', 1, 2, 3, [4.1, 5.2, 6.3], [7, 8, 9], 123456)
+        ]
 
     def test_replace(self, store, dbconnection):
         store.add_calibration(make_calibration(identifier='ccc001'))

--- a/tests/integration/data/test_calibrationstore.py
+++ b/tests/integration/data/test_calibrationstore.py
@@ -74,7 +74,7 @@ class TestAddCalibration:
                 'ccc001',
                 'S. Kombuchae',
                 'Anonymous et al., 2020',
-                'under construction',
+                'UnderConstruction',
                 None,
                 'authorization001',
             )]
@@ -103,7 +103,7 @@ class TestAddCalibration:
             'ccc001',
             'S. Kombuchae',
             'Anonymous et al., 2020',
-            'active',
+            'Active',
             [1, 2, 3],
             'authorization001',
         )]
@@ -258,7 +258,7 @@ class TestSetCalibrationStatus:
                     WHERE id='ccc001'
                 '''
             )
-        ) == [('active',)]
+        ) == [('Active',)]
 
     def test_delete(self, store, dbconnection):
         store.add_calibration(
@@ -274,7 +274,7 @@ class TestSetCalibrationStatus:
                     WHERE id='ccc001'
                 '''
             )
-        ) == [('deleted',)]
+        ) == [('Deleted',)]
 
     def test_activate_unknown(self, store):
         with pytest.raises(LookupError):


### PR DESCRIPTION
Add migration script to create the tables, `CalibrationStore` and integration tests.

I didn't change the data model itself: the information stored in the database is the same as what was in the `.ccc` files and with approximately the same structure.

The default calibration is added to the database directly as part of the migration. This makes the code simpler (no special cases) but the tests have to take it into account.