### PR TITLE
A simple project panel

### DIFF
--- a/scanomatic/ui_server_data/js/src/components/ProjectPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectPanel.jsx
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default function ProjectPanel({ name, description }) {
+    return (
+        <div
+            className="panel panel-default project-listing"
+            data-projectname={name}
+        >
+            <div className="panel-heading">
+                <h3 className="panel-title">{name}</h3>
+            </div>
+            <div className="panel-body">
+                {description}
+            </div>
+        </div>
+    );
+}
+
+ProjectPanel.propTypes = {
+    name: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+};

--- a/scanomatic/ui_server_data/js/src/components/ProjectPanel.spec.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectPanel.spec.jsx
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import './enzyme-setup';
+import ProjectPanel from './ProjectPanel';
+
+describe('<ProjectPanel />', () => {
+    let panel;
+    beforeEach(() => {
+        const wrapper = shallow(<ProjectPanel
+            name="Test"
+            description="Debugging the system."
+        />);
+        panel = wrapper.find('.panel');
+    });
+
+    it('renders a panel', () => {
+        expect(panel.exists()).toBeTruthy();
+        expect(panel.prop('data-projectname')).toEqual('Test');
+    });
+
+    it('renders a panel-heading with name', () => {
+        const panelHeading = panel.find('.panel-heading');
+        expect(panelHeading.exists()).toBeTruthy();
+        expect(panelHeading.text()).toEqual('Test');
+    });
+
+    it('readners a panel-body with the description', () => {
+        const panelBody = panel.find('.panel-body');
+        expect(panelBody.exists()).toBeTruthy();
+        expect(panelBody.text()).toEqual('Debugging the system.');
+    });
+});


### PR DESCRIPTION
Faking how it would look with proper bootstrap and overriding some of the `main.css` rules:
![screenshot from 2018-04-19 10-13-18](https://user-images.githubusercontent.com/8041100/38979434-76751b98-43ba-11e8-971a-d480013c68bf.png)

Implements a simple `ProjectPanel` and tests that it renders what it should render.