### PR TITLE
Refactor <NewExperimentPanel/>

### DIFF
--- a/scanomatic/ui_server_data/js/src/components/NewExperimentPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/NewExperimentPanel.jsx
@@ -11,15 +11,15 @@ export default function NewExperimentPanel(props) {
             <div className="col-md-6">
                 <div className="panel panel-default">
                     <div className="panel-heading">
-                        New &ldquo;{props.project}&rdquo; experiment
+                        New &ldquo;{props.projectName}&rdquo; experiment
                     </div>
                     <div className="panel-body">
-                        {(props.errors && props.errors.general) && (
+                        {(props.errors.has('general')) && (
                             <div className="alert general-alert alert-danger" role="alert">
-                                {props.errors.general}
+                                {props.errors.get('general')}
                             </div>
                         )}
-                        <div className={`form-group group-name ${props.errors && props.errors.name ? 'has-error' : ''}`}>
+                        <div className={`form-group group-name ${props.errors.has('name') ? 'has-error' : ''}`}>
                             <label className="control-label" htmlFor="new-exp-name">Name</label>
                             <input
                                 className="name form-control"
@@ -27,15 +27,15 @@ export default function NewExperimentPanel(props) {
                                 placeholder="Short description of content"
                                 onChange={e => props.onChange('name', e.target.value)}
                                 name="new-exp-name"
-                                data-error={props.errors && props.errors.name}
+                                data-error={props.errors.get('name')}
                             />
-                            {(props.errors && props.errors.name) && (
+                            {(props.errors.has('name')) && (
                                 <span className="help-block">
-                                    {props.errors.name}
+                                    {props.errors.get('name')}
                                 </span>
                             )}
                         </div>
-                        <div className={`form-group group-description ${props.errors && props.errors.description ? 'has-error' : ''}`}>
+                        <div className={`form-group group-description ${props.errors.has('description') ? 'has-error' : ''}`}>
                             <label className="control-label" htmlFor="new-exp-desc">Description</label>
                             <textarea
                                 className="description form-control vertical-textarea"
@@ -44,18 +44,18 @@ export default function NewExperimentPanel(props) {
                                 name="new-exp-desc"
                                 value={props.description}
                             />
-                            {(props.errors && props.errors.description) && (
+                            {(props.errors.has('description')) && (
                                 <span className="help-block">
-                                    {props.errors.description}
+                                    {props.errors.get('description')}
                                 </span>
                             )}
                         </div>
                         <DurationInput
                             duration={props.duration}
                             onChange={v => props.onChange('duration', v)}
-                            error={props.errors && props.errors.duration}
+                            error={props.errors.get('duration')}
                         />
-                        <div className={`form-group group-interval ${props.errors && props.errors.interval ? 'has-error' : ''}`}>
+                        <div className={`form-group group-interval ${props.errors.has('interval') ? 'has-error' : ''}`}>
                             <label htmlFor="new-exp-interval" className="control-label">Interval</label>
                             <div className="input-group">
                                 <input
@@ -68,26 +68,24 @@ export default function NewExperimentPanel(props) {
                                 />
                                 <span className="input-group-addon" id="interval-unit">minutes</span>
                             </div>
-                            {(props.errors && props.errors.interval) && (
+                            {(props.errors.has('interval')) && (
                                 <span className="help-block">
-                                    {props.errors.interval}
+                                    {props.errors.get('interval')}
                                 </span>
                             )}
                         </div>
-                        <div className={`form-group group-scanner ${props.errors && props.errors.scanner ? 'has-error' : ''}`}>
+                        <div className={`form-group group-scanner ${props.errors.has('scannerId') ? 'has-error' : ''}`}>
                             <label htmlFor="new-exp-scanner" className="control-label">Scanner</label>
                             <select
                                 className="scanner form-control"
-                                onChange={e => props.onChange('scanner', e.target.value)}
+                                onChange={e => props.onChange('scannerId', e.target.value)}
                                 value={props.scannerId}
                                 name="new-exp-scanner"
                             >
+                                <option key="" value="">
+                                    --- Choose scanner ---
+                                </option>
                                 {props.scanners
-                                    .sort((a, b) => {
-                                        if (a.name < b.name) return -1;
-                                        if (a.name > b.name) return 1;
-                                        return 0;
-                                    })
                                     .map(v => (
                                         <option key={v.name} value={v.identifier}>
                                             {v.name}
@@ -95,9 +93,9 @@ export default function NewExperimentPanel(props) {
                                         </option>
                                     ))}
                             </select>
-                            {(props.errors && props.errors.scanner) && (
+                            {(props.errors.has('scannerId')) && (
                                 <span className="help-block">
-                                    {props.errors.scanner}
+                                    {props.errors.get('scannerId')}
                                 </span>
                             )}
                         </div>
@@ -117,8 +115,8 @@ export default function NewExperimentPanel(props) {
 }
 
 NewExperimentPanel.propTypes = {
-    project: PropTypes.string.isRequired,
-    errors: PropTypes.shape(myTypes.newExperimentErrorsShape),
+    projectName: PropTypes.string.isRequired,
+    errors: PropTypes.instanceOf(Map),
     scannerId: PropTypes.string,
     scanners: PropTypes.arrayOf(PropTypes.shape(myTypes.scannerShape)),
     onChange: PropTypes.func.isRequired,
@@ -128,7 +126,7 @@ NewExperimentPanel.propTypes = {
 };
 
 NewExperimentPanel.defaultProps = {
-    errors: null,
+    errors: new Map(),
     scannerId: null,
     scanners: [],
 };

--- a/scanomatic/ui_server_data/js/src/components/NewExperimentPanel.spec.jsx
+++ b/scanomatic/ui_server_data/js/src/components/NewExperimentPanel.spec.jsx
@@ -6,7 +6,7 @@ import NewExperimentPanel from './NewExperimentPanel';
 
 describe('<NewExperimentPanel/>', () => {
     const defaultProps = {
-        project: 'I project',
+        projectName: 'I project',
         name: 'Cool idea',
         description: 'Test all the things',
         duration: 120000,
@@ -31,14 +31,14 @@ describe('<NewExperimentPanel/>', () => {
         onCancel: jasmine.createSpy('onCancel'),
     };
 
-    const errors = {
-        general: 'Cound not reach server',
-        name: 'Maybe you should change yours',
-        description: 'Give me at least one word',
-        duration: 'Need a minute',
-        interval: 'Takes at least five',
-        scanner: 'Thats just a fake scanner',
-    };
+    const errors = new Map([
+        ['general', 'Cound not reach server'],
+        ['name', 'Maybe you should change yours'],
+        ['description', 'Give me at least one word'],
+        ['duration', 'Need a minute'],
+        ['interval', 'Takes at least five'],
+        ['scannerId', 'Thats just a fake scanner'],
+    ]);
 
     let wrapper;
     let wrapperErrors;
@@ -78,7 +78,7 @@ describe('<NewExperimentPanel/>', () => {
         it('should call onChange when scanner is changed', () => {
             const evt = { target: { value: 'myscanner' } };
             wrapper.find('select.scanner').simulate('change', evt);
-            expect(defaultProps.onChange).toHaveBeenCalledWith('scanner', evt.target.value);
+            expect(defaultProps.onChange).toHaveBeenCalledWith('scannerId', evt.target.value);
         });
 
         it('should call onSubmit when form is submitted', () => {
@@ -116,7 +116,7 @@ describe('<NewExperimentPanel/>', () => {
                 const formGroup = wrapperErrors.find('div.group-name');
                 const helpBlock = formGroup.find('.help-block');
                 expect(helpBlock.exists()).toBeTruthy();
-                expect(helpBlock.text()).toEqual(errors.name);
+                expect(helpBlock.text()).toEqual(errors.get('name'));
             });
         });
 
@@ -137,7 +137,7 @@ describe('<NewExperimentPanel/>', () => {
                 const formGroup = wrapperErrors.find('div.group-description');
                 const helpBlock = formGroup.find('.help-block');
                 expect(helpBlock.exists()).toBeTruthy();
-                expect(helpBlock.text()).toEqual(errors.description);
+                expect(helpBlock.text()).toEqual(errors.get('description'));
             });
         });
 
@@ -154,7 +154,7 @@ describe('<NewExperimentPanel/>', () => {
 
             it('passes the error', () => {
                 const duration = wrapperErrors.find('DurationInput');
-                expect(duration.prop('error')).toEqual(errors.duration);
+                expect(duration.prop('error')).toEqual(errors.get('duration'));
             });
         });
 
@@ -175,7 +175,7 @@ describe('<NewExperimentPanel/>', () => {
                 const formGroup = wrapperErrors.find('div.group-interval');
                 const helpBlock = formGroup.find('.help-block');
                 expect(helpBlock.exists()).toBeTruthy();
-                expect(helpBlock.text()).toEqual(errors.interval);
+                expect(helpBlock.text()).toEqual(errors.get('interval'));
             });
         });
 
@@ -189,21 +189,21 @@ describe('<NewExperimentPanel/>', () => {
             it('renders scanners as options', () => {
                 const select = wrapper.find('select.scanner');
                 const options = select.find('option');
-                expect(options.length).toEqual(2);
+                expect(options.length).toEqual(3);
             });
 
-            it('renders first scanner in alphabetical order first', () => {
-                const select = wrapper.find('select.scanner');
-                const options = select.find('option');
-                expect(options.at(0).text()).toEqual('Npm (offline, occupied)');
-                expect(options.at(0).prop('value')).toEqual('haha');
-            });
-
-            it('renders second scanner in alphabetical order second', () => {
+            it('renders first scanner', () => {
                 const select = wrapper.find('select.scanner');
                 const options = select.find('option');
                 expect(options.at(1).text()).toEqual('Tox (online, free)');
                 expect(options.at(1).prop('value')).toEqual('hoho');
+            });
+
+            it('renders second scanner', () => {
+                const select = wrapper.find('select.scanner');
+                const options = select.find('option');
+                expect(options.at(2).text()).toEqual('Npm (offline, occupied)');
+                expect(options.at(2).prop('value')).toEqual('haha');
             });
 
             it('marks as error', () => {
@@ -216,7 +216,7 @@ describe('<NewExperimentPanel/>', () => {
                 const formGroup = wrapperErrors.find('div.group-scanner');
                 const helpBlock = formGroup.find('.help-block');
                 expect(helpBlock.exists()).toBeTruthy();
-                expect(helpBlock.text()).toEqual(errors.scanner);
+                expect(helpBlock.text()).toEqual(errors.get('scannerId'));
             });
         });
 
@@ -224,7 +224,7 @@ describe('<NewExperimentPanel/>', () => {
             const alert = wrapperErrors.find('.general-alert');
             expect(alert.exists()).toBeTruthy();
             expect(alert.hasClass('alert'));
-            expect(alert.text()).toEqual(errors.general);
+            expect(alert.text()).toEqual(errors.get('general'));
         });
     });
 });

--- a/scanomatic/ui_server_data/js/src/components/ProjectPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectPanel.jsx
@@ -55,7 +55,7 @@ ProjectPanel.propTypes = {
 };
 
 ProjectPanel.defaultProps = {
-    newExperimentErrors: null,
+    newExperimentErrors: undefined,
     newExperiment: null,
     newExperimentActions: {},
 };

--- a/scanomatic/ui_server_data/js/src/components/ProjectPanel.stories.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectPanel.stories.jsx
@@ -26,7 +26,7 @@ storiesOf('ProjectPanel', module)
             name="I am project"
             description="The rapid horizontal transmission of many antibiotic resistance genes between bacterial host cells on conjugative plasmids is a major cause of the accelerating antibiotic resistance crisis. Preventing understanding and targeting conjugation, there currently are no experimental platforms for fast and cost-efficient screening of genetic effects on antibiotic resistance transmission by conjugation. We introduce a novel experimental framework to screen for conjugation based horizontal transmission of antibiotic resistance between >60,000 pairs of cell populations in parallel. Plasmid-carrying donor strains are constructed in high throughput."
             newExperiment={{
-                project: 'I am project',
+                projectName: 'I am project',
                 name: '',
                 description: '',
                 duration: 0,
@@ -60,7 +60,7 @@ storiesOf('ProjectPanel', module)
             name="I am project"
             description="The rapid horizontal transmission of many antibiotic resistance genes between bacterial host cells on conjugative plasmids is a major cause of the accelerating antibiotic resistance crisis. Preventing understanding and targeting conjugation, there currently are no experimental platforms for fast and cost-efficient screening of genetic effects on antibiotic resistance transmission by conjugation. We introduce a novel experimental framework to screen for conjugation based horizontal transmission of antibiotic resistance between >60,000 pairs of cell populations in parallel. Plasmid-carrying donor strains are constructed in high throughput."
             newExperiment={{
-                project: 'I am project',
+                projectName: 'I am project',
                 name: '',
                 description: '',
                 duration: 0,
@@ -87,14 +87,14 @@ storiesOf('ProjectPanel', module)
                     identifier: 'haha',
                 },
             ]}
-            newExperimentErrors={{
-                general: 'No repsonse from server.',
-                name: 'Can not be blank',
-                description: 'Dont be lazy, write something',
-                duration: 'I do not like days, I want nights',
-                interval: 'Must be at least 5 minutes',
-                scanner: 'Can not be empty',
-            }}
+            newExperimentErrors={new Map([
+                ['general', 'No repsonse from server.'],
+                ['name', 'Can not be blank'],
+                ['description', 'Dont be lazy, write something'],
+                ['duration', 'I do not like days, I want nights'],
+                ['interval', 'Must be at least 5 minutes'],
+                ['scannerId', 'Can not be empty'],
+            ])}
         />
     ))
     .add('new experiment with only duration error', () => (
@@ -102,7 +102,7 @@ storiesOf('ProjectPanel', module)
             name="I am project"
             description="The rapid horizontal transmission of many antibiotic resistance genes between bacterial host cells on conjugative plasmids is a major cause of the accelerating antibiotic resistance crisis. Preventing understanding and targeting conjugation, there currently are no experimental platforms for fast and cost-efficient screening of genetic effects on antibiotic resistance transmission by conjugation. We introduce a novel experimental framework to screen for conjugation based horizontal transmission of antibiotic resistance between >60,000 pairs of cell populations in parallel. Plasmid-carrying donor strains are constructed in high throughput."
             newExperiment={{
-                project: 'I am project',
+                projectName: 'I am project',
                 name: '',
                 description: '',
                 duration: 0,
@@ -129,8 +129,8 @@ storiesOf('ProjectPanel', module)
                     identifier: 'haha',
                 },
             ]}
-            newExperimentErrors={{
-                duration: 'There should be at least 25h / day',
-            }}
+            newExperimentErrors={new Map([
+                ['duration', 'There should be at least 25h / day'],
+            ])}
         />
     ));

--- a/scanomatic/ui_server_data/js/src/prop-types.js
+++ b/scanomatic/ui_server_data/js/src/prop-types.js
@@ -41,7 +41,6 @@ const projectShape = {
 
 const experimentShape = {
     name: PropTypes.string.isRequired,
-    project: PropTypes.string.isRequired,
     description: PropTypes.string,
     duration: PropTypes.number.isRequired,
     interval: PropTypes.number.isRequired,


### PR DESCRIPTION
- Make `erros` a `Map` instead of an object
- Make the name of the scanner id more consistent with the prop name `scannerId`
  (`scanner -> scannerId` in errors and in the callback)
- Add a valid option in the scanner drop down for when `scannerId` is
  empty
- Leave sorting the scanners to the selector