### PR TITLE
Run system test using sauce labs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,3 +55,17 @@ jobs:
             docker-compose push;
             curl "https://jenkins.molflow.com/buildByToken/buildWithParameters?job=INFRA&token=${JENKINS_TOKEN}";
           fi
+    - stage: "Testing with SauceLabs"
+      if: repo=Scan-o-Matic/scanomatic AND branch=master AND type=push
+      python: "2.7"
+      services: ["docker"]
+      addons:
+        apt:
+          packages:
+            - docker-ce
+        sauce_connect: true
+      before_install:
+        - sudo pip install tox
+      script:
+        - docker build --cache-from=phenomique/scanomatic:latest --tag=phenomique/scanomatic:latest .
+        - tox -e system-tests -- --browser saucelabs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/Scan-o-Matic/scanomatic.svg?branch=master)](https://travis-ci.org/Scan-o-Matic/scanomatic)
+[![Sauce Test Status](https://saucelabs.com/buildstatus/scan-o-matic)](https://saucelabs.com/u/scan-o-matic)
 
 # Scan-o-matic (program) and scanomatic (python module)
 
@@ -31,3 +32,8 @@ Please also include the server and ui-server log files (those will be localized 
 
 Do however please note, that if you are doing something super secret, the files will contain some information on what you are doing and it may be needed that you go through them before uploading them publically.
 In this case, only redact the sensitive information, but keep general systematic parts of these lines as intact as possible.
+
+### Big Thanks
+
+Cross-browser Testing Platform and Open Source <3 Provided by
+[Sauce Labs](https://saucelabs.com)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--browser',
         action='store',
-        choices=['firefox', 'chrome'],
+        choices=['firefox', 'chrome', 'saucelabs'],
         default='firefox',
     )
     parser.addoption(

--- a/tests/system/test_experiment_page.py
+++ b/tests/system/test_experiment_page.py
@@ -129,7 +129,7 @@ class ScanningJobPanel(object):
             self.element.find_element_by_css_selector(
                 '.scanning-job-stop-dialogue .confirm-button'
             ).click()
-            WebDriverWait(self.element, 2).until(
+            WebDriverWait(self.element, 5).until(
                 EC.text_to_be_present_in_element(
                     self.status_label_locator, 'Completed'
                 )

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,7 @@ whitelist_externals =
     chromedriver
 passenv =
     DISPLAY
+    SAUCE_*
+    TRAVIS_*
 commands =
     pytest tests/system {posargs}


### PR DESCRIPTION
This adds an extra stage to the travis build that runs the system tests using saucelabs browsers.
* it is configured to use two browser: Firefox and Chrome, both on windows (the available browsers on Linux are lagging behind quite a bit :disappointed:).
* It will only run on push to master.  There are a few reason for this: the credentials are not available on external pull requests ; I want to make sure it's not too flaky ; and more importantly, it takes 20 minutes to run :fearful: