### PR TITLE
Delete scanjob API

### DIFF
--- a/scanomatic/data/scanjobstore.py
+++ b/scanomatic/data/scanjobstore.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 from pytz import utc
 import sqlalchemy as sa
 from sqlalchemy.sql import and_
@@ -54,6 +55,13 @@ class ScanJobStore(object):
             )
         except sa.exc.IntegrityError as e:
             raise self.IntegrityError(e)
+        if result.rowcount < 1:
+            raise LookupError(id_)
+
+    def delete_scanjob(self, id_):
+        result = self._connection.execute(
+            self._table.delete().where(self._table.c.id == id_)
+        )
         if result.rowcount < 1:
             raise LookupError(id_)
 

--- a/scanomatic/scanning/delete_scanjob.py
+++ b/scanomatic/scanning/delete_scanjob.py
@@ -1,0 +1,17 @@
+from .exceptions import UnknownScanjobError
+
+
+class DeleteScanjobError(Exception):
+    pass
+
+
+def delete_scanjob(scanjob_store, scanjob_id):
+    try:
+        scanjob = scanjob_store.get_scanjob_by_id(scanjob_id)
+    except LookupError:
+        raise UnknownScanjobError('No scanjob with id "{}"'.format(scanjob_id))
+    if scanjob.start_time is not None:
+        raise DeleteScanjobError(
+            'Scanjob {} has been started, cannot delete'.format(scanjob_id)
+        )
+    scanjob_store.delete_scanjob(scanjob_id)

--- a/scanomatic/scanning/exceptions.py
+++ b/scanomatic/scanning/exceptions.py
@@ -1,0 +1,2 @@
+class UnknownScanjobError(Exception):
+    pass

--- a/scanomatic/scanning/terminate_scanjob.py
+++ b/scanomatic/scanning/terminate_scanjob.py
@@ -2,12 +2,10 @@ from datetime import datetime
 
 from pytz import utc
 
+from .exceptions import UnknownScanjobError
+
 
 class TerminateScanJobError(Exception):
-    pass
-
-
-class UnknownScanjobError(Exception):
     pass
 
 

--- a/scanomatic/ui_server/scan_jobs_api.py
+++ b/scanomatic/ui_server/scan_jobs_api.py
@@ -10,8 +10,12 @@ import pytz
 from werkzeug.exceptions import BadRequest, NotFound
 
 from scanomatic.models.scanjob import ScanJob
+from scanomatic.scanning.delete_scanjob import (
+    DeleteScanjobError, delete_scanjob
+)
+from scanomatic.scanning.exceptions import UnknownScanjobError
 from scanomatic.scanning.terminate_scanjob import (
-    TerminateScanJobError, UnknownScanjobError, terminate_scanjob
+    TerminateScanJobError, terminate_scanjob
 )
 from . import database
 from .general import json_abort
@@ -87,6 +91,7 @@ def scan_jobs_list():
 
 
 class ScanJobDocument(Resource):
+
     def get(self, scanjobid):
         scanjobstore = database.getscanjobstore()
         try:
@@ -94,6 +99,15 @@ class ScanJobDocument(Resource):
         except KeyError:
             raise NotFound
         return job2json(job)
+
+    def delete(self, scanjobid):
+        scanjobstore = database.getscanjobstore()
+        try:
+            delete_scanjob(scanjobstore, scanjobid)
+        except UnknownScanjobError:
+            raise NotFound
+        except DeleteScanjobError as e:
+            raise BadRequest(str(e))
 
 
 class ScanJobStartController(Resource):

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -73,6 +73,9 @@ def apiclient(client):
                 content_type='application/json',
             )
 
+        def delete_scan_job(self, jobid):
+            return client.delete('/scan-jobs/{}'.format(jobid))
+
         def get_scanner_job(self, scannerid):
             return client.get('/scanners/{}/job'.format(scannerid))
 

--- a/tests/integration/data/test_scanjobstore.py
+++ b/tests/integration/data/test_scanjobstore.py
@@ -163,6 +163,30 @@ class TestTerminateScanjob:
             store.terminate_scanjob('scnjb001', termination_time, "Message")
 
 
+class TestDeleteScanJob:
+    def test_delete_scanjob(self, store, dbconnection):
+        dbconnection.execute(
+            '''
+            INSERT INTO scanners(id) values ('scanner001');
+            INSERT INTO scanjobs(id, scanner_id, name, duration, interval)
+            VALUES ('scnjb001', 'scanner001', 'Test Scanjob', '5 minutes',
+                    '1 minute');
+            '''
+        )
+        store.delete_scanjob('scnjb001')
+        assert list(
+            dbconnection.execute(
+                '''
+                SELECT * FROM scanjobs WHERE id = 'scnjb001'
+                '''
+            )
+        ) == []
+
+    def test_delete_unknown(self, store):
+        with pytest.raises(LookupError):
+            store.delete_scanjob('unknown')
+
+
 @pytest.mark.usefixtures('insert_test_scanjobs')
 class TestHasScanJobWithName:
     def test_exists(self, store, scanjob01):

--- a/tests/unit/scanning/test_delete_scanjob.py
+++ b/tests/unit/scanning/test_delete_scanjob.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta
+
+from mock import MagicMock
+import pytest
+from pytz import utc
+
+from scanomatic.data.scanjobstore import ScanJobStore
+from scanomatic.models.scanjob import ScanJob
+from scanomatic.scanning.delete_scanjob import (
+    DeleteScanjobError, delete_scanjob
+)
+from scanomatic.scanning.exceptions import UnknownScanjobError
+
+
+def make_scanjob(start_time=None):
+    return ScanJob(
+        identifier='scjb001',
+        name='Test Scanjob',
+        duration=timedelta(minutes=20),
+        interval=timedelta(minutes=5),
+        scanner_id='scnr002',
+        start_time=start_time,
+    )
+
+
+def test_delete_unstarted_scanjob():
+    scanjob_store = MagicMock(spec=ScanJobStore)
+    scanjob_store.get_scanjob_by_id.return_value = make_scanjob(
+        start_time=None,
+    )
+    delete_scanjob(scanjob_store, 'scjb001')
+    scanjob_store.delete_scanjob.assert_called_with('scjb001')
+
+
+def test_delete_unknown_scanjob():
+    scanjob_store = MagicMock(spec=ScanJobStore)
+    scanjob_store.get_scanjob_by_id.side_effect = LookupError
+    with pytest.raises(
+        UnknownScanjobError, match='No scanjob with id "scjb001"'
+    ):
+        delete_scanjob(scanjob_store, 'scjb001')
+    scanjob_store.delete_scanjob.assert_not_called()
+
+
+def test_delete_started_scanjob():
+    scanjob_store = MagicMock(spec=ScanJobStore)
+    scanjob_store.get_scanjob_by_id.return_value = make_scanjob(
+        start_time=datetime(
+            1985, 10, 26, 1, 20, tzinfo=utc
+        )
+    )
+    with pytest.raises(
+        DeleteScanjobError,
+        match='Scanjob scjb001 has been started, cannot delete'
+    ):
+        delete_scanjob(scanjob_store, 'scjb001')
+    scanjob_store.delete_scanjob.assert_not_called()


### PR DESCRIPTION
Add API endpoint `DELETE /api/scan-jobs/$ID` that removes the scanjob from the database. It checks that the scanjob hasn't started yet.