### PR TITLE
Bug fix in NewScanningJobContainer

### DIFF
--- a/scanomatic/ui_server_data/js/specs/containers/NewScanningJobContainer.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/containers/NewScanningJobContainer.spec.jsx
@@ -7,6 +7,16 @@ import * as API from '../../src/api';
 import FakePromise from '../helpers/FakePromise';
 
 
+function makeScanner({ identifier } = { identifiier: 'scanner01' }) {
+    return {
+        identifier,
+        name: `Test scanner ${identifier}`,
+        power: true,
+        owned: false,
+    };
+}
+
+
 describe('<NewScanningJobContainer />', () => {
     const onClose = jasmine.createSpy('onError');
     const props = { onClose, scanners: [] };
@@ -35,6 +45,46 @@ describe('<NewScanningJobContainer />', () => {
             it('should set interval', () => {
                 const wrapper = shallow(<NewScanningJobContainer {...props} />);
                 expect(wrapper.prop('interval')).toEqual(20);
+            });
+
+            it('should set scannerId to "" if no scanners', () => {
+                const wrapper = shallow(<NewScanningJobContainer
+                    {...props}
+                    scanners={[]}
+                />);
+                expect(wrapper.prop('scannerId')).toEqual('');
+            });
+        });
+
+        describe('on props update', () => {
+            it('should set scannerId when scanners are populated', () => {
+                const wrapper = shallow(<NewScanningJobContainer
+                    {...props}
+                    scanners={[]}
+                />);
+                const nextProps = Object.assign({}, props, {
+                    scanners: [
+                        makeScanner({ identifier: 'scnr01' }),
+                        makeScanner({ identifier: 'scnr02' }),
+                    ],
+                });
+                wrapper.setProps(nextProps);
+                expect(wrapper.prop('scannerId')).toEqual('scnr01');
+            });
+
+            it('should not set scannerId if already set', () => {
+                const wrapper = shallow(<NewScanningJobContainer
+                    {...props}
+                    scanners={[makeScanner({ identifier: 'scnr02' })]}
+                />);
+                const nextProps = Object.assign({}, props, {
+                    scanners: [
+                        makeScanner({ identifier: 'scnr01' }),
+                        makeScanner({ identifier: 'scnr02' }),
+                    ],
+                });
+                wrapper.setProps(nextProps);
+                expect(wrapper.prop('scannerId')).toEqual('scnr02');
             });
         });
 

--- a/scanomatic/ui_server_data/js/src/containers/NewScanningJobContainer.jsx
+++ b/scanomatic/ui_server_data/js/src/containers/NewScanningJobContainer.jsx
@@ -15,7 +15,7 @@ export default class NewScanningJobContainer extends React.Component {
                 minutes: 0,
             },
             interval: 20,
-            scannerId: props.scanners.length > 0 ? props.scanners[0].identifier : null,
+            scannerId: props.scanners.length > 0 ? props.scanners[0].identifier : '',
         };
 
         this.handleNameChange = this.handleNameChange.bind(this);
@@ -27,8 +27,8 @@ export default class NewScanningJobContainer extends React.Component {
         this.handleScannerChange = this.handleScannerChange.bind(this);
     }
 
-    willRecieveNewProps(nextProps) {
-        if (this.state.scannerId === null && nextProps.scanners.length > 0) {
+    componentWillReceiveProps(nextProps) {
+        if (this.state.scannerId === '' && nextProps.scanners.length > 0) {
             this.setState({ scannerId: nextProps.scanners[0].identifier });
         }
     }


### PR DESCRIPTION
The React lifecycle method called when props are updated is named
`componentWillReceiveProps`, not `willRecieveNewProps`.