### PR TITLE
Extends <ProjectsRootContainer/> to allow adding experiments

### DIFF
--- a/scanomatic/ui_server_data/js/src/components/NewExperimentPanel.stories.jsx
+++ b/scanomatic/ui_server_data/js/src/components/NewExperimentPanel.stories.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import NewExperimentPanel from './NewExperimentPanel';
+import '../../../style/bootstrap.css';
+import '../../../style/project.css';
+
+
+storiesOf('NewExperimentPanel', module)
+    .addDecorator(story => (
+        <div className="row">
+            <div className="col-md-offset-1 col-md-10">
+                {story()}
+            </div>
+        </div>
+    ))
+    .add('new experiment', () => (
+        <NewExperimentPanel
+            projectName="I am project"
+            name=""
+            description=""
+            duration={0}
+            interval={0}
+            scannerId="haha"
+            onChange={action('change')}
+            onSubmit={action('submit')}
+            onCancel={action('cancel')}
+            scanners={[
+                {
+                    name: 'Tox',
+                    owned: false,
+                    power: true,
+                    identifier: 'hoho',
+                },
+                {
+                    name: 'Npm',
+                    owned: true,
+                    power: false,
+                    identifier: 'haha',
+                },
+            ]}
+        />
+    ))
+    .add('with errors', () => (
+        <NewExperimentPanel
+            projectName="I am project"
+            name=""
+            description=""
+            duration={0}
+            interval={0}
+            scannerId="haha"
+            onChange={action('change')}
+            onSubmit={action('submit')}
+            onCancel={action('cancel')}
+            scanners={[
+                {
+                    name: 'Tox',
+                    owned: false,
+                    power: true,
+                    identifier: 'hoho',
+                },
+                {
+                    name: 'Npm',
+                    owned: true,
+                    power: false,
+                    identifier: 'haha',
+                },
+            ]}
+            errors={new Map([
+                ['general', 'No repsonse from server.'],
+                ['name', 'Can not be blank'],
+                ['description', 'Dont be lazy, write something'],
+                ['duration', 'I do not like days, I want nights'],
+                ['interval', 'Must be at least 5 minutes'],
+                ['scannerId', 'Can not be empty'],
+            ])}
+        />
+    ))
+    .add('new experiment with only duration error', () => (
+        <NewExperimentPanel
+            projectName="I am project"
+            name=""
+            description=""
+            duration={0}
+            interval={1200000}
+            scannerId="haha"
+            onChange={action('change')}
+            onSubmit={action('submit')}
+            onCancel={action('cancel')}
+            scanners={[
+                {
+                    name: 'Tox',
+                    owned: false,
+                    power: true,
+                    identifier: 'hoho',
+                },
+                {
+                    name: 'Npm',
+                    owned: true,
+                    power: false,
+                    identifier: 'haha',
+                },
+            ]}
+            errors={new Map([
+                ['duration', 'There should be at least 25h / day'],
+            ])}
+        />
+    ));

--- a/scanomatic/ui_server_data/js/src/components/ProjectPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectPanel.jsx
@@ -1,24 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import myTypes from '../prop-types';
-import NewExperimentPanel from './NewExperimentPanel';
 
 export default function ProjectPanel({
-    name, description, onNewExperiment, newExperiment, newExperimentActions, newExperimentErrors,
-    scanners,
+    children,
+    description,
+    name,
+    newExperimentDisabled,
+    onNewExperiment,
 }) {
-    let newExperimentPanel;
-    if (newExperiment) {
-        newExperimentPanel = (
-            <NewExperimentPanel
-                errors={newExperimentErrors}
-                scanners={scanners}
-                {...newExperiment}
-                {...newExperimentActions}
-            />
-        );
-    }
-
     return (
         <div
             className="panel panel-default project-listing"
@@ -31,31 +20,26 @@ export default function ProjectPanel({
                 <div className="row">
                     <div className="col-md-9"><div className="text-justify project-description">{description}</div></div>
                     <div className="col-md-3 text-right">
-                        <button className="btn btn-default new-experiment" onClick={() => onNewExperiment(name)} disabled={newExperiment}>
+                        <button className="btn btn-default new-experiment" onClick={() => onNewExperiment(name)} disabled={newExperimentDisabled}>
                             <div className="glyphicon glyphicon-plus" /> New Experiment
                         </button>
                     </div>
                 </div>
-                {newExperimentPanel}
+                {children}
             </div>
         </div>
     );
 }
 
 ProjectPanel.propTypes = {
+    children: PropTypes.node,
+    description: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    newExperimentDisabled: PropTypes.bool,
     onNewExperiment: PropTypes.func.isRequired,
-    newExperiment: PropTypes.shape(myTypes.experimentShape),
-    newExperimentActions: PropTypes.shape({
-        onChange: PropTypes.func,
-        onCancel: PropTypes.func,
-        onSubmit: PropTypes.func,
-    }),
-    newExperimentErrors: PropTypes.shape(myTypes.newExperimentErrorsShape),
-    ...myTypes.projectShape,
 };
 
 ProjectPanel.defaultProps = {
-    newExperimentErrors: undefined,
-    newExperiment: null,
-    newExperimentActions: {},
+    newExperimentDisabled: false,
+    children: null,
 };

--- a/scanomatic/ui_server_data/js/src/components/ProjectPanel.stories.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectPanel.stories.jsx
@@ -21,116 +21,21 @@ storiesOf('ProjectPanel', module)
             onNewExperiment={action('newExperiment')}
         />
     ))
-    .add('new experiment', () => (
+    .add('disable "New Experiment"', () => (
         <ProjectPanel
             name="I am project"
             description="The rapid horizontal transmission of many antibiotic resistance genes between bacterial host cells on conjugative plasmids is a major cause of the accelerating antibiotic resistance crisis. Preventing understanding and targeting conjugation, there currently are no experimental platforms for fast and cost-efficient screening of genetic effects on antibiotic resistance transmission by conjugation. We introduce a novel experimental framework to screen for conjugation based horizontal transmission of antibiotic resistance between >60,000 pairs of cell populations in parallel. Plasmid-carrying donor strains are constructed in high throughput."
-            newExperiment={{
-                projectName: 'I am project',
-                name: '',
-                description: '',
-                duration: 0,
-                interval: 0,
-                scannerId: 'haha',
-            }}
-            newExperimentActions={{
-                onChange: action('change'),
-                onSubmit: action('submit'),
-                onCancel: action('cancel'),
-            }}
             onNewExperiment={action('newExperiment')}
-            scanners={[
-                {
-                    name: 'Tox',
-                    owned: false,
-                    power: true,
-                    identifier: 'hoho',
-                },
-                {
-                    name: 'Npm',
-                    owned: true,
-                    power: false,
-                    identifier: 'haha',
-                },
-            ]}
+            newExperimentDisabled
         />
     ))
-    .add('new experiment with errors', () => (
+    .add('with children', () => (
         <ProjectPanel
             name="I am project"
             description="The rapid horizontal transmission of many antibiotic resistance genes between bacterial host cells on conjugative plasmids is a major cause of the accelerating antibiotic resistance crisis. Preventing understanding and targeting conjugation, there currently are no experimental platforms for fast and cost-efficient screening of genetic effects on antibiotic resistance transmission by conjugation. We introduce a novel experimental framework to screen for conjugation based horizontal transmission of antibiotic resistance between >60,000 pairs of cell populations in parallel. Plasmid-carrying donor strains are constructed in high throughput."
-            newExperiment={{
-                projectName: 'I am project',
-                name: '',
-                description: '',
-                duration: 0,
-                interval: 0,
-                scannerId: 'haha',
-            }}
-            newExperimentActions={{
-                onChange: action('change'),
-                onSubmit: action('submit'),
-                onCancel: action('cancel'),
-            }}
             onNewExperiment={action('newExperiment')}
-            scanners={[
-                {
-                    name: 'Tox',
-                    owned: false,
-                    power: true,
-                    identifier: 'hoho',
-                },
-                {
-                    name: 'Npm',
-                    owned: true,
-                    power: false,
-                    identifier: 'haha',
-                },
-            ]}
-            newExperimentErrors={new Map([
-                ['general', 'No repsonse from server.'],
-                ['name', 'Can not be blank'],
-                ['description', 'Dont be lazy, write something'],
-                ['duration', 'I do not like days, I want nights'],
-                ['interval', 'Must be at least 5 minutes'],
-                ['scannerId', 'Can not be empty'],
-            ])}
-        />
-    ))
-    .add('new experiment with only duration error', () => (
-        <ProjectPanel
-            name="I am project"
-            description="The rapid horizontal transmission of many antibiotic resistance genes between bacterial host cells on conjugative plasmids is a major cause of the accelerating antibiotic resistance crisis. Preventing understanding and targeting conjugation, there currently are no experimental platforms for fast and cost-efficient screening of genetic effects on antibiotic resistance transmission by conjugation. We introduce a novel experimental framework to screen for conjugation based horizontal transmission of antibiotic resistance between >60,000 pairs of cell populations in parallel. Plasmid-carrying donor strains are constructed in high throughput."
-            newExperiment={{
-                projectName: 'I am project',
-                name: '',
-                description: '',
-                duration: 0,
-                interval: 1200000,
-                scannerId: 'haha',
-            }}
-            newExperimentActions={{
-                onChange: action('change'),
-                onSubmit: action('submit'),
-                onCancel: action('cancel'),
-            }}
-            onNewExperiment={action('newExperiment')}
-            scanners={[
-                {
-                    name: 'Tox',
-                    owned: false,
-                    power: true,
-                    identifier: 'hoho',
-                },
-                {
-                    name: 'Npm',
-                    owned: true,
-                    power: false,
-                    identifier: 'haha',
-                },
-            ]}
-            newExperimentErrors={new Map([
-                ['duration', 'There should be at least 25h / day'],
-            ])}
-        />
+        >
+            <div>I am a child!</div>
+            <div>Me too!</div>
+        </ProjectPanel>
     ));

--- a/scanomatic/ui_server_data/js/src/components/ProjectsRoot.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectsRoot.jsx
@@ -13,20 +13,16 @@ export default class ProjectsRoot extends React.Component {
             onNewExperiment, newExperiment, newExperimentErrors, newExperimentActions,
             scanners,
         } = this.props;
+        const hasNewExperiment = newExperiment && newExperiment.projectId === project.id;
         return (
             <ProjectPanel
                 {...project}
                 key={project.name}
-                newExperiment={
-                    (newExperiment && newExperiment.projectId === project.id)
-                        ? newExperiment
-                        : null}
-                newExperimentActions={newExperimentActions}
-                newExperimentErrors={newExperimentErrors}
                 onNewExperiment={() => onNewExperiment(project.id)}
+                newExperimentDisabled={hasNewExperiment}
                 scanners={scanners}
             >
-                {newExperiment && newExperiment.projectId === project.id &&
+                {hasNewExperiment &&
                 <NewExperimentPanel
                     {...newExperiment}
                     {...newExperimentActions}

--- a/scanomatic/ui_server_data/js/src/components/ProjectsRoot.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectsRoot.jsx
@@ -3,57 +3,98 @@ import PropTypes from 'prop-types';
 
 import myTypes from '../prop-types';
 import ProjectPanel from './ProjectPanel';
+import ExperimentPanel from './ExperimentPanel';
 import NewProjectPanel from './NewProjectPanel';
+import NewExperimentPanel from './NewExperimentPanel';
 
-export default function ProjectsRoot({
-    projects, newProject, newProjectActions, newProjectErrors, onNewProject,
-    onNewExperiment,
-}) {
-    let newProjectForm = null;
-    if (newProject) {
-        newProjectForm = (<NewProjectPanel
-            {...newProject}
-            {...newProjectActions}
-            errors={newProjectErrors}
-        />);
+export default class ProjectsRoot extends React.Component {
+    renderProject(project) {
+        const {
+            onNewExperiment, newExperiment, newExperimentErrors, newExperimentActions,
+            scanners,
+        } = this.props;
+        return (
+            <ProjectPanel
+                {...project}
+                key={project.name}
+                newExperiment={
+                    (newExperiment && newExperiment.projectId === project.id)
+                        ? newExperiment
+                        : null}
+                newExperimentActions={newExperimentActions}
+                newExperimentErrors={newExperimentErrors}
+                onNewExperiment={() => onNewExperiment(project.id)}
+                scanners={scanners}
+            >
+                {newExperiment && newExperiment.projectId === project.id &&
+                <NewExperimentPanel
+                    {...newExperiment}
+                    {...newExperimentActions}
+                    projectName={project.name}
+                    errors={newExperimentErrors}
+                    scanners={scanners}
+                />}
+                {project.experiments.map(experiment => (
+                    <ExperimentPanel key={experiment.id} {...experiment} />
+                ))}
+            </ProjectPanel>);
     }
-    const newProjectButton = (
-        <button className="btn btn-primary new-project" onClick={onNewProject} disabled={newProject}>
-            <div className="glyphicon glyphicon-plus" /> New Project
-        </button>
-    );
 
-    const projectPanels = projects.map(project =>
-        (<ProjectPanel
-            {...project}
-            key={project.name}
-            onNewExperiment={() => onNewExperiment(project.id)}
-        />));
-    return (
-        <div>
-            <h1>Projects</h1>
-            {newProjectButton}
-            {newProjectForm}
-            {projectPanels}
-        </div>
-    );
+    render() {
+        const {
+            projects, newProject, newProjectActions, newProjectErrors, onNewProject,
+        } = this.props;
+        let newProjectForm = null;
+        if (newProject) {
+            newProjectForm = (<NewProjectPanel
+                {...newProject}
+                {...newProjectActions}
+                errors={newProjectErrors}
+            />);
+        }
+        const newProjectButton = (
+            <button className="btn btn-primary new-project" onClick={onNewProject} disabled={newProject}>
+                <div className="glyphicon glyphicon-plus" /> New Project
+            </button>
+        );
+
+        return (
+            <div>
+                <h1>Projects</h1>
+                {newProjectButton}
+                {newProjectForm}
+                {projects.map(p => this.renderProject(p))}
+            </div>
+        );
+    }
 }
 
 ProjectsRoot.propTypes = {
-    projects: PropTypes.arrayOf(PropTypes.shape(myTypes.projectShape)),
+    newExperiment: PropTypes.shape(myTypes.experimentShape),
+    newExperimentActions: PropTypes.shape({
+        onChange: PropTypes.func.isRequired,
+        onCancel: PropTypes.func.isRequired,
+        onSubmit: PropTypes.func.isRequired,
+    }).isRequired,
+    newExperimentErrors: PropTypes.instanceOf(Map),
     newProject: PropTypes.shape(myTypes.projectShape),
-    newProjectErrors: PropTypes.instanceOf(Map),
     newProjectActions: PropTypes.shape({
         onChange: PropTypes.func.isRequired,
         onCancel: PropTypes.func.isRequired,
         onSubmit: PropTypes.func.isRequired,
     }).isRequired,
-    onNewProject: PropTypes.func.isRequired,
+    newProjectErrors: PropTypes.instanceOf(Map),
     onNewExperiment: PropTypes.func.isRequired,
+    onNewProject: PropTypes.func.isRequired,
+    projects: PropTypes.arrayOf(PropTypes.shape(myTypes.projectShape)),
+    scanners: PropTypes.arrayOf(PropTypes.shape(myTypes.scannerShape)),
 };
 
 ProjectsRoot.defaultProps = {
-    projects: [],
+    newExperiment: undefined,
+    newExperimentErrors: undefined,
     newProject: null,
     newProjectErrors: null,
+    projects: [],
+    scanners: [],
 };

--- a/scanomatic/ui_server_data/js/src/components/ProjectsRoot.spec.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectsRoot.spec.jsx
@@ -7,6 +7,11 @@ import ProjectsRoot from './ProjectsRoot';
 describe('<ProjectsRoot />', () => {
     const props = {
         projects: [],
+        newExperimentActions: {
+            onChange: () => {},
+            onCancel: () => {},
+            onSubmit: () => {},
+        },
         newProject: null,
         newProjectActions: {
             onChange: () => {},
@@ -90,11 +95,13 @@ describe('<ProjectsRoot />', () => {
                 id: '1',
                 name: 'Test',
                 description: 'Testing',
+                experiments: [],
             },
             {
                 id: '2',
                 name: 'Old Test',
                 description: 'Bla bala bal',
+                experiments: [],
             },
         ];
 
@@ -119,11 +126,76 @@ describe('<ProjectsRoot />', () => {
         });
     });
 
-    it('should bing the <ProjectPanel/> onNewExperiment callback to the project id', () => {
-        const projects = [{ id: '147', name: 'Foo', description: 'bar' }];
+    it('should bind the <ProjectPanel/> onNewExperiment callback to the project id', () => {
+        const projects = [{
+            id: '147', name: 'Foo', description: 'bar', experiments: [],
+        }];
         const onNewExperiment = jasmine.createSpy('onNewExperiment');
-        const wrapper = shallow(<ProjectsRoot {...props} projects={projects} onNewExperiment={onNewExperiment} />);
+        const wrapper = shallow(<ProjectsRoot
+            {...props}
+            projects={projects}
+            onNewExperiment={onNewExperiment}
+        />);
         wrapper.find('ProjectPanel').prop('onNewExperiment')();
         expect(onNewExperiment).toHaveBeenCalledWith('147');
     });
+
+    it(
+        'should create <NewExperimentPanel/> under <ProjectPanel/> with corresponding id',
+        () => {
+            const projects = [
+                {
+                    id: '42', name: 'Foo', description: 'bar', experiments: [],
+                },
+                {
+                    id: '147', name: 'Bla', description: 'Bla bla bl', experiments: [],
+                },
+            ];
+            const newExperiment = {
+                name: 'grow stuff',
+                description: '',
+                duration: 123,
+                interval: 1,
+                scannerId: '',
+                projectId: '42',
+            };
+            const wrapper = shallow(<ProjectsRoot
+                {...props}
+                projects={projects}
+                newExperiment={newExperiment}
+            />);
+            expect(wrapper.find('ProjectPanel[id="42"]').find('NewExperimentPanel').exists())
+                .toBeTruthy();
+            expect(wrapper.find('ProjectPanel[id="147"]').find('NewExperimentPanel').exists())
+                .toBeFalsy();
+        },
+    );
+    it(
+        'should create an <ExperimentPanel/> under <ProjectPanel/> for each experiment',
+        () => {
+            const projects = [
+                {
+                    id: '42',
+                    name: 'Foo',
+                    description: 'bar',
+                    experiments: [{
+                        id: '01',
+                        name: 'First Experiment',
+                        description: 'Bla bla',
+                        duration: 36000000,
+                        interval: 500000,
+                        scanner: {
+                            identifier: 'S01', name: 'Scanny', power: true, owned: true,
+                        },
+                    }],
+                },
+            ];
+            const wrapper = shallow(<ProjectsRoot
+                {...props}
+                projects={projects}
+            />);
+            expect(wrapper.find('ProjectPanel[id="42"]').find('ExperimentPanel').exists())
+                .toBeTruthy();
+        },
+    );
 });

--- a/scanomatic/ui_server_data/js/src/components/ProjectsRoot.spec.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectsRoot.spec.jsx
@@ -170,6 +170,31 @@ describe('<ProjectsRoot />', () => {
                 .toBeFalsy();
         },
     );
+
+    it(
+        'should pass newExperimentDisabled=true to <ProjectPanel/> if there is a new experiment for project',
+        () => {
+            const projects = [
+                {
+                    id: '42', name: 'Foo', description: 'bar', experiments: [],
+                },
+            ];
+            const newExperiment = {
+                name: 'grow stuff',
+                description: '',
+                duration: 123,
+                interval: 1,
+                scannerId: '',
+                projectId: '42',
+            };
+            const wrapper = shallow(<ProjectsRoot
+                {...props}
+                projects={projects}
+                newExperiment={newExperiment}
+            />);
+            expect(wrapper.find('ProjectPanel[id="42"]').prop('newExperimentDisabled')).toBeTruthy();
+        },
+    );
     it(
         'should create an <ExperimentPanel/> under <ProjectPanel/> for each experiment',
         () => {

--- a/scanomatic/ui_server_data/js/src/containers/ProjectsRootContainer.jsx
+++ b/scanomatic/ui_server_data/js/src/containers/ProjectsRootContainer.jsx
@@ -1,13 +1,32 @@
 import { connect } from 'react-redux';
 import ProjectRoot from '../components/ProjectsRoot';
-import { initNewProject, clearNewProject, changeNewProject, submitNewProject } from '../projects/actions';
-import { getNewProject, getNewProjectErrors, getProjects } from '../projects/selectors';
+import {
+    changeNewExperiment,
+    changeNewProject,
+    clearNewExperiment,
+    clearNewProject,
+    initNewExperiment,
+    initNewProject,
+    submitNewExperiment,
+    submitNewProject,
+} from '../projects/actions';
+import {
+    getNewExperiment,
+    getNewExperimentErrors,
+    getNewProject,
+    getNewProjectErrors,
+    getProjects,
+    getScanners,
+} from '../projects/selectors';
 
 function mapStateToProps(state) {
     return {
         newProject: getNewProject(state),
         newProjectErrors: getNewProjectErrors(state),
+        newExperiment: getNewExperiment(state),
+        newExperimentErrors: getNewExperimentErrors(state),
         projects: getProjects(state),
+        scanners: getScanners(state),
     };
 }
 
@@ -15,6 +34,12 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         onNewProject: () => dispatch(initNewProject()),
+        onNewExperiment: projectId => dispatch(initNewExperiment(projectId)),
+        newExperimentActions: {
+            onCancel: () => dispatch(clearNewExperiment()),
+            onChange: (field, value) => dispatch(changeNewExperiment(field, value)),
+            onSubmit: () => dispatch(submitNewExperiment()),
+        },
         newProjectActions: {
             onCancel: () => dispatch(clearNewProject()),
             onChange: (field, value) => dispatch(changeNewProject(field, value)),

--- a/scanomatic/ui_server_data/js/src/projects/index.jsx
+++ b/scanomatic/ui_server_data/js/src/projects/index.jsx
@@ -8,7 +8,21 @@ import reducer from './reducers';
 import ProjectsRootContainer from '../containers/ProjectsRootContainer';
 
 
-const store = createStore(reducer, applyMiddleware(thunk));
+const store = createStore(
+    reducer,
+    {
+        entities: {
+            scanners: {
+                '0000': {
+                    name: 'Scanner One',
+                    isOnline: true,
+                    isFree: true,
+                },
+            },
+        },
+    },
+    applyMiddleware(thunk),
+);
 
 document.addEventListener('DOMContentLoaded', () => {
     ReactDOM.render(

--- a/scanomatic/ui_server_data/js/src/projects/reducers/entities/index.js
+++ b/scanomatic/ui_server_data/js/src/projects/reducers/entities/index.js
@@ -2,6 +2,7 @@
 import { combineReducers } from 'redux';
 import projects from './projects';
 import experiments from './experiments';
+import scanners from './scanners';
 
-const entities = combineReducers({ experiments, projects });
+const entities = combineReducers({ experiments, projects, scanners });
 export default entities;

--- a/scanomatic/ui_server_data/js/src/projects/reducers/entities/scanners.js
+++ b/scanomatic/ui_server_data/js/src/projects/reducers/entities/scanners.js
@@ -1,0 +1,12 @@
+// @flow
+import type { Action } from '../../actions';
+import type { Scanners as State } from '../../state';
+
+const initialState : State = {};
+
+export default function scanners(state: State = initialState, action: Action): State {
+    switch (action.type) {
+    default:
+        return state;
+    }
+}

--- a/scanomatic/ui_server_data/js/src/projects/reducers/entities/scanners.spec.js
+++ b/scanomatic/ui_server_data/js/src/projects/reducers/entities/scanners.spec.js
@@ -1,0 +1,7 @@
+import reducer from './scanners';
+
+describe('projects/reducers/entities/scanners', () => {
+    it('should return the default state', () => {
+        expect(reducer(undefined, {})).toEqual({});
+    });
+});

--- a/scanomatic/ui_server_data/js/src/projects/selectors.js
+++ b/scanomatic/ui_server_data/js/src/projects/selectors.js
@@ -59,12 +59,12 @@ export function getProjects(state: State): Array<Project> {
     return projects;
 }
 
-export function getScanners(state: State): Array<{ name: string, id: string, power: boolean, owned: boolean }> {
+export function getScanners(state: State): Array<{ name: string, identifier: string, power: boolean, owned: boolean }> {
     const scanners = Array.from(
         state.entities.scanners,
         ([key, { name, isOnline, isFree }]) => (
             {
-                id: key,
+                identifier: key,
                 name,
                 power: isOnline,
                 owned: !isFree,

--- a/scanomatic/ui_server_data/js/src/projects/selectors.spec.js
+++ b/scanomatic/ui_server_data/js/src/projects/selectors.spec.js
@@ -86,7 +86,7 @@ describe('projects/selectors', () => {
                 })
                 .build();
             expect(selectors.getScanners(state)).toEqual([{
-                id: 'S01', name: 'Scanny', power: true, owned: true,
+                identifier: 'S01', name: 'Scanny', power: true, owned: true,
             }]);
         });
 

--- a/tests/system/test_projects_page.py
+++ b/tests/system/test_projects_page.py
@@ -247,5 +247,4 @@ def test_create_experiment_without_name(scanomatic, browser):
     form.set_interval(123)
     form.set_scanner('0000')
     form.click_submit()
-    print(form.errors)
     assert 'Required' in form.errors

--- a/tests/system/test_projects_page.py
+++ b/tests/system/test_projects_page.py
@@ -1,5 +1,3 @@
-import time
-
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select, WebDriverWait
@@ -120,16 +118,22 @@ class NewExperimentForm(object):
         input.send_keys(description)
 
     def set_duration(self, days, hours, minutes):
-        self.element.find_element(*self.duration_input_locator('days')
-                                 ).send_keys(days)
-        self.element.find_element(*self.duration_input_locator('hours')
-                                 ).send_keys(hours)
-        self.element.find_element(*self.duration_input_locator('minutes')
-                                 ).send_keys(minutes)
+        days_input = self.element.find_element(
+            *self.duration_input_locator('days')
+        )
+        days_input.send_keys(days)
+        hours_input = self.element.find_element(
+            *self.duration_input_locator('hours')
+        )
+        hours_input.send_keys(hours)
+        minutes_input = self.element.find_element(
+            *self.duration_input_locator('minutes')
+        )
+        minutes_input.send_keys(minutes)
 
     def set_interval(self, minutes):
-        self.element.find_element(*self.interval_input_locator
-                                 ).send_keys(minutes)
+        input = self.element.find_element(*self.interval_input_locator)
+        input.send_keys(minutes)
 
     def set_scanner(self, scannerid):
         element = self.element.find_element(*self.scanner_select_locator)
@@ -159,7 +163,9 @@ class ExperimentPanel(object):
         )
 
     def __init__(self, parent, name):
-        self.element = parent.find_element(*self.experiment_panel_locator(name))
+        self.element = parent.find_element(
+            *self.experiment_panel_locator(name)
+        )
 
     @property
     def heading(self):


### PR DESCRIPTION
This connects all the new components to the state:
- sets the `newExperiment*` props in the appropriate components
- render `<ExperimentPanel/>`s for each projects' experiment.
- add system tests that create new experiments

Refactor `<ProjectPanel/>`: instead of rendering the (new) experiment in the `<ProjectPanel/>` componenet, they are passed as children. This makes the component much simpler and avoid passing a gazillion props through.
