### PR TITLE
Flow config

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,5 @@
 [ignore]
+./node_modules/config-chain/test/broken.json
 
 [include]
 


### PR DESCRIPTION
This test-file causes error in flow. I wasn't sure if it was good idea to omit entire `node_modules` since it might be useful if we use modules that use flow too.