### PR TITLE
Delete UI integration

### DIFF
--- a/scanomatic/ui_server_data/js/specs/components/ScanningJobPanel.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/ScanningJobPanel.spec.jsx
@@ -6,15 +6,17 @@ import ScanningJobPanel, { duration2milliseconds, getProgress } from '../../src/
 
 
 describe('<ScanningJobPanel />', () => {
-    const onStartJob = jasmine.createSpy('onStartJob');
     const props = {
-        name: 'Omnibus',
-        identifier: 'job0000',
-        duration: { days: 3, hours: 2, minutes: 51 },
-        interval: 13,
-        scannerId: 'hoho',
-        status: 'Planned',
-        onStartJob,
+        scanningJob: {
+            name: 'Omnibus',
+            identifier: 'job0000',
+            duration: { days: 3, hours: 2, minutes: 51 },
+            interval: 13,
+            scannerId: 'hoho',
+            status: 'Planned',
+        },
+        onStartJob: () => {},
+        onRemoveJob: () => {},
     };
 
     const scanner = {
@@ -24,376 +26,125 @@ describe('<ScanningJobPanel />', () => {
         identifier: 'hoho',
     };
 
-    const scannerOffline = {
-        name: 'Consule',
-        owned: false,
-        power: false,
-        identifier: 'hoho',
-    };
-
-    const scannerOccupied = {
-        name: 'Consule',
-        owned: true,
-        power: true,
-        identifier: 'hoho',
-    };
-
-    beforeEach(() => {
-        onStartJob.calls.reset();
-    });
-
     it('should render a panel-title with the name', () => {
         const wrapper = shallow(<ScanningJobPanel {...props} />);
         const title = wrapper.find('h3.panel-title');
         expect(title.exists()).toBeTruthy();
-        expect(title.text()).toContain(props.name);
+        expect(title.text()).toContain('Omnibus');
     });
 
     it('should render a panel with id from the job', () => {
         const wrapper = shallow(<ScanningJobPanel {...props} />);
         const panel = wrapper.find('div.panel');
-        expect(panel.prop('id')).toEqual(`job-${props.identifier}`);
+        expect(panel.prop('id')).toEqual('job-job0000');
     });
 
-    describe('Status Planned', () => {
-        it('should render a status label', () => {
+    it('should render a <ScanningJobStatusLabel />', () => {
+        const wrapper = shallow(<ScanningJobPanel
+            {...props}
+        />);
+        const label = wrapper.find('ScanningJobStatusLabel');
+        expect(label.exists()).toBeTruthy();
+        expect(label.prop('status')).toEqual('Planned');
+    });
+
+    it('should render a <ScanningJobPanelBody />', () => {
+        const wrapper = shallow(<ScanningJobPanel
+            {...props}
+            scanner={scanner}
+        />);
+        const body = wrapper.find('ScanningJobPanelBody');
+        expect(body.exists()).toBeTruthy();
+        expect(body.prop('scanner')).toEqual(scanner);
+        expect(body.props())
+            .toEqual(jasmine.objectContaining(props.scanningJob));
+    });
+
+    describe('on remove', () => {
+        it('should hide <ScanningJobPanelBody/>', () => {
             const wrapper = shallow(<ScanningJobPanel {...props} />);
-            const heading = wrapper.find('div.panel-heading');
-            const label = heading.find('.label-default');
-            expect(label.exists()).toBeTruthy();
-            expect(label.text()).toEqual('Planned');
+            wrapper.find('ScanningJobPanelBody').prop('onRemoveJob')();
+            wrapper.update();
+            const body = wrapper.find('ScanningJobPanelBody');
+            expect(body.exists()).toBeFalsy();
         });
 
-        it('should render a job-start button', () => {
-            const wrapper = shallow(<ScanningJobPanel {...props} scanner={scanner} />);
-            const btn = wrapper.find('button.job-start');
-            expect(btn.exists()).toBeTruthy();
-            expect(btn.text()).toContain('Start');
-            expect(btn.find('span.glyphicon-play').exists()).toBeTruthy();
-        });
-
-        it('should disable job-start button if scanner unknown', () => {
-            const wrapper = shallow(<ScanningJobPanel
-                {...props}
-                scanner={null}
-            />);
-            const btn = wrapper.find('button.job-start');
-            expect(btn.prop('disabled')).toBeTruthy();
-            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
-        });
-
-        it('should disable job-start button if scanner offline', () => {
-            const wrapper = shallow(<ScanningJobPanel
-                {...props}
-                scanner={scannerOffline}
-            />);
-            const btn = wrapper.find('button.job-start');
-            expect(btn.prop('disabled')).toBeTruthy();
-            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
-        });
-
-        it('should disable job-start button if scanner ownded', () => {
-            const wrapper = shallow(<ScanningJobPanel
-                {...props}
-                scanner={scannerOccupied}
-            />);
-            const btn = wrapper.find('button.job-start');
-            expect(btn.prop('disabled')).toBeTruthy();
-            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
-        });
-
-        it('should not render a start button if job is starting', () => {
-            const wrapper = shallow(<ScanningJobPanel {...props} disableStart />);
-            const btn = wrapper.find('button.job-start');
-            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
-        });
-
-        it('should not render a link to the compile page', () => {
+        it('should render <ScanningJobRemoveDialogue/>', () => {
             const wrapper = shallow(<ScanningJobPanel {...props} />);
-            const link = wrapper
-                .find('[href="/compile?projectdirectory=root/job0000"]');
-            expect(link.exists()).toBeFalsy();
-        });
-
-        it('should not render a link to the qc page', () => {
-            const wrapper = shallow(<ScanningJobPanel {...props} />);
-            const link = wrapper
-                .find('[href="/qc_norm?analysisdirectory=job0000/analysis&project=Omnibus"]');
-            expect(link.exists()).toBeFalsy();
-        });
-
-        it('should say scanning frequency', () => {
-            const wrapper = shallow(<ScanningJobPanel {...props} />);
-            const desc = wrapper.find('tr.job-interval');
-            expect(desc.exists()).toBeTruthy();
-            expect(desc.find('td').at(0).text()).toEqual('Frequency');
-            expect(desc.find('td').at(1).text()).toEqual('Scan every 13 minutes');
-        });
-
-        describe('scanner', () => {
-            it('should have a table row', () => {
-                const wrapper = shallow(<ScanningJobPanel {...props} />);
-                const desc = wrapper.find('tr.job-scanner');
-                expect(desc.exists()).toBeTruthy();
-                expect(desc.find('td').at(0).text()).toEqual('Scanner');
-            });
-
-            it('should render the scanner retrieving scanner status', () => {
-                const wrapper = shallow(<ScanningJobPanel {...props} />);
-                const desc = wrapper.find('tr.job-scanner');
-                expect(desc.find('td').at(1).text()).toEqual('Retrieving scanner status...');
-            });
-
-            it('should render the scanner offline', () => {
-                const wrapper = shallow(<ScanningJobPanel
-                    {...props}
-                    scanner={scannerOffline}
-                />);
-                const desc = wrapper.find('tr.job-scanner');
-                expect(desc.find('td').at(1).text()).toEqual('Consule (offline, free)');
-            });
-
-            it('should render the scanner occupied', () => {
-                const wrapper = shallow(<ScanningJobPanel
-                    {...props}
-                    scanner={scannerOccupied}
-                />);
-                const desc = wrapper.find('tr.job-scanner');
-                expect(desc.find('td').at(1).text()).toEqual('Consule (online, occupied)');
-            });
+            wrapper.find('ScanningJobPanelBody').prop('onRemoveJob')();
+            wrapper.update();
+            const dialogue = wrapper.find('ScanningJobRemoveDialogue');
+            expect(dialogue.exists()).toBeTruthy();
         });
     });
 
-    describe('Status Running', () => {
-        let wrapper;
-
-        beforeEach(() => {
-            jasmine.clock().install();
-            jasmine.clock().mockDate(new Date('1980-03-24T13:00:00Z'));
-            wrapper = shallow(<ScanningJobPanel
-                {...props}
-                startTime={new Date('1980-03-23T13:00:00Z')}
-                endTime={new Date('1980-03-26T15:51:00Z')}
-                status="Running"
-            />);
-        });
-
-        afterEach(() => {
-            jasmine.clock().uninstall();
-        });
-
-        it('should render a status label', () => {
-            const heading = wrapper.find('div.panel-heading');
-            const label = heading.find('.label-info');
-            expect(label.exists()).toBeTruthy();
-            expect(label.text()).toEqual('Running');
-        });
-
-        it('should not render a start button', () => {
-            const btn = wrapper.find('button.job-start');
-            expect(btn.exists()).toBeFalsy();
-        });
-
-        it('should not render a link to the compile page', () => {
-            const link = wrapper
-                .find('[href="/compile?projectdirectory=root/job0000"]');
-            expect(link.exists()).toBeFalsy();
-        });
-
-        it('should not render a link to the qc page', () => {
-            const link = wrapper
-                .find('[href="/qc_norm?analysisdirectory=job0000/analysis&project=Omnibus"]');
-            expect(link.exists()).toBeFalsy();
-        });
-
-        it('should say when a job was started', () => {
-            const desc = wrapper.find('tr.job-start');
-            expect(desc.exists()).toBeTruthy();
-            expect(desc.find('td').at(0).text()).toEqual('Started');
-            expect(desc.find('td').at(1).text()).toEqual(`${new Date('1980-03-23T13:00:00Z')}`);
-        });
-
-        it('should say when a job will end', () => {
-            const desc = wrapper.find('tr.job-end');
-            expect(desc.exists()).toBeTruthy();
-            expect(desc.find('td').at(0).text()).toEqual('Will end');
-            expect(desc.find('td').at(1).text()).toEqual(`${new Date('1980-03-26T15:51:00Z')}`);
-        });
-
-        it('should say scanning frequency', () => {
-            const desc = wrapper.find('tr.job-interval');
-            expect(desc.exists()).toBeTruthy();
-            expect(desc.find('td').at(0).text()).toEqual('Frequency');
-            expect(desc.find('td').at(1).text()).toEqual('Scanning every 13 minutes');
-        });
-
-        describe('Progress bar', () => {
-            it('should render a progress bar', () => {
-                const progress = wrapper.find('.progress');
-                expect(progress.exists()).toBeTruthy();
-            });
-
-            it('should have the progressbar display the progress', () => {
-                const progressbar = wrapper.find('.progress-bar');
-                expect(progressbar.prop('style').width).toEqual('32.1%');
-            });
-
-            it('should have the progressbar display the progress as text', () => {
-                const progressbar = wrapper.find('.progress-bar');
-                expect(progressbar.render().text()).toEqual('32.1%');
-            });
-        });
-
-        it('should have also show scanner info', () => {
-            const desc = wrapper.find('tr.job-scanner');
-            expect(desc.exists()).toBeTruthy();
-            expect(desc.find('td').at(0).text()).toEqual('Scanner');
-        });
-    });
-
-    describe('Status Completed', () => {
-        let wrapper;
-        beforeEach(() => {
-            wrapper = shallow(<ScanningJobPanel
-                {...props}
-                startTime={new Date('1980-03-23T13:00:00Z')}
-                endTime={new Date('1980-03-26T15:51:00Z')}
-                status="Completed"
-            />);
-        });
-
-        it('should render a status label', () => {
-            const heading = wrapper.find('div.panel-heading');
-            const label = heading.find('.label-success');
-            expect(label.exists()).toBeTruthy();
-            expect(label.text()).toEqual('Completed');
-        });
-
-        it('should render a link to the compile page', () => {
-            const link = wrapper
-                .find('[href="/compile?projectdirectory=root/job0000"]');
-            expect(link.exists()).toBeTruthy();
-            expect(link.text()).toEqual('Compile project');
-        });
-
-        it('should render a link to the qc page', () => {
-            const link = wrapper
-                .find('[href="/qc_norm?analysisdirectory=job0000/analysis&project=Omnibus"]');
-            expect(link.exists()).toBeTruthy();
-            expect(link.text()).toEqual('QC project');
-        });
-
-        it('should not show scanner info', () => {
-            const desc = wrapper.find('tr.job-scanner');
-            expect(desc.exists()).toBeFalsy();
-        });
-
-        it('should say when a job was started', () => {
-            const desc = wrapper.find('tr.job-start');
-            expect(desc.exists()).toBeTruthy();
-            expect(desc.find('td').at(0).text()).toEqual('Started');
-            expect(desc.find('td').at(1).text()).toEqual(`${new Date('1980-03-23T13:00:00Z')}`);
-        });
-
-        it('should say when a job ended', () => {
-            const desc = wrapper.find('tr.job-end');
-            expect(desc.exists()).toBeTruthy();
-            expect(desc.find('td').at(0).text()).toEqual('Ended');
-            expect(desc.find('td').at(1).text()).toEqual(`${new Date('1980-03-26T15:51:00Z')}`);
-        });
-
-        it('should say scanning frequency', () => {
-            const desc = wrapper.find('tr.job-interval');
-            expect(desc.exists()).toBeTruthy();
-            expect(desc.find('td').at(0).text()).toEqual('Frequency');
-            expect(desc.find('td').at(1).text()).toEqual('Scanned every 13 minutes');
-        });
-    });
-
-    describe('duration', () => {
-        it('should render the duration', () => {
+    describe('on confirm remove', () => {
+        it('should render <ScanningJobPanelBody/>', () => {
             const wrapper = shallow(<ScanningJobPanel {...props} />);
-            const desc = wrapper.find('tr.job-duration');
-            expect(desc.find('td').at(0).text()).toEqual('Duration');
-            expect(desc.find('td').at(1).text()).toEqual('3 days 2 hours 51 minutes');
+            wrapper.find('ScanningJobPanelBody').prop('onRemoveJob')();
+            wrapper.update();
+            wrapper.find('ScanningJobRemoveDialogue').prop('onConfirm')();
+            wrapper.update();
+            const dialogue = wrapper.find('ScanningJobPanelBody');
+            expect(dialogue.exists()).toBeTruthy();
         });
 
-        it('should skip days if zero', () => {
+        it('should hide <ScanningJobRemoveDialogue/>', () => {
+            const wrapper = shallow(<ScanningJobPanel {...props} />);
+            wrapper.find('ScanningJobPanelBody').prop('onRemoveJob')();
+            wrapper.update();
+            wrapper.find('ScanningJobRemoveDialogue').prop('onConfirm')();
+            wrapper.update();
+            const dialogue = wrapper.find('ScanningJobRemoveDialogue');
+            expect(dialogue.exists()).toBeFalsy();
+        });
+
+        it('should call onDelete with the job identifier', () => {
+            const onRemoveJob = jasmine.createSpy('onRemoveJob');
             const wrapper = shallow(<ScanningJobPanel
                 {...props}
-                duration={{ days: 0, hours: 2, minutes: 51 }}
+                onRemoveJob={onRemoveJob}
             />);
-            const desc = wrapper.find('tr.job-duration');
-            expect(desc.find('td').at(1).text()).toEqual('2 hours 51 minutes');
+            wrapper.find('ScanningJobPanelBody').prop('onRemoveJob')();
+            wrapper.update();
+            wrapper.find('ScanningJobRemoveDialogue').prop('onConfirm')();
+            wrapper.update();
+            expect(onRemoveJob).toHaveBeenCalledWith(props.scanningJob.identifier);
+        });
+    });
+
+    describe('on cancel remove', () => {
+        it('should render <ScanningJobPanelBody/>', () => {
+            const wrapper = shallow(<ScanningJobPanel {...props} />);
+            wrapper.find('ScanningJobPanelBody').prop('onRemoveJob')();
+            wrapper.update();
+            wrapper.find('ScanningJobRemoveDialogue').prop('onCancel')();
+            wrapper.update();
+            const dialogue = wrapper.find('ScanningJobPanelBody');
+            expect(dialogue.exists()).toBeTruthy();
         });
 
-        it('should skip hours if zero', () => {
+        it('should hide <ScanningJobRemoveDialogue/>', () => {
+            const wrapper = shallow(<ScanningJobPanel {...props} />);
+            wrapper.find('ScanningJobPanelBody').prop('onRemoveJob')();
+            wrapper.update();
+            wrapper.find('ScanningJobRemoveDialogue').prop('onCancel')();
+            wrapper.update();
+            const dialogue = wrapper.find('ScanningJobRemoveDialogue');
+            expect(dialogue.exists()).toBeFalsy();
+        });
+
+        it('should not call onDelete', () => {
+            const onRemoveJob = jasmine.createSpy('onRemoveJob');
             const wrapper = shallow(<ScanningJobPanel
                 {...props}
-                duration={{ days: 2, hours: 0, minutes: 51 }}
+                onRemoveJob={onRemoveJob}
             />);
-            const desc = wrapper.find('div.job-description');
-            expect(desc.find('td').at(1).text()).toEqual('2 days 51 minutes');
+            wrapper.find('ScanningJobPanelBody').prop('onRemoveJob')();
+            wrapper.update();
+            wrapper.find('ScanningJobRemoveDialogue').prop('onCancel')();
+            wrapper.update();
+            expect(onRemoveJob).not.toHaveBeenCalled();
         });
-
-        it('should skip minues if zero', () => {
-            const wrapper = shallow(<ScanningJobPanel
-                {...props}
-                duration={{ days: 3, hours: 2, minutes: 0 }}
-            />);
-            const desc = wrapper.find('div.job-description');
-            expect(desc.find('td').at(1).text()).toEqual('3 days 2 hours');
-        });
-    });
-});
-
-describe('duration2milliseconds', () => {
-    it('should convert a minutes to 60000', () => {
-        expect(duration2milliseconds({ minutes: 2, hours: 0, days: 0 }))
-            .toEqual(120000);
-    });
-
-    it('should convert an hour to 3600000', () => {
-        expect(duration2milliseconds({ minutes: 0, hours: 1, days: 0 }))
-            .toEqual(3600000);
-    });
-
-    it('should convert a day to 8.64 x 10^7', () => {
-        expect(duration2milliseconds({ minutes: 0, hours: 0, days: 1 }))
-            .toEqual(86400000);
-    });
-
-    it('should sum it up', () => {
-        expect(duration2milliseconds({ minutes: 1, hours: 1, days: 1 }))
-            .toEqual(90060000);
-    });
-
-    it('should return 0 if no duration', () => {
-        expect(duration2milliseconds()).toEqual(0);
-    });
-});
-
-describe('getProgress', () => {
-    beforeEach(() => {
-        jasmine.clock().install();
-        jasmine.clock().mockDate(new Date('2040-05-02T12:00:00.000Z'));
-    });
-
-    afterEach(() => {
-        jasmine.clock().uninstall();
-    });
-
-    it('should cap duration at 100', () => {
-        expect(getProgress({
-            startTime: new Date('1024-07-02T00:00:00.000Z'),
-            duration: { days: 666, hours: 66, minutes: 6 },
-        })).toEqual(100);
-    });
-
-    it('should return percent completed', () => {
-        expect(getProgress({
-            startTime: new Date('2040-05-01T12:00:00.000Z'),
-            duration: { days: 2, hours: 0, minutes: 0 },
-        })).toEqual(50);
     });
 });

--- a/scanomatic/ui_server_data/js/specs/components/ScanningJobPanelBody.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/ScanningJobPanelBody.spec.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import './enzyme-setup';
 import ScanningJobPanelBody, { duration2milliseconds, getProgress }
-from '../../src/components/ScanningJobPanelBody';
+    from '../../src/components/ScanningJobPanelBody';
 
 
 describe('<ScanningJobPanelBody />', () => {
@@ -321,7 +321,7 @@ describe('<ScanningJobPanelBody />', () => {
                 {...props}
                 duration={{ days: 2, hours: 0, minutes: 51 }}
             />);
-            const desc = wrapper.find('div.job-description');
+            const desc = wrapper.find('tr.job-duration');
             expect(desc.find('td').at(1).text()).toEqual('2 days 51 minutes');
         });
 
@@ -330,7 +330,7 @@ describe('<ScanningJobPanelBody />', () => {
                 {...props}
                 duration={{ days: 3, hours: 2, minutes: 0 }}
             />);
-            const desc = wrapper.find('div.job-description');
+            const desc = wrapper.find('tr.job-duration');
             expect(desc.find('td').at(1).text()).toEqual('3 days 2 hours');
         });
     });

--- a/scanomatic/ui_server_data/js/specs/components/ScanningJobPanelBody.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/ScanningJobPanelBody.spec.jsx
@@ -1,0 +1,388 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import './enzyme-setup';
+import ScanningJobPanelBody, { duration2milliseconds, getProgress }
+from '../../src/components/ScanningJobPanelBody';
+
+
+describe('<ScanningJobPanelBody />', () => {
+    const onStartJob = jasmine.createSpy('onStartJob');
+    const props = {
+        name: 'Omnibus',
+        identifier: 'job0000',
+        duration: { days: 3, hours: 2, minutes: 51 },
+        interval: 13,
+        scannerId: 'hoho',
+        status: 'Planned',
+        onStartJob,
+        onRemoveJob: () => {},
+    };
+
+    const scanner = {
+        name: 'Consule',
+        owned: false,
+        power: true,
+        identifier: 'hoho',
+    };
+
+    const scannerOffline = {
+        name: 'Consule',
+        owned: false,
+        power: false,
+        identifier: 'hoho',
+    };
+
+    const scannerOccupied = {
+        name: 'Consule',
+        owned: true,
+        power: true,
+        identifier: 'hoho',
+    };
+
+    beforeEach(() => {
+        onStartJob.calls.reset();
+    });
+
+    describe('Status Planned', () => {
+        it('should render a job-start button', () => {
+            const wrapper = shallow(<ScanningJobPanelBody {...props} scanner={scanner} />);
+            const btn = wrapper.find('button.job-start');
+            expect(btn.exists()).toBeTruthy();
+            expect(btn.text()).toContain('Start');
+            expect(btn.find('span.glyphicon-play').exists()).toBeTruthy();
+        });
+
+        it('should disable job-start button if scanner unknown', () => {
+            const wrapper = shallow(<ScanningJobPanelBody
+                {...props}
+                scanner={null}
+            />);
+            const btn = wrapper.find('button.job-start');
+            expect(btn.prop('disabled')).toBeTruthy();
+            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
+        });
+
+        it('should disable job-start button if scanner offline', () => {
+            const wrapper = shallow(<ScanningJobPanelBody
+                {...props}
+                scanner={scannerOffline}
+            />);
+            const btn = wrapper.find('button.job-start');
+            expect(btn.prop('disabled')).toBeTruthy();
+            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
+        });
+
+        it('should disable job-start button if scanner ownded', () => {
+            const wrapper = shallow(<ScanningJobPanelBody
+                {...props}
+                scanner={scannerOccupied}
+            />);
+            const btn = wrapper.find('button.job-start');
+            expect(btn.prop('disabled')).toBeTruthy();
+            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
+        });
+
+        it('should not render a start button if job is starting', () => {
+            const wrapper = shallow(<ScanningJobPanelBody {...props} disableStart />);
+            const btn = wrapper.find('button.job-start');
+            expect(btn.find('span.glyphicon-ban-circle').exists()).toBeTruthy();
+        });
+
+        it('should not render a link to the compile page', () => {
+            const wrapper = shallow(<ScanningJobPanelBody {...props} />);
+            const link = wrapper
+                .find('[href="/compile?projectdirectory=root/job0000"]');
+            expect(link.exists()).toBeFalsy();
+        });
+
+        it('should not render a link to the qc page', () => {
+            const wrapper = shallow(<ScanningJobPanelBody {...props} />);
+            const link = wrapper
+                .find('[href="/qc_norm?analysisdirectory=job0000/analysis&project=Omnibus"]');
+            expect(link.exists()).toBeFalsy();
+        });
+
+        it('should say scanning frequency', () => {
+            const wrapper = shallow(<ScanningJobPanelBody {...props} />);
+            const desc = wrapper.find('tr.job-interval');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Frequency');
+            expect(desc.find('td').at(1).text()).toEqual('Scan every 13 minutes');
+        });
+
+        describe('scanner', () => {
+            it('should have a table row', () => {
+                const wrapper = shallow(<ScanningJobPanelBody {...props} />);
+                const desc = wrapper.find('tr.job-scanner');
+                expect(desc.exists()).toBeTruthy();
+                expect(desc.find('td').at(0).text()).toEqual('Scanner');
+            });
+
+            it('should render the scanner retrieving scanner status', () => {
+                const wrapper = shallow(<ScanningJobPanelBody {...props} />);
+                const desc = wrapper.find('tr.job-scanner');
+                expect(desc.find('td').at(1).text()).toEqual('Retrieving scanner status...');
+            });
+
+            it('should render the scanner offline', () => {
+                const wrapper = shallow(<ScanningJobPanelBody
+                    {...props}
+                    scanner={scannerOffline}
+                />);
+                const desc = wrapper.find('tr.job-scanner');
+                expect(desc.find('td').at(1).text()).toEqual('Consule (offline, free)');
+            });
+
+            it('should render the scanner occupied', () => {
+                const wrapper = shallow(<ScanningJobPanelBody
+                    {...props}
+                    scanner={scannerOccupied}
+                />);
+                const desc = wrapper.find('tr.job-scanner');
+                expect(desc.find('td').at(1).text()).toEqual('Consule (online, occupied)');
+            });
+        });
+
+        it('should render a remove button', () => {
+            const wrapper = shallow(<ScanningJobPanelBody
+                {...props}
+                status="Planned"
+                identifier="scnjb001"
+            />);
+            const btn = wrapper.find('ScanningJobRemoveButton');
+            expect(btn.exists()).toBeTruthy();
+            expect(btn.prop('identifier')).toEqual('scnjb001');
+            expect(btn.prop('onRemoveJob')).toBe(props.onRemoveJob);
+        });
+    });
+
+    describe('Status Running', () => {
+        let wrapper;
+
+        beforeEach(() => {
+            jasmine.clock().install();
+            jasmine.clock().mockDate(new Date('1980-03-24T13:00:00Z'));
+            wrapper = shallow(<ScanningJobPanelBody
+                {...props}
+                startTime={new Date('1980-03-23T13:00:00Z')}
+                endTime={new Date('1980-03-26T15:51:00Z')}
+                status="Running"
+            />);
+        });
+
+        afterEach(() => {
+            jasmine.clock().uninstall();
+        });
+
+        it('should not render a start button', () => {
+            const btn = wrapper.find('button.job-start');
+            expect(btn.exists()).toBeFalsy();
+        });
+
+        it('should not render a link to the compile page', () => {
+            const link = wrapper
+                .find('[href="/compile?projectdirectory=root/job0000"]');
+            expect(link.exists()).toBeFalsy();
+        });
+
+        it('should not render a link to the qc page', () => {
+            const link = wrapper
+                .find('[href="/qc_norm?analysisdirectory=job0000/analysis&project=Omnibus"]');
+            expect(link.exists()).toBeFalsy();
+        });
+
+        it('should say when a job was started', () => {
+            const desc = wrapper.find('tr.job-start');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Started');
+            expect(desc.find('td').at(1).text()).toEqual(`${new Date('1980-03-23T13:00:00Z')}`);
+        });
+
+        it('should say when a job will end', () => {
+            const desc = wrapper.find('tr.job-end');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Will end');
+            expect(desc.find('td').at(1).text()).toEqual(`${new Date('1980-03-26T15:51:00Z')}`);
+        });
+
+        it('should say scanning frequency', () => {
+            const desc = wrapper.find('tr.job-interval');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Frequency');
+            expect(desc.find('td').at(1).text()).toEqual('Scanning every 13 minutes');
+        });
+
+        describe('Progress bar', () => {
+            it('should render a progress bar', () => {
+                const progress = wrapper.find('.progress');
+                expect(progress.exists()).toBeTruthy();
+            });
+
+            it('should have the progressbar display the progress', () => {
+                const progressbar = wrapper.find('.progress-bar');
+                expect(progressbar.prop('style').width).toEqual('32.1%');
+            });
+
+            it('should have the progressbar display the progress as text', () => {
+                const progressbar = wrapper.find('.progress-bar');
+                expect(progressbar.render().text()).toEqual('32.1%');
+            });
+        });
+
+        it('should have also show scanner info', () => {
+            const desc = wrapper.find('tr.job-scanner');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Scanner');
+        });
+
+        it('should not render a remove button', () => {
+            const btn = wrapper.find('ScanningJobRemoveButton');
+            expect(btn.exists()).toBeFalsy();
+        });
+    });
+
+    describe('Status Completed', () => {
+        let wrapper;
+        beforeEach(() => {
+            wrapper = shallow(<ScanningJobPanelBody
+                {...props}
+                startTime={new Date('1980-03-23T13:00:00Z')}
+                endTime={new Date('1980-03-26T15:51:00Z')}
+                status="Completed"
+            />);
+        });
+
+        it('should render a link to the compile page', () => {
+            const link = wrapper
+                .find('[href="/compile?projectdirectory=root/job0000"]');
+            expect(link.exists()).toBeTruthy();
+            expect(link.text()).toEqual('Compile project');
+        });
+
+        it('should render a link to the qc page', () => {
+            const link = wrapper
+                .find('[href="/qc_norm?analysisdirectory=job0000/analysis&project=Omnibus"]');
+            expect(link.exists()).toBeTruthy();
+            expect(link.text()).toEqual('QC project');
+        });
+
+        it('should not show scanner info', () => {
+            const desc = wrapper.find('tr.job-scanner');
+            expect(desc.exists()).toBeFalsy();
+        });
+
+        it('should say when a job was started', () => {
+            const desc = wrapper.find('tr.job-start');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Started');
+            expect(desc.find('td').at(1).text()).toEqual(`${new Date('1980-03-23T13:00:00Z')}`);
+        });
+
+        it('should say when a job ended', () => {
+            const desc = wrapper.find('tr.job-end');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Ended');
+            expect(desc.find('td').at(1).text()).toEqual(`${new Date('1980-03-26T15:51:00Z')}`);
+        });
+
+        it('should say scanning frequency', () => {
+            const desc = wrapper.find('tr.job-interval');
+            expect(desc.exists()).toBeTruthy();
+            expect(desc.find('td').at(0).text()).toEqual('Frequency');
+            expect(desc.find('td').at(1).text()).toEqual('Scanned every 13 minutes');
+        });
+
+        it('should not render a remove button', () => {
+            const btn = wrapper.find('ScanningJobRemoveButton');
+            expect(btn.exists()).toBeFalsy();
+        });
+    });
+
+    describe('duration', () => {
+        it('should render the duration', () => {
+            const wrapper = shallow(<ScanningJobPanelBody {...props} />);
+            const desc = wrapper.find('tr.job-duration');
+            expect(desc.find('td').at(0).text()).toEqual('Duration');
+            expect(desc.find('td').at(1).text()).toEqual('3 days 2 hours 51 minutes');
+        });
+
+        it('should skip days if zero', () => {
+            const wrapper = shallow(<ScanningJobPanelBody
+                {...props}
+                duration={{ days: 0, hours: 2, minutes: 51 }}
+            />);
+            const desc = wrapper.find('tr.job-duration');
+            expect(desc.find('td').at(1).text()).toEqual('2 hours 51 minutes');
+        });
+
+        it('should skip hours if zero', () => {
+            const wrapper = shallow(<ScanningJobPanelBody
+                {...props}
+                duration={{ days: 2, hours: 0, minutes: 51 }}
+            />);
+            const desc = wrapper.find('div.job-description');
+            expect(desc.find('td').at(1).text()).toEqual('2 days 51 minutes');
+        });
+
+        it('should skip minues if zero', () => {
+            const wrapper = shallow(<ScanningJobPanelBody
+                {...props}
+                duration={{ days: 3, hours: 2, minutes: 0 }}
+            />);
+            const desc = wrapper.find('div.job-description');
+            expect(desc.find('td').at(1).text()).toEqual('3 days 2 hours');
+        });
+    });
+});
+
+describe('duration2milliseconds', () => {
+    it('should convert a minutes to 60000', () => {
+        expect(duration2milliseconds({ minutes: 2, hours: 0, days: 0 }))
+            .toEqual(120000);
+    });
+
+    it('should convert an hour to 3600000', () => {
+        expect(duration2milliseconds({ minutes: 0, hours: 1, days: 0 }))
+            .toEqual(3600000);
+    });
+
+    it('should convert a day to 8.64 x 10^7', () => {
+        expect(duration2milliseconds({ minutes: 0, hours: 0, days: 1 }))
+            .toEqual(86400000);
+    });
+
+    it('should sum it up', () => {
+        expect(duration2milliseconds({ minutes: 1, hours: 1, days: 1 }))
+            .toEqual(90060000);
+    });
+
+    it('should return 0 if no duration', () => {
+        expect(duration2milliseconds()).toEqual(0);
+    });
+});
+
+describe('getProgress', () => {
+    beforeEach(() => {
+        jasmine.clock().install();
+        jasmine.clock().mockDate(new Date('2040-05-02T12:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jasmine.clock().uninstall();
+    });
+
+    it('should cap duration at 100', () => {
+        expect(getProgress({
+            startTime: new Date('1024-07-02T00:00:00.000Z'),
+            duration: { days: 666, hours: 66, minutes: 6 },
+        })).toEqual(100);
+    });
+
+    it('should return percent completed', () => {
+        expect(getProgress({
+            startTime: new Date('2040-05-01T12:00:00.000Z'),
+            duration: { days: 2, hours: 0, minutes: 0 },
+        })).toEqual(50);
+    });
+});

--- a/scanomatic/ui_server_data/js/specs/components/ScanningJobStatusLabel.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/ScanningJobStatusLabel.spec.jsx
@@ -1,0 +1,28 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import './enzyme-setup';
+import ScanningJobStatusLabel
+    from '../../src/components/ScanningJobStatusLabel';
+
+
+describe('<ScanningJobStatusLabel />', () => {
+    it('should render Planned as a default label', () => {
+        const wrapper = shallow(<ScanningJobStatusLabel status="Planned" />);
+        expect(wrapper.text()).toEqual('Planned');
+        expect(wrapper.prop('className')).toContain('label-default');
+    });
+
+    it('should render Running as an info label', () => {
+        const wrapper = shallow(<ScanningJobStatusLabel status="Running" />);
+        expect(wrapper.text()).toEqual('Running');
+        expect(wrapper.prop('className')).toContain('label-info');
+    });
+
+    it('should render Completed as a success label', () => {
+        const wrapper = shallow(<ScanningJobStatusLabel status="Completed" />);
+        expect(wrapper.text()).toEqual('Completed');
+        expect(wrapper.prop('className')).toContain('label-success');
+    });
+});
+

--- a/scanomatic/ui_server_data/js/specs/components/ScanningRoot.spec.jsx
+++ b/scanomatic/ui_server_data/js/specs/components/ScanningRoot.spec.jsx
@@ -71,8 +71,8 @@ describe('<ScanningRoot />', () => {
         it('passes jobs-data to <ScanningJobPanel />:s', () => {
             const wrapper = shallow(<ScanningRoot {...props} jobs={jobs} />);
             const jobPanels = wrapper.find('ScanningJobPanel');
-            expect(jobPanels.last().prop('name')).toEqual('A');
-            expect(jobPanels.first().prop('name')).toEqual('B');
+            expect(jobPanels.last().prop('scanningJob').name).toEqual('A');
+            expect(jobPanels.first().prop('scanningJob').name).toEqual('B');
         });
 
         it('couples start callback with job (first)', () => {
@@ -94,8 +94,8 @@ describe('<ScanningRoot />', () => {
         it('should add statuses to the jobs', () => {
             const wrapper = shallow(<ScanningRoot {...props} jobs={jobs} />);
             const jobPanels = wrapper.find('ScanningJobPanel');
-            expect(jobPanels.first().prop('status')).toEqual('Planned');
-            expect(jobPanels.last().prop('status')).toEqual('Completed');
+            expect(jobPanels.first().prop('scanningJob').status).toEqual('Planned');
+            expect(jobPanels.last().prop('scanningJob').status).toEqual('Completed');
         });
 
         it('should pass onRemoveJob to <ScanningJobPanel/>', () => {

--- a/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
@@ -1,202 +1,76 @@
-
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import SoMPropTypes from '../prop-types';
+import ScanningJobPanelBody from './ScanningJobPanelBody';
+import ScanningJobRemoveDialogue from './ScanningJobRemoveDialogue';
+import ScanningJobStatusLabel from './ScanningJobStatusLabel';
 
-export function duration2milliseconds(duration) {
-    if (duration) {
-        const date = new Date(0);
-        return date.setUTCHours((duration.days * 24) + duration.hours, duration.minutes);
+class ScanningJobPanel extends React.Component {
+    constructor() {
+        super();
+        this.state = { dialogue: null };
+        this.handleRemove = this.handleRemove.bind(this);
+        this.handleCancelRemove = this.handleCancelRemove.bind(this);
+        this.handleConfirmRemove = this.handleConfirmRemove.bind(this);
     }
-    return 0;
-}
 
-export function getProgress(job) {
-    const duration = duration2milliseconds(job.duration);
-    const progress = new Date() - new Date(job.startTime);
-    return Math.min(1, progress / duration) * 100;
-}
+    handleRemove() {
+        this.setState({ dialogue: 'remove' });
+    }
 
-export default function ScanningJobPanel(props) {
-    const duration = [];
-    if (props.duration.days > 0) {
-        duration.push(`${props.duration.days} days`);
+    handleCancelRemove() {
+        this.setState({ dialogue: null });
     }
-    if (props.duration.hours > 0) {
-        duration.push(`${props.duration.hours} hours`);
+
+    handleConfirmRemove() {
+        this.setState({ dialogue: null });
+        this.props.onRemoveJob(this.props.scanningJob.identifier);
     }
-    if (props.duration.minutes > 0) {
-        duration.push(`${props.duration.minutes} minutes`);
-    }
-    const { scanner } = props;
-    let showStart = null;
-    let status = null;
-    let scanFrequency;
-    let links;
-    if (props.status === 'Running') {
-        const progress = getProgress(props).toFixed(1);
-        status = (
-            <div className="progress">
-                <div
-                    className="progress-bar"
-                    role="progressbar"
-                    aria-valuenow={progress}
-                    aria-valuemin="0"
-                    aria-valuemax="100"
-                    style={{ minWidth: '4em', width: `${progress}%` }}
-                >
-                    {progress}%
+
+    render() {
+        const {
+            onStartJob,
+            scanner,
+            scanningJob,
+        } = this.props;
+        const { identifier, name, status } = scanningJob;
+        const { dialogue } = this.state;
+
+        return (
+            <div
+                className="panel panel-default job-listing"
+                id={`job-${identifier}`}
+            >
+                <div className="panel-heading">
+                    <h3 className="panel-title">{name}</h3>
+                    <ScanningJobStatusLabel status={status} />
                 </div>
+                {!dialogue &&
+                    <ScanningJobPanelBody
+                        {...scanningJob}
+                        onRemoveJob={this.handleRemove}
+                        onStartJob={onStartJob}
+                        scanner={scanner}
+                    />
+                }
+                {dialogue === 'remove' &&
+                    <ScanningJobRemoveDialogue
+                        name={name}
+                        onCancel={this.handleCancelRemove}
+                        onConfirm={this.handleConfirmRemove}
+                    />
+                }
             </div>
         );
-        scanFrequency = (
-            <tr className="job-info job-interval">
-                <td>Frequency</td>
-                <td>Scanning every {props.interval} minutes</td>
-            </tr>
-        );
-    } else if (props.status === 'Completed') {
-        scanFrequency = (
-            <tr className="job-info job-interval">
-                <td>Frequency</td>
-                <td>Scanned every {props.interval} minutes</td>
-            </tr>
-        );
-        links = (
-            <div className="text-right job-links">
-                <a href={`/compile?projectdirectory=root/${props.identifier}`}>
-                    Compile project
-                </a>
-                <a href={`/qc_norm?analysisdirectory=${encodeURI(props.identifier)}/analysis&project=${encodeURI(props.name)}`}>
-                    QC project
-                </a>
-            </div>
-        );
-    } else if (props.disableStart || !scanner || scanner.owned || !scanner.power) {
-        scanFrequency = (
-            <tr className="job-info job-interval">
-                <td>Frequency</td>
-                <td>Scan every {props.interval} minutes</td>
-            </tr>
-        );
-        showStart = (
-            <button type="button" className="btn btn-lg job-start" disabled>
-                <span className="glyphicon glyphicon-ban-circle" /> Start
-            </button>
-        );
-    } else {
-        scanFrequency = (
-            <tr className="job-info job-interval">
-                <td>Frequency</td>
-                <td>Scan every {props.interval} minutes</td>
-            </tr>
-        );
-        showStart = (
-            <button type="button" className="btn btn-lg job-start" onClick={props.onStartJob} >
-                <span className="glyphicon glyphicon-play" /> Start
-            </button>
-        );
     }
-    const jobDuration = (
-        <tr className="job-info job-duration">
-            <td>Duration</td>
-            <td>{duration.join(' ')}</td>
-        </tr>
-    );
-    let jobScanner;
-    if (props.status === 'Completed') {
-        jobScanner = null;
-    } else if (scanner) {
-        jobScanner = (
-            <tr className="job-info job-scanner">
-                <td>Scanner</td>
-                <td>{scanner.name} ({scanner.power ? 'online' : 'offline'}, {scanner.owned ? 'occupied' : 'free'})</td>
-            </tr>
-        );
-    } else {
-        jobScanner = (
-            <tr className="job-info job-scanner">
-                <td>Scanner</td>
-                <td>Retrieving scanner status...</td>
-            </tr>
-        );
-    }
-    let jobStart;
-    let jobEnd;
-    if (props.startTime) {
-        jobStart = (
-            <tr className="job-info job-start">
-                <td>Started</td>
-                <td>{`${props.startTime}`}</td>
-            </tr>
-        );
-        if (props.status === 'Completed') {
-            jobEnd = (
-                <tr className="job-info job-end">
-                    <td>Ended</td>
-                    <td>{`${props.endTime}`}</td>
-                </tr>
-            );
-        } else {
-            jobEnd = (
-                <tr className="job-info job-end">
-                    <td>Will end</td>
-                    <td>{`${props.endTime}`}</td>
-                </tr>
-            );
-        }
-    }
-    let labelStyle = 'label label-default';
-    if (props.status === 'Running') {
-        labelStyle = 'label label-info';
-    } else if (props.status === 'Completed') {
-        labelStyle = 'label label-success';
-    }
-    return (
-        <div className="panel panel-default job-listing" id={`job-${props.identifier}`}>
-            <div className="panel-heading">
-                <h3 className="panel-title">{props.name}</h3>
-                <span className={labelStyle}>{props.status}</span>
-            </div>
-            {showStart}
-            <div className="job-description">
-                {status}
-                <table className="table job-stats">
-                    <tbody>
-                        {jobDuration}
-                        {scanFrequency}
-                        {jobScanner}
-                        {jobStart}
-                        {jobEnd}
-                    </tbody>
-                </table>
-            </div>
-            {links}
-        </div>
-    );
 }
 
 ScanningJobPanel.propTypes = {
-    duration: PropTypes.shape({
-        days: PropTypes.number.isRequired,
-        hours: PropTypes.number.isRequired,
-        minutes: PropTypes.number.isRequired,
-    }).isRequired,
+    scanningJob: SoMPropTypes.scanningJobType.isRequired,
     scanner: SoMPropTypes.scannerType,
-    status: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-    interval: PropTypes.number.isRequired,
-    startTime: PropTypes.instanceOf(Date),
-    endTime: PropTypes.instanceOf(Date),
     onStartJob: PropTypes.func.isRequired,
-    disableStart: PropTypes.bool,
-    identifier: PropTypes.string.isRequired,
+    onRemoveJob: PropTypes.func.isRequired,
 };
 
-ScanningJobPanel.defaultProps = {
-    scanner: null,
-    startTime: null,
-    endTime: null,
-    disableStart: false,
-};
+export default ScanningJobPanel;

--- a/scanomatic/ui_server_data/js/src/components/ScanningJobPanelBody.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningJobPanelBody.jsx
@@ -1,0 +1,198 @@
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import SoMPropTypes from '../prop-types';
+import ScanningJobRemoveButton from './ScanningJobRemoveButton';
+
+export function duration2milliseconds(duration) {
+    if (duration) {
+        const date = new Date(0);
+        return date.setUTCHours((duration.days * 24) + duration.hours, duration.minutes);
+    }
+    return 0;
+}
+
+export function getProgress(job) {
+    const duration = duration2milliseconds(job.duration);
+    const progress = new Date() - new Date(job.startTime);
+    return Math.min(1, progress / duration) * 100;
+}
+
+export default function ScanningJobPanelBody(props) {
+    const duration = [];
+    if (props.duration.days > 0) {
+        duration.push(`${props.duration.days} days`);
+    }
+    if (props.duration.hours > 0) {
+        duration.push(`${props.duration.hours} hours`);
+    }
+    if (props.duration.minutes > 0) {
+        duration.push(`${props.duration.minutes} minutes`);
+    }
+    const { scanner } = props;
+    let showStart = null;
+    let status = null;
+    let scanFrequency;
+    let links;
+    if (props.status === 'Running') {
+        const progress = getProgress(props).toFixed(1);
+        status = (
+            <div className="progress">
+                <div
+                    className="progress-bar"
+                    role="progressbar"
+                    aria-valuenow={progress}
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                    style={{ minWidth: '4em', width: `${progress}%` }}
+                >
+                    {progress}%
+                </div>
+            </div>
+        );
+        scanFrequency = (
+            <tr className="job-info job-interval">
+                <td>Frequency</td>
+                <td>Scanning every {props.interval} minutes</td>
+            </tr>
+        );
+    } else if (props.status === 'Completed') {
+        scanFrequency = (
+            <tr className="job-info job-interval">
+                <td>Frequency</td>
+                <td>Scanned every {props.interval} minutes</td>
+            </tr>
+        );
+        links = (
+            <div className="text-right job-links">
+                <a href={`/compile?projectdirectory=root/${props.identifier}`}>
+                    Compile project
+                </a>
+                <a href={`/qc_norm?analysisdirectory=${encodeURI(props.identifier)}/analysis&project=${encodeURI(props.name)}`}>
+                    QC project
+                </a>
+            </div>
+        );
+    } else if (props.disableStart || !scanner || scanner.owned || !scanner.power) {
+        scanFrequency = (
+            <tr className="job-info job-interval">
+                <td>Frequency</td>
+                <td>Scan every {props.interval} minutes</td>
+            </tr>
+        );
+        showStart = (
+            <button type="button" className="btn btn-lg job-start" disabled>
+                <span className="glyphicon glyphicon-ban-circle" /> Start
+            </button>
+        );
+    } else {
+        scanFrequency = (
+            <tr className="job-info job-interval">
+                <td>Frequency</td>
+                <td>Scan every {props.interval} minutes</td>
+            </tr>
+        );
+        showStart = (
+            <button type="button" className="btn btn-lg job-start" onClick={props.onStartJob} >
+                <span className="glyphicon glyphicon-play" /> Start
+            </button>
+        );
+    }
+    const jobDuration = (
+        <tr className="job-info job-duration">
+            <td>Duration</td>
+            <td>{duration.join(' ')}</td>
+        </tr>
+    );
+    let jobScanner;
+    if (props.status === 'Completed') {
+        jobScanner = null;
+    } else if (scanner) {
+        jobScanner = (
+            <tr className="job-info job-scanner">
+                <td>Scanner</td>
+                <td>{scanner.name} ({scanner.power ? 'online' : 'offline'}, {scanner.owned ? 'occupied' : 'free'})</td>
+            </tr>
+        );
+    } else {
+        jobScanner = (
+            <tr className="job-info job-scanner">
+                <td>Scanner</td>
+                <td>Retrieving scanner status...</td>
+            </tr>
+        );
+    }
+    let jobStart;
+    let jobEnd;
+    if (props.startTime) {
+        jobStart = (
+            <tr className="job-info job-start">
+                <td>Started</td>
+                <td>{`${props.startTime}`}</td>
+            </tr>
+        );
+        if (props.status === 'Completed') {
+            jobEnd = (
+                <tr className="job-info job-end">
+                    <td>Ended</td>
+                    <td>{`${props.endTime}`}</td>
+                </tr>
+            );
+        } else {
+            jobEnd = (
+                <tr className="job-info job-end">
+                    <td>Will end</td>
+                    <td>{`${props.endTime}`}</td>
+                </tr>
+            );
+        }
+    }
+    return (
+        <div>
+            <div className="panel-body">
+                {showStart}
+                {props.status === 'Planned' && <ScanningJobRemoveButton
+                    identifier={props.identifier}
+                    onRemoveJob={props.onRemoveJob}
+                />}
+                {status}
+            </div>
+            <table className="table job-stats">
+                <tbody>
+                    {jobDuration}
+                    {scanFrequency}
+                    {jobScanner}
+                    {jobStart}
+                    {jobEnd}
+                </tbody>
+            </table>
+            {links}
+        </div>
+    );
+}
+
+ScanningJobPanelBody.propTypes = {
+    disableStart: PropTypes.bool,
+    duration: PropTypes.shape({
+        days: PropTypes.number.isRequired,
+        hours: PropTypes.number.isRequired,
+        minutes: PropTypes.number.isRequired,
+    }).isRequired,
+    endTime: PropTypes.instanceOf(Date),
+    identifier: PropTypes.string.isRequired,
+    interval: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    onRemoveJob: PropTypes.func.isRequired,
+    onStartJob: PropTypes.func.isRequired,
+    scanner: SoMPropTypes.scannerType,
+    startTime: PropTypes.instanceOf(Date),
+    status: PropTypes.string.isRequired,
+};
+
+ScanningJobPanelBody.defaultProps = {
+    disableStart: false,
+    endTime: null,
+    scanner: null,
+    startTime: null,
+};

--- a/scanomatic/ui_server_data/js/src/components/ScanningJobStatusLabel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningJobStatusLabel.jsx
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const ScanningJobStatusLabel = (props) => {
+    const { status } = props;
+    let className = 'label label-default';
+    if (status === 'Running') {
+        className = 'label label-info';
+    } else if (status === 'Completed') {
+        className = 'label label-success';
+    }
+    return <span className={className}>{status}</span>;
+};
+
+ScanningJobStatusLabel.propTypes = {
+    status: PropTypes.oneOf(['Planned', 'Completed', 'Running']).isRequired,
+};
+
+export default ScanningJobStatusLabel;

--- a/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
@@ -54,7 +54,7 @@ export default function ScanningRoot(props) {
                     onRemoveJob={props.onRemoveJob}
                     key={job.name}
                     scanner={scanner}
-                    {...job}
+                    scanningJob={job}
                 />);
             });
         jobList = (

--- a/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningRoot.jsx
@@ -71,7 +71,7 @@ export default function ScanningRoot(props) {
                     {props.error}
                 </div>
             )}
-            <div className="col-md-6">
+            <div className="col-md-12">
                 <button
                     className="btn btn-primary btn-next new-job"
                     onClick={props.onNewJob}

--- a/scanomatic/ui_server_data/js/src/containers/ScanningRootContainer.jsx
+++ b/scanomatic/ui_server_data/js/src/containers/ScanningRootContainer.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { getScanningJobs, startScanningJob, deleteScanningJob } from '../api';
 import { getScannersWithOwned } from '../helpers';
 import ScanningRoot from '../components/ScanningRoot';
-import { duration2milliseconds } from '../components/ScanningJobPanel';
+import { duration2milliseconds } from '../components/ScanningJobPanelBody';
 
 
 export default class ScanningRootContainer extends React.Component {

--- a/scanomatic/ui_server_data/style/experiment.css
+++ b/scanomatic/ui_server_data/style/experiment.css
@@ -33,17 +33,8 @@ button.new-job {
   min-height: 7.5em;
 }
 
-.job-description {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.job-description .progress {
+.job-listing .progress {
   margin-bottom: 0;
-}
-
-table.job-stats {
-  margin: 0.5em 0 0 0;
 }
 
 table.job-stats tr td:first-child {

--- a/tests/system/test_experiment_page.py
+++ b/tests/system/test_experiment_page.py
@@ -1,0 +1,119 @@
+from uuid import uuid4
+
+import pytest
+import requests
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.support.ui import Select
+
+
+@pytest.fixture(autouse=True, scope='module')
+def scanner(scanomatic):
+    scannerid = uuid4().hex
+    response = requests.put(
+        scanomatic + '/api/scanners/{}/status'.format(scannerid),
+        json={
+            'startTime': '2000-01-02T00:00:00Z',
+            'imagesToSend': 0,
+            'devices': ['epson'],
+        },
+    )
+    response.raise_for_status()
+    return scannerid
+
+
+class PageObject(object):
+    path = '/'
+
+    def __init__(self, driver, baseurl):
+        self.driver = driver
+        self.baseurl = baseurl
+        self.driver.get(self.baseurl + self.path)
+
+
+class ExperimentPage(PageObject):
+    path = '/experiment'
+
+    def add_job(self, name, scannerid=None):
+        btn = self.driver.find_element_by_css_selector('button.new-job')
+        btn.click()
+        form = self.driver.find_element_by_css_selector('div.panel-body')
+        name_input = form.find_element_by_css_selector('input.name')
+        name_input.send_keys(name)
+        scanner_select = Select(
+            self.driver.find_element_by_css_selector('select.scanner')
+        )
+        if scannerid:
+            scanner_select.select_by_value(scannerid)
+        form.find_element_by_css_selector('button.job-add').click()
+
+    def find_job_panel_by_name(self, name):
+        for el in self.driver.find_elements_by_css_selector('div.job-listing'):
+            title = el.find_element_by_tag_name('h3').text
+            print('title', title)
+            if title == name:
+                return ExperimentPage.ScanningJobPanel(el)
+        raise LookupError('No job panel with name "{}"'.format(name))
+
+    class ScanningJobPanel(object):
+
+        def __init__(self, element):
+            self.element = element
+
+        def can_remove_job(self):
+            try:
+                self.element.find_element_by_class_name(
+                    'scanning-job-remove-button'
+                )
+                return True
+            except NoSuchElementException:
+                return False
+
+        def remove_job(self, confirm=True):
+            self.element.find_element_by_class_name(
+                'scanning-job-remove-button'
+            ).click()
+            if confirm:
+                self.element.find_element_by_css_selector(
+                    '.scanning-job-remove-dialogue .confirm-button'
+                ).click()
+            else:
+                self.element.find_element_by_css_selector(
+                    '.scanning-job-remove-dialogue .cancel-button'
+                ).click()
+
+        def start_job(self):
+            self.element.find_element_by_class_name('job-start').click()
+
+    def has_job_with_name(self, name):
+        try:
+            self.find_job_panel_by_name(name)
+            return True
+        except LookupError:
+            return False
+
+
+def test_remove_scanning_job(scanomatic, browser):
+    page = ExperimentPage(browser, scanomatic)
+    name = 'Test job that should be removed {}'.format(uuid4())
+    page.add_job(name=name)
+    panel = page.find_job_panel_by_name(name)
+    panel.remove_job(confirm=True)
+    assert not page.has_job_with_name(name)
+
+
+def test_cancel_removing_scanning_job(scanomatic, browser):
+    page = ExperimentPage(browser, scanomatic)
+    name = 'Test job that should not be removed {}'.format(uuid4())
+    page.add_job(name=name)
+    panel = page.find_job_panel_by_name(name)
+    panel.remove_job(confirm=False)
+    assert page.has_job_with_name(name)
+
+
+def test_cannot_remove_started_job(scanomatic, browser, scanner):
+    page = ExperimentPage(browser, scanomatic)
+    name = 'Started test job that cannot be removed {}'.format(uuid4())
+    page.add_job(name=name, scannerid=scanner)
+    panel = page.find_job_panel_by_name(name)
+    panel.start_job()
+    assert not panel.can_remove_job()

--- a/tests/system/test_experiment_page.py
+++ b/tests/system/test_experiment_page.py
@@ -49,7 +49,6 @@ class ExperimentPage(PageObject):
     def find_job_panel_by_name(self, name):
         for el in self.driver.find_elements_by_css_selector('div.job-listing'):
             title = el.find_element_by_tag_name('h3').text
-            print('title', title)
             if title == name:
                 return ExperimentPage.ScanningJobPanel(el)
         raise LookupError('No job panel with name "{}"'.format(name))


### PR DESCRIPTION
Integrate the changes from the previous PRs: #331, #333, and #335

Refactor `<ScanningJobPanel/>` to handle the job removing interaction:
- move the panel body in a separate component, `<ScannigJobPanelBody/>`
- add state to the panel to decide what is shown inside (normal body or
    remove dialogue).
- move the status label logic in it's own component as well

Add system tests for removing scanning jobs.

*Note: I had to make the panel larger to accomodate the remove dialogue as provided in the UI mocks.*

Screenshots:

**step 1**
![image](https://user-images.githubusercontent.com/38019/37968141-a4578afe-31cd-11e8-912b-bd59f8cccd21.png)


**step 2**
![image](https://user-images.githubusercontent.com/38019/37968040-5f7b1446-31cd-11e8-9867-18dc477ecb38.png)

**Started jobs have no Remove button**
![image](https://user-images.githubusercontent.com/38019/37968236-deaa51d2-31cd-11e8-97f0-b757dd247606.png)
