### PR TITLE
Make jasmine fail on console.error

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,6 +18,7 @@ module.exports = function (config) {
             'js/external/jquery-ui.js',
             'js/qc2.js',
             'js/qc_normHelper.js',
+            'js/src/helpers/jasmine-fail-on-console-error.js',
             { pattern: 'js/src/**/*.spec.@(js|jsx)', watched: false },
         ],
 

--- a/scanomatic/ui_server_data/js/src/components/PolynomialConstruction.spec.jsx
+++ b/scanomatic/ui_server_data/js/src/components/PolynomialConstruction.spec.jsx
@@ -28,6 +28,7 @@ describe('<PolynomialConstruction />', () => {
             stderr: 0.01,
         },
         colonies: {
+            independentMeasurements: [1, 2],
             pixelValues: [[1, 2], [5.5]],
             pixelCounts: [[100, 1], [44]],
             targetValues: [123, 441],

--- a/scanomatic/ui_server_data/js/src/components/ProjectsRoot.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectsRoot.jsx
@@ -7,6 +7,7 @@ import NewProjectPanel from './NewProjectPanel';
 
 export default function ProjectsRoot({
     projects, newProject, newProjectActions, newProjectErrors, onNewProject,
+    onNewExperiment,
 }) {
     let newProjectForm = null;
     if (newProject) {
@@ -22,7 +23,12 @@ export default function ProjectsRoot({
         </button>
     );
 
-    const projectPanels = projects.map(project => <ProjectPanel {...project} key={project.name} />);
+    const projectPanels = projects.map(project =>
+        (<ProjectPanel
+            {...project}
+            key={project.name}
+            onNewExperiment={() => onNewExperiment(project.id)}
+        />));
     return (
         <div>
             <h1>Projects</h1>
@@ -43,6 +49,7 @@ ProjectsRoot.propTypes = {
         onSubmit: PropTypes.func.isRequired,
     }).isRequired,
     onNewProject: PropTypes.func.isRequired,
+    onNewExperiment: PropTypes.func.isRequired,
 };
 
 ProjectsRoot.defaultProps = {

--- a/scanomatic/ui_server_data/js/src/components/ProjectsRoot.spec.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectsRoot.spec.jsx
@@ -14,6 +14,7 @@ describe('<ProjectsRoot />', () => {
             onSubmit: () => {},
         },
         onNewProject: () => {},
+        onNewExperiment: () => {},
     };
 
     describe('New Project button', () => {
@@ -86,10 +87,12 @@ describe('<ProjectsRoot />', () => {
     describe('projects', () => {
         const projects = [
             {
+                id: '1',
                 name: 'Test',
                 description: 'Testing',
             },
             {
+                id: '2',
                 name: 'Old Test',
                 description: 'Bla bala bal',
             },
@@ -114,5 +117,13 @@ describe('<ProjectsRoot />', () => {
             expect(projectPanels.at(0).prop('description')).toEqual(projects[0].description);
             expect(projectPanels.at(1).prop('description')).toEqual(projects[1].description);
         });
+    });
+
+    it('should bing the <ProjectPanel/> onNewExperiment callback to the project id', () => {
+        const projects = [{ id: '147', name: 'Foo', description: 'bar' }];
+        const onNewExperiment = jasmine.createSpy('onNewExperiment');
+        const wrapper = shallow(<ProjectsRoot {...props} projects={projects} onNewExperiment={onNewExperiment} />);
+        wrapper.find('ProjectPanel').prop('onNewExperiment')();
+        expect(onNewExperiment).toHaveBeenCalledWith('147');
     });
 });

--- a/scanomatic/ui_server_data/js/src/helpers/jasmine-fail-on-console-error.js
+++ b/scanomatic/ui_server_data/js/src/helpers/jasmine-fail-on-console-error.js
@@ -1,0 +1,3 @@
+beforeEach(() => {
+    spyOn(console, 'error').and.callFake((warning) => { throw new Error(warning); });
+});


### PR DESCRIPTION
This adds a spy on `console.error` that throw an exception. This mostly concerns prop types. That way, there's no need to scroll through the test results to look for error message (that don't even appear under the correct test). Instead, the test will fail.

Fix the existing errors.