### PR TITLE
Stylefixes

### DIFF
--- a/scanomatic/ui_server_data/js/src/components/ExperimentPanel/index.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ExperimentPanel/index.jsx
@@ -20,7 +20,7 @@ export default function ExperimentPanel({
                 <ScanningJobStatusLabel status={status} />
             </div>
             <div className="panel-body">
-                <div className="row">
+                <div className="row description-and-actions">
                     <div className="col-md-9">
                         <div className="text-justify experiment-description">{description}</div>
                     </div>

--- a/scanomatic/ui_server_data/js/src/components/ProjectPanel.jsx
+++ b/scanomatic/ui_server_data/js/src/components/ProjectPanel.jsx
@@ -42,7 +42,7 @@ class ProjectPanel extends React.Component {
                 </div>
                 {this.state.expanded && (
                     <div className="panel-body">
-                        <div className="row">
+                        <div className="row description-and-actions">
                             <div className="col-md-9">
                                 <div className="text-justify project-description">
                                     {description}

--- a/scanomatic/ui_server_data/style/project.css
+++ b/scanomatic/ui_server_data/style/project.css
@@ -26,3 +26,15 @@
 .form-group {
   margin-top: 2rem;
 }
+
+.panel-title {
+  display: inline-block;
+}
+
+.scanning-job-status-label {
+  float: right;
+}
+
+.description-and-actions {
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
![screenshot from 2018-05-04 11-07-57](https://user-images.githubusercontent.com/8041100/39620512-b6ae7d58-4f8b-11e8-9d9c-c056ad15f1d5.png)

Margin below the `+ Add Experiment` button and having the status label to the right again.