### PR TITLE
Add --scanomati-url option to tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,12 @@ def pytest_addoption(parser):
         choices=['firefox', 'chrome'],
         default='firefox',
     )
+    parser.addoption(
+        '--scanomatic-url',
+        action='store',
+        help='''Run system tests againt the provided URL instead of starting
+                scan-o-matic with docker-compose''',
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -17,7 +17,8 @@ def docker_compose_file(pytestconfig):
 
 
 @pytest.fixture(scope='session')
-def scanomatic(docker_ip, docker_services):
+def _scanomatic(docker_ip, docker_services):
+
     def is_responsive(url):
         try:
             requests.get(url).raise_for_status()
@@ -35,6 +36,16 @@ def scanomatic(docker_ip, docker_services):
         check=lambda: is_responsive(url + '/fixtures')
     )
     return url
+
+
+def pytest_configure(config):
+    scanomatic_url = config.getoption('--scanomatic-url')
+    if scanomatic_url is not None:
+        globals()['scanomatic'] = (
+            pytest.fixture(scope='session')(lambda: scanomatic_url)
+        )
+    else:
+        globals()['scanomatic'] = _scanomatic
 
 
 @pytest.fixture()


### PR DESCRIPTION
Allow passing the url to a running scan-o-matic server and inhibit
starting docker-compose.
This makes working on system tests much quicker.