### PR TITLE
Add explicit wait when creating a job in system tests

### DIFF
--- a/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ScanningJobPanel.jsx
@@ -58,6 +58,7 @@ class ScanningJobPanel extends React.Component {
             <div
                 className="panel panel-default job-listing"
                 id={`job-${identifier}`}
+                data-jobname={name}
             >
                 <div className="panel-heading">
                     <h3 className="panel-title">{name}</h3>

--- a/tests/system/test_experiment_page.py
+++ b/tests/system/test_experiment_page.py
@@ -32,6 +32,11 @@ class ExperimentPage(object):
 
     scanner_select_locator = (By.CSS_SELECTOR, 'select.scanner')
 
+    def scanning_job_panel_locator(self, name):
+        return (
+            By.CSS_SELECTOR, 'div.job-listing[data-jobname="{}"]'.format(name)
+        )
+
     def __init__(self, driver, baseurl):
         self.driver = driver
         self.baseurl = baseurl
@@ -50,19 +55,22 @@ class ExperimentPage(object):
         if scannerid:
             Select(scanner_select).select_by_value(scannerid)
         form.find_element_by_css_selector('button.job-add').click()
+        WebDriverWait(self.driver, 5).until(
+            EC.
+            presence_of_element_located(self.scanning_job_panel_locator(name))
+        )
 
     def find_job_panel_by_name(self, name):
-        for el in self.driver.find_elements_by_css_selector('div.job-listing'):
-            title = el.find_element_by_tag_name('h3').text
-            if title == name:
-                return ScanningJobPanel(el, self.driver)
-        raise LookupError('No job panel with name "{}"'.format(name))
+        return ScanningJobPanel(
+            self.driver.find_element(*self.scanning_job_panel_locator(name)),
+            self.driver
+        )
 
     def has_job_with_name(self, name):
         try:
-            self.find_job_panel_by_name(name)
+            self.driver.find_element(*self.scanning_job_panel_locator(name))
             return True
-        except LookupError:
+        except NoSuchElementException:
             return False
 
 


### PR DESCRIPTION
This fix the system tests that fails randomly by explicitely waiting for the job to appear after adding.

To avoid having to loop through the jobs all the time, I added the job name to the panel as a data attribute.