### PR TITLE
 Add "Projects" page scaffolding

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
-    "presets": ["env", "react"],
+    "presets": ["env", "react", "flow"],
+    "plugins": ["transform-object-rest-spread"],
     "env": {
         "test": {
             "plugins": [ "istanbul" ]

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-    "presets": ["env", "react", "flow"],
+    "presets": ["env", "react"],
     "plugins": ["transform-object-rest-spread"],
     "env": {
         "test": {

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ data/config/rpc.admin
 /docker-compose.override.yml
 /scanomatic/ui_server_data/js/ccc.js
 /scanomatic/ui_server_data/js/scanning.js
+/scanomatic/ui_server_data/js/projects.js
 /scanomatic/ui_server_data/coverage
 geckodriver.log
 /node_modules

--- a/package.json
+++ b/package.json
@@ -2,13 +2,16 @@
   "scripts": {
     "test": "BABEL_ENV=test karma start --single-run",
     "build": "webpack",
-    "lint": "eslint scanomatic/ui_server_data/js/ccc scanomatic/ui_server_data/js/spec"
+    "lint": "eslint scanomatic/ui_server_data/js/src scanomatic/ui_server_data/js/spec",
+    "flow": "flow"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-istanbul": "^4.1.5",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "css-loader": "^0.28.7",
     "enzyme": "^3.1.0",
@@ -23,6 +26,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "^2.0.13",
     "react-test-renderer": "^16.0.0",
+    "redux": "^3.7.2",
     "style-loader": "^0.19.0",
     "webpack": "^3.8.1"
   },
@@ -37,6 +41,7 @@
     "jquery": "^3.2.1",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react-dom": "^16.0.0",
+    "react-redux": "^5.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "scripts": {
     "test": "BABEL_ENV=test karma start --single-run",
     "build": "webpack",
-    "lint": "eslint scanomatic/ui_server_data/js/src scanomatic/ui_server_data/js/spec",
-    "flow": "flow"
+    "lint": "eslint scanomatic/ui_server_data/js/src scanomatic/ui_server_data/js/spec"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
@@ -11,7 +10,6 @@
     "babel-plugin-istanbul": "^4.1.5",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
-    "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "css-loader": "^0.28.7",
     "enzyme": "^3.1.0",
@@ -26,7 +24,6 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "^2.0.13",
     "react-test-renderer": "^16.0.0",
-    "redux": "^3.7.2",
     "style-loader": "^0.19.0",
     "webpack": "^3.8.1"
   },
@@ -42,6 +39,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-redux": "^5.0.7"
+    "react-redux": "^5.0.7",
+    "redux": "^3.7.2"
   }
 }

--- a/scanomatic/ui_server/templates/projects.html
+++ b/scanomatic/ui_server/templates/projects.html
@@ -1,0 +1,10 @@
+{% extends "root.html" %}
+{% block header %}
+  <script src="js/projects.js"></script>
+  <link rel="stylesheet" type="text/css" href="style/main.css">
+{% endblock %}
+{% block page %}
+  <div id="cont" class="container">
+    <div id="react-root"></div>
+  </div>
+{% endblock %}

--- a/scanomatic/ui_server/ui_pages.py
+++ b/scanomatic/ui_server/ui_pages.py
@@ -2,13 +2,10 @@ from __future__ import absolute_import
 
 import os
 
-from flask import (
-    send_from_directory, render_template, redirect, abort, request
-)
+from flask import abort, redirect, render_template, request
 
 from scanomatic import get_version
 from scanomatic.data_processing import phenotyper
-from scanomatic.io.paths import Paths
 from .general import convert_url_to_path, serve_log_as_html
 
 
@@ -94,6 +91,14 @@ def add_routes(app):
     def _experiment():
         return render_template(
             'experiment.html',
+            debug=app.debug,
+            version=get_version(),
+        )
+
+    @app.route("/projects")
+    def _projects():
+        return render_template(
+            'projects.html',
             debug=app.debug,
             version=get_version(),
         )

--- a/scanomatic/ui_server_data/js/src/components/ProjectsRoot.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectsRoot.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function ProjectsRoot() {
+    return (
+        <div>
+            <h1>Projects</h1>
+        </div>
+    );
+}

--- a/scanomatic/ui_server_data/js/src/projects/index.jsx
+++ b/scanomatic/ui_server_data/js/src/projects/index.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+
+import reducer from './reducers';
+import ProjectsRoot from '../components/ProjectsRoot';
+
+
+const store = createStore(reducer);
+
+document.addEventListener('DOMContentLoaded', () => {
+    ReactDOM.render(
+        <Provider store={store}>
+            <ProjectsRoot />
+        </Provider>,
+        document.getElementById('react-root'),
+    );
+});

--- a/scanomatic/ui_server_data/js/src/projects/reducers.js
+++ b/scanomatic/ui_server_data/js/src/projects/reducers.js
@@ -1,0 +1,3 @@
+export default function reducer(state) {
+    return state;
+}

--- a/tests/system/test_projects_page.py
+++ b/tests/system/test_projects_page.py
@@ -1,4 +1,6 @@
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 
 class ProjectsPage(object):
@@ -10,6 +12,9 @@ class ProjectsPage(object):
         self.driver = driver
         self.baseurl = baseurl
         self.driver.get(self.baseurl + self.path)
+        WebDriverWait(
+            self.driver, 5
+        ).until(EC.presence_of_element_located(*self.page_heading_locator))
 
     def get_page_heading(self):
         element = self.driver.find_element(*self.page_heading_locator)

--- a/tests/system/test_projects_page.py
+++ b/tests/system/test_projects_page.py
@@ -1,0 +1,21 @@
+from selenium.webdriver.common.by import By
+
+
+class ProjectsPage(object):
+    path = '/projects'
+
+    page_heading_locator = (By.TAG_NAME, 'h1')
+
+    def __init__(self, driver, baseurl):
+        self.driver = driver
+        self.baseurl = baseurl
+        self.driver.get(self.baseurl + self.path)
+
+    def get_page_heading(self):
+        element = self.driver.find_element(*self.page_heading_locator)
+        return element.text
+
+
+def test_page_is_up(scanomatic, browser):
+    page = ProjectsPage(browser, scanomatic)
+    assert page.get_page_heading() == 'Projects'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ module.exports = {
     entry: {
         ccc: ['./scanomatic/ui_server_data/js/src/ccc.jsx'],
         scanning: ['./scanomatic/ui_server_data/js/src/scanning.jsx'],
+        projects: ['./scanomatic/ui_server_data/js/src/projects'],
     },
     output: {
         filename: 'scanomatic/ui_server_data/js/[name].js',


### PR DESCRIPTION
Add a new path `/projects` with a web page rendering a simple react component and a system test ensuring that everything works.

I also updated the babel config to enable object spread (i.e. `{ ...object  }`).