### PR TITLE
Refactor redux store to use Map

### DIFF
--- a/scanomatic/ui_server_data/js/src/projects/StateBuilder.js
+++ b/scanomatic/ui_server_data/js/src/projects/StateBuilder.js
@@ -74,7 +74,7 @@ export default class StateBuilder {
         this.projectIds = ['001', '002'];
         this.extraProjects = [];
         this.experiments = [];
-        this.scanners = [];
+        this.scanners = [{ id: '001' }];
     }
 
     setNewProjectName(name: string): StateBuilder {
@@ -163,29 +163,29 @@ export default class StateBuilder {
     }
 
     buildProjects(): Projects {
-        const projects = {};
+        const projects = new Map();
         this.projectIds.forEach((id) => {
-            projects[id] = { ...projectDefaults };
+            projects.set(id, { ...projectDefaults });
         });
         this.extraProjects.forEach((p) => {
-            projects[p.id] = { ...projectDefaults, ...p };
+            projects.set(p.id, { ...projectDefaults, ...p });
         });
         return projects;
     }
 
     buildExperiments(): Experiments {
-        const experiments = {};
+        const experiments = new Map();
         this.experiments.forEach((e) => {
-            experiments[e.id] = { ...experimentDefaults, ...e };
+            experiments.set(e.id, { ...experimentDefaults, ...e });
         });
 
         return experiments;
     }
 
     buildScanners(): Scanners {
-        const scanners = {};
+        const scanners = new Map();
         this.scanners.forEach((s) => {
-            scanners[s.id] = { ...scannerDefaults, ...s };
+            scanners.set(s.id, { ...scannerDefaults, ...s });
         });
         return scanners;
     }

--- a/scanomatic/ui_server_data/js/src/projects/actions.js
+++ b/scanomatic/ui_server_data/js/src/projects/actions.js
@@ -21,7 +21,7 @@ export type Action
         interval: number,
         name: string,
         projectId: string,
-        scanner: string,
+        scannerId: string,
     |}
     | {| type: 'EXPERIMENTS_START', id: string, date: Date |}
     | {| type: 'EXPERIMENTS_STOP', id: string, date: Date |}
@@ -91,7 +91,7 @@ export function addExperiment(
     description: string,
     duration: number,
     interval: number,
-    scanner: string,
+    scannerId: string,
 ): Action {
     return {
         type: 'EXPERIMENTS_ADD',
@@ -101,7 +101,7 @@ export function addExperiment(
         description,
         duration,
         interval,
-        scanner,
+        scannerId,
     };
 }
 

--- a/scanomatic/ui_server_data/js/src/projects/actions.spec.js
+++ b/scanomatic/ui_server_data/js/src/projects/actions.spec.js
@@ -89,7 +89,7 @@ describe('projects/actions', () => {
                 description: 'Bla bla bla',
                 duration: 300,
                 interval: 60,
-                scanner: 'sc042',
+                scannerId: 'sc042',
             });
         });
     });
@@ -203,7 +203,7 @@ describe('projects/actions', () => {
                 expect(dispatch).toHaveBeenCalledWith(jasmine.objectContaining({
                     type: 'EXPERIMENTS_ADD',
                     name: 'Some experiment',
-                    scanner: 'xyz',
+                    scannerId: 'xyz',
                     duration: 5000,
                     interval: 500,
                     description: 'bla bla bla',

--- a/scanomatic/ui_server_data/js/src/projects/reducers/entities/experiments.js
+++ b/scanomatic/ui_server_data/js/src/projects/reducers/entities/experiments.js
@@ -2,24 +2,25 @@
 import type { Action } from '../../actions';
 import type { Experiments as State } from '../../state';
 
-const initialState : State = {};
+const initialState : State = new Map();
 
 export default function experiments(state: State = initialState, action: Action): State {
     switch (action.type) {
     case 'EXPERIMENTS_ADD':
-        return {
-            ...state,
-            [action.id]: {
-                name: action.name,
-                description: action.description,
-                duration: action.duration,
-                interval: action.interval,
-                started: null,
-                stopped: null,
-                reason: null,
-                scanner: action.scanner,
-            },
-        };
+    {
+        const newState = new Map(state);
+        newState.set(action.id, {
+            name: action.name,
+            description: action.description,
+            duration: action.duration,
+            interval: action.interval,
+            started: null,
+            stopped: null,
+            reason: null,
+            scannerId: action.scannerId,
+        });
+        return newState;
+    }
     default:
         return state;
     }

--- a/scanomatic/ui_server_data/js/src/projects/reducers/entities/experiments.spec.js
+++ b/scanomatic/ui_server_data/js/src/projects/reducers/entities/experiments.spec.js
@@ -2,12 +2,12 @@ import experiments from './experiments';
 
 describe('projects/reducers/entities/experiments', () => {
     it('should return an empty initial state', () => {
-        expect(experiments(undefined, {})).toEqual({});
+        expect(experiments(undefined, {})).toEqual(new Map());
     });
 
     it('should handle EXPERIMENT_ADD', () => {
-        const state = {
-            '002': {
+        const state = new Map([
+            ['002', {
                 name: 'Some experiment',
                 description: 'This is an experiment',
                 duration: 1200,
@@ -15,9 +15,9 @@ describe('projects/reducers/entities/experiments', () => {
                 started: null,
                 stopped: null,
                 reason: null,
-                scanner: '001',
-            },
-        };
+                scannerId: '001',
+            }],
+        ]);
         const action = {
             type: 'EXPERIMENTS_ADD',
             description: '',
@@ -25,11 +25,11 @@ describe('projects/reducers/entities/experiments', () => {
             id: '003',
             interval: 24,
             name: 'Other experiment',
-            scanner: 'S04',
+            scannerId: 'S04',
         };
-        expect(experiments(state, action)).toEqual({
+        expect(experiments(state, action)).toEqual(new Map([
             ...state,
-            '003': {
+            ['003', {
                 name: 'Other experiment',
                 description: '',
                 duration: 357,
@@ -37,8 +37,8 @@ describe('projects/reducers/entities/experiments', () => {
                 started: null,
                 stopped: null,
                 reason: null,
-                scanner: 'S04',
-            },
-        });
+                scannerId: 'S04',
+            }],
+        ]));
     });
 });

--- a/scanomatic/ui_server_data/js/src/projects/reducers/entities/projects.js
+++ b/scanomatic/ui_server_data/js/src/projects/reducers/entities/projects.js
@@ -2,28 +2,31 @@
 import type { Projects as State } from '../../state';
 import type { Action } from '../../actions';
 
-const defaultState: State = {};
+const defaultState: State = new Map();
 
 export default function projects(state: State = defaultState, action: Action): State {
     switch (action.type) {
     case 'PROJECTS_ADD':
-        return {
-            ...state,
-            [action.id]: {
-                id: action.id,
-                name: action.name,
-                description: action.description,
-                experimentIds: [],
-            },
-        };
+    {
+        const newState = new Map(state);
+        newState.set(action.id, {
+            name: action.name,
+            description: action.description,
+            experimentIds: [],
+        });
+        return newState;
+    }
     case 'EXPERIMENTS_ADD':
-        return {
-            ...state,
-            [action.projectId]: {
-                ...state[action.projectId],
-                experimentIds: [action.id, ...state[action.projectId].experimentIds],
-            },
-        };
+    {
+        const project = state.get(action.projectId);
+        if (!project) return state;
+        const newState = new Map(state);
+        newState.set(action.projectId, {
+            ...project,
+            experimentIds: [action.id, ...project.experimentIds],
+        });
+        return newState;
+    }
     default:
         return state;
     }

--- a/scanomatic/ui_server_data/js/src/projects/reducers/entities/projects.spec.js
+++ b/scanomatic/ui_server_data/js/src/projects/reducers/entities/projects.spec.js
@@ -2,50 +2,47 @@ import reducer from './projects';
 
 describe('projects/reducers/entities/projects', () => {
     it('should return the default state', () => {
-        expect(reducer(undefined, {})).toEqual({});
+        expect(reducer(undefined, {})).toEqual(new Map());
     });
 
     it('should add a project on PROJECTS_ADD', () => {
-        const state = {
-            p1: {
-                id: 'p1',
+        const state = new Map([
+            ['p1', {
                 name: 'Existing Project',
                 description: '',
                 experimentIds: ['e12'],
-            },
-        };
+            }],
+        ]);
         const action = {
             type: 'PROJECTS_ADD', id: 'p2', name: 'New Project', description: 'Very new',
         };
-        expect(reducer(state, action)).toEqual({
-            p1: {
-                id: 'p1',
+        expect(reducer(state, action)).toEqual(new Map([
+            ['p1', {
                 name: 'Existing Project',
                 description: '',
                 experimentIds: ['e12'],
-            },
-            p2: {
-                id: 'p2',
+            }],
+            ['p2', {
                 name: 'New Project',
                 description: 'Very new',
                 experimentIds: [],
-            },
-        });
+            }],
+        ]));
     });
 
     it('should handle EXPERIMENTS_ADD', () => {
-        const state = {
-            p1: {
+        const state = new Map([
+            ['p1', {
                 name: 'Project',
                 description: '',
                 experimentIds: ['e12'],
-            },
-            p2: {
+            }],
+            ['p2', {
                 name: 'Other Project',
                 description: '',
                 experimentIds: ['e34'],
-            },
-        };
+            }],
+        ]);
         const action = {
             type: 'EXPERIMENTS_ADD',
             description: '',
@@ -56,17 +53,17 @@ describe('projects/reducers/entities/projects', () => {
             scannerId: 'S04',
             projectId: 'p1',
         };
-        expect(reducer(state, action)).toEqual({
-            p1: {
+        expect(reducer(state, action)).toEqual(new Map([
+            ['p1', {
                 name: 'Project',
                 description: '',
                 experimentIds: ['003', 'e12'],
-            },
-            p2: {
+            }],
+            ['p2', {
                 name: 'Other Project',
                 description: '',
                 experimentIds: ['e34'],
-            },
-        });
+            }],
+        ]));
     });
 });

--- a/scanomatic/ui_server_data/js/src/projects/selectors.js
+++ b/scanomatic/ui_server_data/js/src/projects/selectors.js
@@ -13,42 +13,64 @@ type Project = {
         interval: number,
         scanner: {
             name: string,
-            isFree: boolean,
-            isOnline: boolean,
+            power: boolean,
+            owned: boolean,
         },
     }>,
 };
 
 export function getProjects(state: State): Array<Project> {
-    return Object.keys(state.entities.projects).sort().reverse().map((key) => {
-        const { name, description, experimentIds } = state.entities.projects[key];
-        return {
+    const projects = Array.from(
+        state.entities.projects,
+        ([key, { name, description, experimentIds }]) => ({
             id: key,
             name,
             description,
             experiments: experimentIds.map((eid) => {
+                const experiment = state.entities.experiments.get(eid);
+                if (!experiment) { throw Error(`Missing experiment with id ${eid}`); }
                 const {
                     name: ename, description: edescription, duration, interval, scannerId,
-                } = state.entities.experiments[eid];
-                const scanner = state.entities.scanners[scannerId];
+                } = experiment;
+                const scanner = state.entities.scanners.get(scannerId);
+                if (!scanner) { throw Error(`Missing scanner with id ${scannerId}`); }
                 return {
                     id: eid,
                     name: ename,
                     description: edescription,
                     duration,
                     interval,
-                    scanner: { ...scanner, id: scannerId },
+                    scanner: {
+                        id: scannerId,
+                        name: scanner.name,
+                        power: scanner.isOnline,
+                        owned: !scanner.isFree,
+                    },
                 };
             }),
-        };
+        }),
+    );
+
+    projects.sort((p1, p2) => {
+        if (p1.id > p2.id) return -1;
+        if (p1.id < p2.id) return 1;
+        return 0;
     });
+    return projects;
 }
 
-export function getScanners(state: State): Array<{ name: string, id: string, isOnline: boolean, isFree: boolean }> {
-    const scanners = Object.keys(state.entities.scanners).map(key => ({
-        ...state.entities.scanners[key],
-        id: key,
-    }));
+export function getScanners(state: State): Array<{ name: string, id: string, power: boolean, owned: boolean }> {
+    const scanners = Array.from(
+        state.entities.scanners,
+        ([key, { name, isOnline, isFree }]) => (
+            {
+                id: key,
+                name,
+                power: isOnline,
+                owned: !isFree,
+            }
+        ),
+    );
     scanners.sort((s1, s2) => {
         if (s1.name < s2.name) return -1;
         if (s1.name > s2.name) return 1;

--- a/scanomatic/ui_server_data/js/src/projects/selectors.spec.js
+++ b/scanomatic/ui_server_data/js/src/projects/selectors.spec.js
@@ -24,7 +24,11 @@ describe('projects/selectors', () => {
                 .clearProjects()
                 .addProject({ id: 'P1', experimentIds: ['E1'] })
                 .addExperiment({
-                    id: 'E1', name: 'Foo experiment', description: 'Experimenting...', duration: 123, interval: 21, scannerid: 'S1',
+                    id: 'E1',
+                    name: 'Foo experiment',
+                    description: 'Experimenting...',
+                    duration: 123,
+                    interval: 21,
                 })
                 .build();
             expect(selectors.getProjects(state)).toEqual([
@@ -59,8 +63,8 @@ describe('projects/selectors', () => {
                             scanner: {
                                 id: 'S1',
                                 name: 'Scanny',
-                                isOnline: true,
-                                isFree: false,
+                                power: true,
+                                owned: true,
                             },
                         }),
                     ],
@@ -82,7 +86,7 @@ describe('projects/selectors', () => {
                 })
                 .build();
             expect(selectors.getScanners(state)).toEqual([{
-                id: 'S01', name: 'Scanny', isOnline: true, isFree: false,
+                id: 'S01', name: 'Scanny', power: true, owned: true,
             }]);
         });
 

--- a/scanomatic/ui_server_data/js/src/projects/state.js
+++ b/scanomatic/ui_server_data/js/src/projects/state.js
@@ -1,38 +1,27 @@
 // @flow
 
-export type Projects = {
-    +[string]: {
-        +name: string,
-        +description: string,
-        +experimentIds: Array<string>,
-    }
-};
+export type Projects = Map<string, {
+    +name: string,
+    +description: string,
+    +experimentIds: Array<string>,
+}>;
 
-export type Experiments = {
-    +[string]: {
-        +name: string,
-        +description: string,
-        +duration: number,
-        +interval: number,
-        +scannerId: string,
-        +started: ?Date,
-        +stopped: ?Date,
-        +reason: ?string,
-    }
-};
+export type Experiments = Map<string, {
+    +name: string,
+    +description: string,
+    +duration: number,
+    +interval: number,
+    +scannerId: string,
+    +started: ?Date,
+    +stopped: ?Date,
+    +reason: ?string,
+}>;
 
-export type Scanners = {
-    +[string]: {
-        +name: string,
-        +isOnline: boolean,
-        +isFree: boolean,
-    }
-};
-
-export type Field = {
-    value: string,
-    touched: boolean,
-};
+export type Scanners = Map<string, {
+    +name: string,
+    +isOnline: boolean,
+    +isFree: boolean,
+}>;
 
 export type NewProject = ?{
     +submitted: boolean,


### PR DESCRIPTION
Refactor the redux store to use Maps instead of objects for entities
(projects, experiments and scanners).

Maps are easier to loop through and easier to typecheck.

This also rename some fields in the actions and the selectors' results
for consistency.