### PR TITLE
Add storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,0 +1,13 @@
+import { configure } from '@storybook/react';
+
+const req = require.context(
+    '../scanomatic/ui_server_data/js/src/components',
+    true,
+    /\.stories\.jsx$/
+)
+
+function loadStories() {
+  req.keys().forEach((filename) => req(filename))
+}
+
+configure(loadStories, module);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@storybook/cli": "^3.4.2",
+    "@storybook/react": "^3.4.2",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-istanbul": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "scripts": {
+    "storybook": "start-storybook -p 9001 -c .storybook",
     "test": "BABEL_ENV=test karma start --single-run",
     "build": "webpack",
     "lint": "eslint scanomatic/ui_server_data/js/src scanomatic/ui_server_data/js/spec"
   },
   "devDependencies": {
+    "@storybook/cli": "^3.4.2",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-istanbul": "^4.1.5",

--- a/scanomatic/ui_server_data/js/src/components/NewProjectPanel.stories.jsx
+++ b/scanomatic/ui_server_data/js/src/components/NewProjectPanel.stories.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import NewProjectPanel from './NewProjectPanel';
+import '../../../style/bootstrap.css';
+import '../../../style/experiment.css';
+
+
+storiesOf('NewProjectPanel', module)
+    .addDecorator(story => (
+        <div className="row">
+            <div className="col-md-offset-1 col-md-10">
+                {story()}
+            </div>
+        </div>
+    ))
+    .add('Empty values', () => (
+        <NewProjectPanel
+            name=""
+            description=""
+            error={null}
+            onChange={action('change')}
+            onSubmit={action('submit')}
+            onCancel={action('cancel')}
+        />
+    ))
+    .add('with error', () => (
+        <NewProjectPanel
+            name="Some name"
+            description="This is the description. It describes."
+            error="Something is wrong..."
+            onChange={action('change')}
+            onSubmit={action('submit')}
+            onCancel={action('cancel')}
+        />
+    ));


### PR DESCRIPTION
One common and annoying problem that arise when working on react component is that it is sometime necessary to go through many hoops just to see how a component looks like. E.g. to see a running scanning job in scan-o-matic, one needs an online scanner, and then to create a job with the correct scanner and start it.

One possible solution is to temporarily insert a component with the desired state in the page but that's not very practical or elegant.  So my idea wast to build a static page with a collection of components in different states but of course, npm already has a tool for that, which is [storybook](https://storybook.js.org/).

It's exactly that: it lets you build a collection of components in different states but it adds some widgets for navigation, auto-reload, a console... (and a gazillion dependencies, but not in production...).

 I think this should be helpful when developing/reviewing components but could maybe also replace many low-vlaue/high-maintenance tests like "&lt;MyComponent/&gt; should render a div with class foo and text bar". 

The current configuration auto-discovers stories from `components/*.stories.js` files.

My suggestion is that we try in in scan-o-matic for a few sprints. If we like it, we may then want to add it to other projects. If it turns out to be too much maintenance for too little value, having the stories in separate files should make it easier to remove the whole thing.  

### to try it

```
npm install
npm run storybook
```
And then http://localhost:9001