### PR TITLE
Global access QC Redux store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ data/config/rpc.admin
 /scanomatic/ui_server_data/js/scanning.js
 /scanomatic/ui_server_data/js/projects.js
 /scanomatic/ui_server_data/js/statuspage.js
+/scanomatic/ui_server_data/js/qc.js
 /scanomatic/ui_server_data/coverage
 geckodriver.log
 /node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=npmbuilder /src/scanomatic/ui_server_data/js/ccc.js /tmp/scanomatic/
 COPY --from=npmbuilder /src/scanomatic/ui_server_data/js/scanning.js /tmp/scanomatic/ui_server_data/js/scanning.js
 COPY --from=npmbuilder /src/scanomatic/ui_server_data/js/projects.js /tmp/scanomatic/ui_server_data/js/projects.js
 COPY --from=npmbuilder /src/scanomatic/ui_server_data/js/statuspage.js /tmp/scanomatic/ui_server_data/js/statuspage.js
+COPY --from=npmbuilder /src/scanomatic/ui_server_data/js/qc.js /tmp/scanomatic/ui_server_data/js/qc.js
 RUN cd /tmp && python setup.py install
 
 COPY scripts/entrypoint.sh /entrypoint.sh

--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -9,6 +9,7 @@
   <script src="js/external/bootstrap-toggle.js"></script>
   <script src="js/external/spin.js"></script>
 
+  <script src="js/qc.js"></script>
   <script src="js/qc_normHelper.js"></script>
   <script src="js/qc_normDrawPlate.js"></script>
   <script src="js/qc_normDrawCurves.js"></script>

--- a/scanomatic/ui_server_data/js/src/api.js
+++ b/scanomatic/ui_server_data/js/src/api.js
@@ -9,7 +9,7 @@ const secondsPerMinute = 60;
 const secondsPerHour = 3600;
 const secondsPerDay = 86400;
 
-class API {
+export class API {
     static get(url) {
         return new Promise((resolve, reject) => $.ajax({
             url,

--- a/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
+++ b/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
@@ -6,12 +6,23 @@ export default class StateBuilder {
     settings: Settings;
 
     constructor() {
-        this.plate = { number: 1 };
+        this.plate = { number: 0 };
         this.settings = {};
+    }
+
+    setProject(project: string) {
+        this.settings = { project };
+        this.plate = { number: 0 };
+        return this;
     }
 
     setPlate(plate: number) {
         this.plate = { number: plate };
+        return this;
+    }
+
+    setPinning(rows: number, cols: number) {
+        this.plate = Object.assign({}, this.plate, { pinning: { rows, cols } });
         return this;
     }
 
@@ -24,6 +35,12 @@ export default class StateBuilder {
     setSmoothCurveData(plate: number, row: number, col: number, data: TimeSeries) {
         if (plate !== this.plate.number) return this;
         this.plate.smooth = getUpdated2DArrayCopy(this.plate.smooth, row, col, data);
+        return this;
+    }
+
+    setTimes(plate: number, times: TimeSeries) {
+        if (plate !== this.plate.number) return this;
+        this.plate.times = times;
         return this;
     }
 

--- a/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
+++ b/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
@@ -1,0 +1,36 @@
+import type { State, TimeSeries, Plate, Settings } from './state';
+import { getUpdated2DArrayCopy } from './helpers';
+
+export default class StateBuilder {
+    plate: Plate;
+    settings: Settings;
+
+    constructor() {
+        this.plate = { number: 1 };
+        this.settings = {};
+    }
+
+    setPlate(plate: number) {
+        this.plate = { number: plate };
+        return this;
+    }
+
+    setRawCurveData(plate: number, row: number, col: number, data: TimeSeries) {
+        if (plate !== this.plate.number) return this;
+        this.plate.raw = getUpdated2DArrayCopy(this.plate.raw, row, col, data);
+        return this;
+    }
+
+    setSmoothCurveData(plate: number, row: number, col: number, data: TimeSeries) {
+        if (plate !== this.plate.number) return this;
+        this.plate.smooth = getUpdated2DArrayCopy(this.plate.smooth, row, col, data);
+        return this;
+    }
+
+    build() : State {
+        return {
+            plate: this.plate,
+            settings: this.settings,
+        };
+    }
+}

--- a/scanomatic/ui_server_data/js/src/qc/actions.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.js
@@ -53,7 +53,7 @@ export function setSmoothCurveData(
     };
 }
 
-type ThunkAction = (dispatch: Action => any, getState: () => State) => any;
+export type ThunkAction = (dispatch: Action => any, getState: () => State) => any;
 
 // Limit on FF and Chrome (IE has more, but who cares?)
 const MAX_CONCURRENT_CONNECTIONS = 6;
@@ -63,8 +63,11 @@ export function retrievePlateCurves() : ThunkAction {
     return (dispatch, getState) => {
         const state = getState();
         const project = getProject(state);
+        if (project == null) {
+            throw new Error('Cannot retrieve curves if project not set');
+        }
         const plate = getPlate(state);
-        const { rows, cols } = getPinning(state) || { rows: 0, cols: 0 };
+        const { rows, cols } = getPinning(state, plate) || { rows: 0, cols: 0 };
         let row = 0;
         let col = -1; // It will be increased to 0 on first poll
         let pending = 0;

--- a/scanomatic/ui_server_data/js/src/qc/actions.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.js
@@ -1,13 +1,17 @@
 // @flow
+import { getProject, getPlate, getPinning } from './selectors';
 import type { State, TimeSeries } from './state';
+import { getCurveData } from './api';
 
 export type Action
-    = {| type: 'PLATE_SET', plate: Number |}
+    = {| type: 'PLATE_SET', plate: number |}
     | {| type: 'PROJECT_SET', project: string |}
-    | {| type: 'CURVE_RAW_SET', plate: Number, row: Number, col: Number, data: TimeSeries |}
-    | {| type: 'CURVE_SMOOTH_SET', plate: Number, row: Number, col: Number, data: TimeSeries |}
+    | {| type: 'CURVE_RAW_SET', plate: number, row: number, col: number, data: TimeSeries |}
+    | {| type: 'CURVE_SMOOTH_SET', plate: number, row: number, col: number, data: TimeSeries |}
+    | {| type: 'PINNING_SET', plate: number, rows: number, cols: number |}
+    | {| type: 'TIMES_SET', times: TimeSeries, plate: number |}
 
-export function setPlate(plate : Number) : Action {
+export function setPlate(plate : number) : Action {
     return { type: 'PLATE_SET', plate };
 }
 
@@ -15,10 +19,22 @@ export function setProject(project : string) : Action {
     return { type: 'PROJECT_SET', project };
 }
 
+export function setPinning(plate : number, rows: number, cols: number) : Action {
+    return {
+        type: 'PINNING_SET', plate, rows, cols,
+    };
+}
+
+export function setTimes(plate: number, times: TimeSeries) : Action {
+    return {
+        type: 'TIMES_SET', plate, times,
+    };
+}
+
 export function setRawCurveData(
-    plate: Number,
-    row: Number,
-    col: Number,
+    plate: number,
+    row: number,
+    col: number,
     data: TimeSeries,
 ) : Action {
     return {
@@ -27,9 +43,9 @@ export function setRawCurveData(
 }
 
 export function setSmoothCurveData(
-    plate: Number,
-    row: Number,
-    col: Number,
+    plate: number,
+    row: number,
+    col: number,
     data: TimeSeries,
 ) : Action {
     return {
@@ -39,11 +55,53 @@ export function setSmoothCurveData(
 
 type ThunkAction = (dispatch: Action => any, getState: () => State) => any;
 
+// Limit on FF and Chrome (IE has more, but who cares?)
+const MAX_CONCURRENT_CONNECTIONS = 6;
+const POLL_INTERVAL = 50;
+
 export function retrievePlateCurves() : ThunkAction {
-    return () => {
-        // dispatch arg if needed
-        // getState second arg if needed
-        // Perform fetching
-        // Set plate curves
+    return (dispatch, getState) => {
+        const project = getProject(getState());
+        const plate = getPlate(getState());
+        const { rows, cols } = getPinning(getState());
+        let row = 0;
+        let col = 0;
+        let pending = 0;
+
+        const success = (r) => {
+            pending -= 1;
+            dispatch(setRawCurveData(plate, r.row, r.col, r.raw));
+            dispatch(setSmoothCurveData(plate, r.row, r.col, r.smooth));
+            if (r.row === 0 && r.col === 0) {
+                dispatch(setTimes(r.plate, r.times));
+            }
+        };
+        const fail = () => {
+            pending -= 1;
+        };
+
+        const poller = () => {
+            if (getPlate(getState()) !== plate) return;
+            while (pending < MAX_CONCURRENT_CONNECTIONS) {
+                // Next position
+                col += 1;
+                if (col === cols) {
+                    row += 1;
+                    if (row === rows) return;
+                }
+
+                pending += 1;
+                getCurveData(
+                    project,
+                    plate,
+                    row,
+                    col,
+                )
+                    .then(success)
+                    .catch(fail);
+            }
+            setTimeout(poller, POLL_INTERVAL);
+        };
+        poller();
     };
 }

--- a/scanomatic/ui_server_data/js/src/qc/actions.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.js
@@ -40,7 +40,9 @@ export function setSmoothCurveData(
 type ThunkAction = (dispatch: Action => any, getState: () => State) => any;
 
 export function retrievePlateCurves() : ThunkAction {
-    return (dispatch, getState) => {
+    return () => {
+        // dispatch arg if needed
+        // getState second arg if needed
         // Perform fetching
         // Set plate curves
     };

--- a/scanomatic/ui_server_data/js/src/qc/actions.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.js
@@ -61,11 +61,12 @@ const POLL_INTERVAL = 50;
 
 export function retrievePlateCurves() : ThunkAction {
     return (dispatch, getState) => {
-        const project = getProject(getState());
-        const plate = getPlate(getState());
-        const { rows, cols } = getPinning(getState());
+        const state = getState();
+        const project = getProject(state);
+        const plate = getPlate(state);
+        const { rows, cols } = getPinning(state) || { rows: 0, cols: 0 };
         let row = 0;
-        let col = 0;
+        let col = -1; // It will be increased to 0 on first poll
         let pending = 0;
 
         const success = (r) => {
@@ -85,9 +86,10 @@ export function retrievePlateCurves() : ThunkAction {
             while (pending < MAX_CONCURRENT_CONNECTIONS) {
                 // Next position
                 col += 1;
-                if (col === cols) {
+                if (col >= cols) {
                     row += 1;
-                    if (row === rows) return;
+                    col = 0;
+                    if (row >= rows) return;
                 }
 
                 pending += 1;

--- a/scanomatic/ui_server_data/js/src/qc/actions.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.js
@@ -1,0 +1,47 @@
+// @flow
+import type { State, TimeSeries } from './state';
+
+export type Action
+    = {| type: 'PLATE_SET', plate: Number |}
+    | {| type: 'PROJECT_SET', project: string |}
+    | {| type: 'CURVE_RAW_SET', plate: Number, row: Number, col: Number, data: TimeSeries |}
+    | {| type: 'CURVE_SMOOTH_SET', plate: Number, row: Number, col: Number, data: TimeSeries |}
+
+export function setPlate(plate : Number) : Action {
+    return { type: 'PLATE_SET', plate };
+}
+
+export function setProject(project : string) : Action {
+    return { type: 'PROJECT_SET', project };
+}
+
+export function setRawCurveData(
+    plate: Number,
+    row: Number,
+    col: Number,
+    data: TimeSeries,
+) : Action {
+    return {
+        type: 'CURVE_RAW_SET', plate, row, col, data,
+    };
+}
+
+export function setSmoothCurveData(
+    plate: Number,
+    row: Number,
+    col: Number,
+    data: TimeSeries,
+) : Action {
+    return {
+        type: 'CURVE_SMOOTH_SET', plate, row, col, data,
+    };
+}
+
+type ThunkAction = (dispatch: Action => any, getState: () => State) => any;
+
+export function retrievePlateCurves() : ThunkAction {
+    return (dispatch, getState) => {
+        // Perform fetching
+        // Set plate curves
+    };
+}

--- a/scanomatic/ui_server_data/js/src/qc/actions.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.spec.js
@@ -1,6 +1,6 @@
 import * as actions from './actions';
 
-describe('qc/actions', () => {
+describe('/qc/actions', () => {
     describe('setPlate', () => {
         it('should return a PLATE_SET action', () => {
             expect(actions.setPlate(5)).toEqual({
@@ -15,6 +15,27 @@ describe('qc/actions', () => {
             expect(actions.setProject('test.me')).toEqual({
                 type: 'PROJECT_SET',
                 project: 'test.me',
+            });
+        });
+    });
+
+    describe('setPinning', () => {
+        it('should return a PINNING_SET action', () => {
+            expect(actions.setPinning(1, 2, 3)).toEqual({
+                type: 'PINNING_SET',
+                plate: 1,
+                rows: 2,
+                cols: 3,
+            });
+        });
+    });
+
+    describe('setTimes', () => {
+        it('should return a TIMES_SET action', () => {
+            expect(actions.setTimes(0, [1, 2, 3])).toEqual({
+                type: 'TIMES_SET',
+                plate: 0,
+                times: [1, 2, 3],
             });
         });
     });

--- a/scanomatic/ui_server_data/js/src/qc/actions.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.spec.js
@@ -1,0 +1,47 @@
+import * as actions from './actions';
+
+describe('qc/actions', () => {
+    describe('setPlate', () => {
+        it('should return a PLATE_SET action', () => {
+            expect(actions.setPlate(5)).toEqual({
+                type: 'PLATE_SET',
+                plate: 5,
+            });
+        });
+    });
+
+    describe('setProject', () => {
+        it('should return a PROJECT_SET action', () => {
+            expect(actions.setProject('test.me')).toEqual({
+                type: 'PROJECT_SET',
+                project: 'test.me',
+            });
+        });
+    });
+
+    describe('setRawCurveData', () => {
+        it('should return a CURVE_RAW_SET action', () => {
+            expect(actions.setRawCurveData(1, 2, 3, [4, 5, 6]))
+                .toEqual({
+                    type: 'CURVE_RAW_SET',
+                    plate: 1,
+                    row: 2,
+                    col: 3,
+                    data: [4, 5, 6],
+                });
+        });
+    });
+
+    describe('setSmoothCurveData', () => {
+        it('should return a CURVE_SMOOTH_SET action', () => {
+            expect(actions.setSmoothCurveData(1, 2, 3, [4, 5, 6]))
+                .toEqual({
+                    type: 'CURVE_SMOOTH_SET',
+                    plate: 1,
+                    row: 2,
+                    col: 3,
+                    data: [4, 5, 6],
+                });
+        });
+    });
+});

--- a/scanomatic/ui_server_data/js/src/qc/api.js
+++ b/scanomatic/ui_server_data/js/src/qc/api.js
@@ -1,0 +1,20 @@
+// @flow
+import { API } from '../api';
+
+export const getCurveData = (project: string, plate: number, row: number, col: number) => {
+    const uri = `/api/results/curves/${plate}/${row}/${col}/${project}`;
+    return API.get(uri)
+        .then(r => ({
+            project,
+            plate,
+            row,
+            col,
+            raw: r.raw_data,
+            smooth: r.smooth_data,
+            times: r.time_data,
+        }));
+};
+
+export default {
+    getCurveData,
+};

--- a/scanomatic/ui_server_data/js/src/qc/api.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/api.spec.js
@@ -1,0 +1,66 @@
+import * as API from './api';
+
+describe('API (qc)', () => {
+    const onSuccess = jasmine.createSpy('onSuccess');
+    const onError = jasmine.createSpy('onError');
+    const mostRecentRequest = () => jasmine.Ajax.requests.mostRecent();
+
+    beforeEach(() => {
+        onSuccess.calls.reset();
+        onError.calls.reset();
+        jasmine.Ajax.install();
+    });
+
+    afterEach(() => {
+        jasmine.Ajax.uninstall();
+    });
+
+    describe('getCurveData', () => {
+        const args = [
+            'something/somewhere', // Project
+            0, // Plate index
+            10, // Row index
+            5, // Col index
+        ];
+
+        it('should query the correct uri', () => {
+            API.getCurveData(...args);
+            expect(mostRecentRequest().url)
+                .toBe('/api/results/curves/0/10/5/something/somewhere');
+        });
+
+        it('should return a promise that resolves on success', (done) => {
+            API.getCurveData(...args).then((response) => {
+                expect(response).toEqual({
+                    project: 'something/somewhere',
+                    plate: 0,
+                    row: 10,
+                    col: 5,
+                    raw: [1, 3, 5],
+                    smooth: [2, 4, 6],
+                    times: [0, 1, 2],
+                });
+                done();
+            });
+            mostRecentRequest().respondWith({
+                status: 200,
+                responseText: JSON.stringify({
+                    raw_data: [1, 3, 5],
+                    smooth_data: [2, 4, 6],
+                    time_data: [0, 1, 2],
+                }),
+            });
+        });
+
+        it('should return a promise that rejects on error', (done) => {
+            API.getCurveData(...args).catch((response) => {
+                expect(response).toEqual('nooo!');
+                done();
+            });
+            mostRecentRequest().respondWith({
+                status: 400,
+                responseText: JSON.stringify({ reason: 'nooo!' }),
+            });
+        });
+    });
+});

--- a/scanomatic/ui_server_data/js/src/qc/bridge.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.js
@@ -1,0 +1,39 @@
+// @flow
+
+import { retrievePlateCurves, setProject } from './actions';
+import { getCurve } from './selectors';
+import type { State } from './state';
+
+export class Selectors {
+    constructor(store : State) {
+        this.store = store;
+    }
+
+    getRawCurve(plate: Number, row : Number, col : Number) {
+        return getCurve(this.store, row, col);
+    }
+
+    getSmoothCurve(plate: Number, row : Number, col : Number) {
+        return getCurve(this.store, row, col);
+    }
+}
+
+export class Actions {
+    constructor(store : State) {
+        this.store = store;
+    }
+
+    setProject(project: string) {
+        this.store.dispatch(setProject(project));
+    }
+
+    retrievePlateCurves(plate: Number) {
+        this.store.dispatch(retrievePlateCurves(plate));
+    }
+}
+
+export default function Bridge(store: State) {
+    const actions = new Actions(store);
+    const selectors = new Selectors(store);
+    return { actions, selectors };
+}

--- a/scanomatic/ui_server_data/js/src/qc/bridge.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.js
@@ -1,30 +1,45 @@
 // @flow
 
-import { retrievePlateCurves, setProject } from './actions';
-import { getCurve } from './selectors';
-import type { State } from './state';
+import { retrievePlateCurves, setProject, setPlate } from './actions';
+import { getRawCurve, getSmoothCurve, getTimes, getPlate } from './selectors';
+import type { State, TimeSeries } from './state';
 
 export class Selectors {
+    store: State;
+
     constructor(store : State) {
         this.store = store;
     }
 
-    getRawCurve(plate: Number, row : Number, col : Number) {
-        return getCurve(this.store, row, col);
+    getRawCurve(plate: number, row : number, col : number) : TimeSeries {
+        if (getPlate(this.store) !== plate) return null;
+        return getRawCurve(this.store, row, col);
     }
 
-    getSmoothCurve(plate: Number, row : Number, col : Number) {
-        return getCurve(this.store, row, col);
+    getSmoothCurve(plate: Number, row : Number, col : Number) : TimeSeries {
+        if (getPlate(this.store) !== plate) return null;
+        return getSmoothCurve(this.store, row, col);
+    }
+
+    getTimes(plate: number) : TimeSeries {
+        if (getPlate(this.store) !== plate) return null;
+        return getTimes(this.store);
     }
 }
 
 export class Actions {
+    store: State;
+
     constructor(store : State) {
         this.store = store;
     }
 
     setProject(project: string) {
         this.store.dispatch(setProject(project));
+    }
+
+    setPlate(plate: number) {
+        this.store.dispatch(setPlate(plate));
     }
 
     retrievePlateCurves(plate: Number) {

--- a/scanomatic/ui_server_data/js/src/qc/bridge.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.js
@@ -35,5 +35,10 @@ export class Actions {
 export default function Bridge(store: State) {
     const actions = new Actions(store);
     const selectors = new Selectors(store);
-    return { actions, selectors };
+    const subscribe: (() => void) => void = callback => this.store.subscribe(callback);
+    return {
+        actions,
+        selectors,
+        subscribe,
+    };
 }

--- a/scanomatic/ui_server_data/js/src/qc/bridge.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.js
@@ -7,32 +7,33 @@ import {
     getRawCurve, getSmoothCurve, getTimes, getPlate,
 } from './selectors';
 
-import type { Action } from './actions';
+import type { Action, ThunkAction } from './actions';
 import type { State, TimeSeries, Pinning } from './state';
 
 type Store = {
-    +dispatch: Action => any,
+    +dispatch: (Action | ThunkAction) => any,
     +getState: () => State,
     +subscribe: (() => any) => any,
 }
-export class Selectors {
+
+class Selectors {
     store : Store
 
     constructor(store : Store) {
         this.store = store;
     }
 
-    getRawCurve(plate: number, row : number, col : number) : TimeSeries {
+    getRawCurve(plate: number, row : number, col : number) : ?TimeSeries {
         const state = this.store.getState();
         return getRawCurve(state, plate, row, col);
     }
 
-    getSmoothCurve(plate: Number, row : Number, col : Number) : TimeSeries {
+    getSmoothCurve(plate: number, row : number, col : number) : ?TimeSeries {
         const state = this.store.getState();
         return getSmoothCurve(state, plate, row, col);
     }
 
-    getTimes(plate: number) : TimeSeries {
+    getTimes(plate: number) : ?TimeSeries {
         const state = this.store.getState();
         return getTimes(state, plate);
     }
@@ -43,7 +44,7 @@ export class Selectors {
     }
 }
 
-export class Actions {
+class Actions {
     store: Store;
 
     constructor(store : Store) {
@@ -64,8 +65,8 @@ export class Actions {
 
     retrievePlateCurves(plate: ?number = null, pinning: ?Pinning = null) {
         if (plate != null) {
-            this.store.dispatch(setPlate(plate));
-            if (pinning != null) this.store.dispatch(setPinning(plate, pinning.rows, pinning.cols));
+            this.setPlate(plate);
+            if (pinning != null) this.setPinning(plate, pinning.rows, pinning.cols);
         }
         this.store.dispatch(retrievePlateCurves());
     }

--- a/scanomatic/ui_server_data/js/src/qc/bridge.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.spec.js
@@ -1,0 +1,119 @@
+import Bridge from './bridge';
+import * as actions from './actions';
+import * as selectors from './selectors';
+
+
+describe('/qc/bridge', () => {
+    const state = { plate: {}, settings: {} };
+    const store = {
+        subscribe: jasmine.createSpy('subscribe'),
+        dispatch: jasmine.createSpy('dispatch'),
+        getState: jasmine.createSpy('getState').and.returnValue(state),
+    };
+
+    const bridge = Bridge(store);
+    let retrievePlateCurves;
+
+    beforeEach(() => {
+        store.subscribe.calls.reset();
+        store.dispatch.calls.reset();
+        store.getState.calls.reset();
+        retrievePlateCurves = spyOn(actions, 'retrievePlateCurves');
+    });
+
+    it('registers subscription to the store changes', () => {
+        const fn = () => {};
+        bridge.subscribe(fn);
+        expect(store.subscribe).toHaveBeenCalledWith(fn);
+    });
+
+    describe('actions', () => {
+        it('dispatches an PROJECT_SET on setProject', () => {
+            bridge.actions.setProject('hello');
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'PROJECT_SET',
+                project: 'hello',
+            });
+        });
+
+        it('dispatches a PLATE_SET on setPlate', () => {
+            bridge.actions.setPlate(42);
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'PLATE_SET',
+                plate: 42,
+            });
+        });
+
+        it('dispatches, a PINNING_SET on setPinning', () => {
+            bridge.actions.setPinning(0, 4, 2);
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'PINNING_SET',
+                plate: 0,
+                rows: 4,
+                cols: 2,
+            });
+        });
+
+        it('dispatches a retrievePlateCurves ThunkAction on retrievePlateCurves', () => {
+            bridge.actions.retrievePlateCurves();
+            expect(store.dispatch).toHaveBeenCalled();
+            expect(retrievePlateCurves).toHaveBeenCalled();
+        });
+
+        it('dispatches a PLATE_SET on retrievePlateCurves if argument set', () => {
+            bridge.actions.retrievePlateCurves(2);
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'PLATE_SET',
+                plate: 2,
+            });
+        });
+
+        it('dispatches a PINNING_SET on retrievePlateCurves if arguments set', () => {
+            bridge.actions.retrievePlateCurves(2, { rows: 5, cols: 3 });
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'PLATE_SET',
+                plate: 2,
+            });
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'PINNING_SET',
+                plate: 2,
+                rows: 5,
+                cols: 3,
+            });
+        });
+    });
+
+    describe('selectors', () => {
+        it('calls getRawCurve on getRawCurve', () => {
+            const getRawCurve = spyOn(selectors, 'getRawCurve').and.returnValue([5, 2]);
+            const raw = bridge.selectors.getRawCurve(0, 1, 2);
+            expect(store.getState).toHaveBeenCalled();
+            expect(getRawCurve).toHaveBeenCalledWith(state, 0, 1, 2);
+            expect(raw).toEqual([5, 2]);
+        });
+
+        it('calls getSmoothCurve on getSmoothCurve', () => {
+            const getSmoothCurve = spyOn(selectors, 'getSmoothCurve').and.returnValue([5, 2]);
+            const smooth = bridge.selectors.getSmoothCurve(0, 1, 2);
+            expect(store.getState).toHaveBeenCalled();
+            expect(getSmoothCurve).toHaveBeenCalledWith(state, 0, 1, 2);
+            expect(smooth).toEqual([5, 2]);
+        });
+
+        it('calls getTimes on getTimes', () => {
+            const getTimes = spyOn(selectors, 'getTimes').and.returnValue([5, 2]);
+            const times = bridge.selectors.getTimes(0);
+            expect(store.getState).toHaveBeenCalled();
+            expect(getTimes).toHaveBeenCalledWith(state, 0);
+            expect(times).toEqual([5, 2]);
+        });
+
+        it('calls getPlate on getPlate', () => {
+            const getPlate = spyOn(selectors, 'getPlate').and.returnValue(52);
+            const plate = bridge.selectors.getPlate();
+            expect(store.getState).toHaveBeenCalled();
+            expect(getPlate).toHaveBeenCalledWith(state);
+            expect(plate).toEqual(52);
+        });
+    });
+});

--- a/scanomatic/ui_server_data/js/src/qc/helpers.js
+++ b/scanomatic/ui_server_data/js/src/qc/helpers.js
@@ -1,8 +1,8 @@
 // @flow
-import { TimeSeries, PlateOfTimeSeries } from './state';
+import type { TimeSeries, PlateOfTimeSeries } from './state';
 
 export const getUpdated2DArrayCopy = (
-    old: PlateOfTimeSeries,
+    old: ?PlateOfTimeSeries,
     row: number,
     col: number,
     data: TimeSeries,

--- a/scanomatic/ui_server_data/js/src/qc/helpers.js
+++ b/scanomatic/ui_server_data/js/src/qc/helpers.js
@@ -1,0 +1,25 @@
+// @flow
+import { TimeSeries, PlateOfTimeSeries } from './state';
+
+export const getUpdated2DArrayCopy = (
+    old: PlateOfTimeSeries,
+    row: number,
+    col: number,
+    data: TimeSeries,
+) : PlateOfTimeSeries => {
+    const ly = Math.max(old ? old.length : 0, row + 1);
+    const lx = Math.max(old && old.length > 0 ? old[0].length : 0, col + 1);
+    const arr = [];
+    for (let y = 0; y < ly; y += 1) {
+        const copy = old && old.length > y ? old[y].slice() : Array(lx).fill(null);
+        if (y === row) {
+            copy[col] = data;
+        }
+        arr.push(copy);
+    }
+    return arr;
+};
+
+export default {
+    getUpdated2DArrayCopy,
+};

--- a/scanomatic/ui_server_data/js/src/qc/helpers.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/helpers.spec.js
@@ -30,12 +30,11 @@ describe('qc/helpers', () => {
                 [null, null, null, null],
                 [null, null, null, [4, 5]],
             ];
-            getUpdated2DArrayCopy(data, 3, 0, [1, 2]);
+            getUpdated2DArrayCopy(data, 0, 0, [1, 2]);
             expect(data).toEqual([
                 [null, null, null, null],
                 [null, null, null, null],
                 [null, null, null, [4, 5]],
-                [[1, 2], null, null, null],
             ]);
         });
     });

--- a/scanomatic/ui_server_data/js/src/qc/helpers.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/helpers.spec.js
@@ -1,0 +1,42 @@
+import { getUpdated2DArrayCopy } from './helpers';
+
+describe('qc/helpers', () => {
+    describe('getUpdated2DArrayCopy', () => {
+        it('creates expected array', () => {
+            expect(getUpdated2DArrayCopy(null, 2, 3, [4, 5])).toEqual([
+                [null, null, null, null],
+                [null, null, null, null],
+                [null, null, null, [4, 5]],
+            ]);
+        });
+
+        it('returns updated copy', () => {
+            const data = [
+                [null, null, null, null],
+                [null, null, null, null],
+                [null, null, null, [4, 5]],
+            ];
+            expect(getUpdated2DArrayCopy(data, 3, 0, [1, 2])).toEqual([
+                [null, null, null, null],
+                [null, null, null, null],
+                [null, null, null, [4, 5]],
+                [[1, 2], null, null, null],
+            ]);
+        });
+
+        it('doesnt modify the input', () => {
+            const data = [
+                [null, null, null, null],
+                [null, null, null, null],
+                [null, null, null, [4, 5]],
+            ];
+            getUpdated2DArrayCopy(data, 3, 0, [1, 2]);
+            expect(data).toEqual([
+                [null, null, null, null],
+                [null, null, null, null],
+                [null, null, null, [4, 5]],
+                [[1, 2], null, null, null],
+            ]);
+        });
+    });
+});

--- a/scanomatic/ui_server_data/js/src/qc/index.js
+++ b/scanomatic/ui_server_data/js/src/qc/index.js
@@ -6,6 +6,7 @@ import Bridge from './bridge';
 
 const store = createStore(
     reducer,
+    // { plate: {}, settings: {} },
     {},
     applyMiddleware(thunk),
 );

--- a/scanomatic/ui_server_data/js/src/qc/index.js
+++ b/scanomatic/ui_server_data/js/src/qc/index.js
@@ -1,0 +1,13 @@
+import { createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+
+import reducer from './reducers';
+import Bridge from './bridge';
+
+const store = createStore(
+    reducer,
+    {},
+    applyMiddleware(thunk),
+);
+
+window.qc = Bridge(store);

--- a/scanomatic/ui_server_data/js/src/qc/reducers/index.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/index.js
@@ -1,0 +1,12 @@
+// @flow
+import { combineReducers } from 'redux';
+
+import type { State } from '../state';
+import type { Action } from '../actions';
+
+import plate from './plate';
+import settings from './settings';
+
+const reducers: (State, Action) => State = combineReducers({ plate, settings });
+
+export default reducers;

--- a/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
@@ -1,0 +1,39 @@
+import type { Action } from '../actions';
+import type { Plate as State } from '../state';
+import type { getPlate } from './selectors';
+
+const initialState : State = { number: 1 };
+
+export function GetUpdated2DArrayCopy(old, row, col, data) {
+    const arr = [];
+    const ly = Math.max(old ? old.length : 0, row + 1);
+    for (let y = 0; y < ly; y += 1) {
+        const copy = old ? old[y].slice() : [];
+        if (y === row) {
+            copy[col] = data;
+        }
+        arr.push(copy);
+    }
+    return arr;
+}
+
+export default function plate(state: State = initialState, action: Action) {
+    switch (action.type) {
+    case 'PROJECT_SET':
+        return initialState;
+    case 'PLATE_SET':
+        return Object.assign({}, state, { number: action.plate });
+    case 'CURVE_RAW_SET': {
+        if (action.plate !== getPlate()) return state;
+        const raw = GetUpdated2DArrayCopy(state.raw, action.row, action.col, action.data);
+        return Object.assign({}, state, { raw });
+    }
+    case 'CURVE_SMOOTH_SET': {
+        if (action.plate !== getPlate()) return state;
+        const smooth = GetUpdated2DArrayCopy(state.smooth, action.row, action.col, action.data);
+        return Object.assign({}, state, { smooth });
+    }
+    default:
+        return state;
+    }
+}

--- a/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
@@ -2,7 +2,7 @@ import type { Action } from '../actions';
 import type { Plate as State } from '../state';
 import { getUpdated2DArrayCopy } from '../helpers';
 
-const initialState : State = { number: 1 };
+const initialState : State = { number: 0 };
 
 export default function plate(state: State = initialState, action: Action) {
     switch (action.type) {
@@ -20,6 +20,12 @@ export default function plate(state: State = initialState, action: Action) {
         const smooth = getUpdated2DArrayCopy(state.smooth, action.row, action.col, action.data);
         return Object.assign({}, state, { smooth });
     }
+    case 'PINNING_SET':
+        if (action.plate !== state.number) return state;
+        return Object.assign({}, state, { pinning: { rows: action.rows, cols: action.cols } });
+    case 'TIMES_SET':
+        if (action.plate !== state.number) return state;
+        return Object.assign({}, state, { times: action.times });
     default:
         return state;
     }

--- a/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
@@ -1,21 +1,8 @@
 import type { Action } from '../actions';
 import type { Plate as State } from '../state';
-import type { getPlate } from './selectors';
+import { getUpdated2DArrayCopy } from '../helpers';
 
 const initialState : State = { number: 1 };
-
-export function GetUpdated2DArrayCopy(old, row, col, data) {
-    const arr = [];
-    const ly = Math.max(old ? old.length : 0, row + 1);
-    for (let y = 0; y < ly; y += 1) {
-        const copy = old ? old[y].slice() : [];
-        if (y === row) {
-            copy[col] = data;
-        }
-        arr.push(copy);
-    }
-    return arr;
-}
 
 export default function plate(state: State = initialState, action: Action) {
     switch (action.type) {
@@ -24,13 +11,13 @@ export default function plate(state: State = initialState, action: Action) {
     case 'PLATE_SET':
         return Object.assign({}, state, { number: action.plate });
     case 'CURVE_RAW_SET': {
-        if (action.plate !== getPlate()) return state;
-        const raw = GetUpdated2DArrayCopy(state.raw, action.row, action.col, action.data);
+        if (action.plate !== state.number) return state;
+        const raw = getUpdated2DArrayCopy(state.raw, action.row, action.col, action.data);
         return Object.assign({}, state, { raw });
     }
     case 'CURVE_SMOOTH_SET': {
-        if (action.plate !== getPlate()) return state;
-        const smooth = GetUpdated2DArrayCopy(state.smooth, action.row, action.col, action.data);
+        if (action.plate !== state.number) return state;
+        const smooth = getUpdated2DArrayCopy(state.smooth, action.row, action.col, action.data);
         return Object.assign({}, state, { smooth });
     }
     default:

--- a/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
@@ -9,7 +9,7 @@ export default function plate(state: State = initialState, action: Action) {
     case 'PROJECT_SET':
         return initialState;
     case 'PLATE_SET':
-        return Object.assign({}, state, { number: action.plate });
+        return { number: action.plate };
     case 'CURVE_RAW_SET': {
         if (action.plate !== state.number) return state;
         const raw = getUpdated2DArrayCopy(state.raw, action.row, action.col, action.data);

--- a/scanomatic/ui_server_data/js/src/qc/reducers/plate.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/plate.spec.js
@@ -1,26 +1,109 @@
 import plate from './plate';
 
-describe('qc/reducers/plate', () => {
+describe('/qc/reducers/plate', () => {
     it('returns the initial state', () => {
-        expect(plate(undefined, {})).toEqual({ number: 1 });
+        expect(plate(undefined, {})).toEqual({ number: 0 });
     });
 
     it('resets to initial state on PROJECT_SET', () => {
         const action = { type: 'PROJECT_SET', project: 'test.a.test' };
-        expect(plate({ number: 4 }, action)).toEqual({ number: 1 });
+        expect(plate({ number: 4 }, action)).toEqual({ number: 0 });
     });
 
-    it('sets raw curve data on CURVE_RAW_SET', () => {
-        const action = {
-            type: 'CURVE_RAW_SET', plate: 1, row: 2, col: 3, data: [4, 5],
-        };
-        expect(plate(undefined, action)).toEqual({
-            number: 1,
-            raw: [
-                [null, null, null, null],
-                [null, null, null, null],
-                [null, null, null, [4, 5]],
-            ],
+    describe('CURVE_RAW_SET', () => {
+        it('sets raw curve data', () => {
+            const action = {
+                type: 'CURVE_RAW_SET', plate: 0, row: 2, col: 3, data: [4, 5],
+            };
+            expect(plate(undefined, action)).toEqual({
+                number: 0,
+                raw: [
+                    [null, null, null, null],
+                    [null, null, null, null],
+                    [null, null, null, [4, 5]],
+                ],
+            });
+        });
+
+        it('doesnt set if the plate is wrong', () => {
+            const action = {
+                type: 'CURVE_RAW_SET', plate: 2, row: 2, col: 3, data: [4, 5],
+            };
+            expect(plate({ number: 3, raw: [null, [1, 1]] }, action)).toEqual({
+                number: 3,
+                raw: [null, [1, 1]],
+            });
+        });
+    });
+
+    describe('CURVE_SMOOTH_SET', () => {
+        it('sets raw curve data', () => {
+            const action = {
+                type: 'CURVE_SMOOTH_SET', plate: 0, row: 2, col: 3, data: [4, 5],
+            };
+            expect(plate(undefined, action)).toEqual({
+                number: 0,
+                smooth: [
+                    [null, null, null, null],
+                    [null, null, null, null],
+                    [null, null, null, [4, 5]],
+                ],
+            });
+        });
+
+        it('doesnt set if the plate is wrong', () => {
+            const action = {
+                type: 'CURVE_SMOOTH_SET', plate: 2, row: 2, col: 3, data: [4, 5],
+            };
+            expect(plate({ number: 3, smooth: [null, [1, 1]] }, action)).toEqual({
+                number: 3,
+                smooth: [null, [1, 1]],
+            });
+        });
+    });
+
+    describe('PINNING_SET', () => {
+        it('sets the pinning', () => {
+            const action = {
+                type: 'PINNING_SET', plate: 0, rows: 4, cols: 31,
+            };
+            expect(plate(undefined, action)).toEqual({
+                number: 0,
+                pinning: {
+                    rows: 4,
+                    cols: 31,
+                },
+            });
+        });
+
+        it('doesnt set if the plate is wrong', () => {
+            const action = {
+                type: 'PINNING_SET', plate: 2, rows: 4, cols: 31,
+            };
+            expect(plate(undefined, action)).toEqual({
+                number: 0,
+            });
+        });
+    });
+
+    describe('TIMES_SET', () => {
+        it('sets the time series', () => {
+            const action = {
+                type: 'TIMES_SET', plate: 0, times: [1, 2, 3],
+            };
+            expect(plate(undefined, action)).toEqual({
+                number: 0,
+                times: [1, 2, 3],
+            });
+        });
+
+        it('doesnt set if the plate is wrong', () => {
+            const action = {
+                type: 'TIMES_SET', plate: 3, times: [1, 2, 3],
+            };
+            expect(plate(undefined, action)).toEqual({
+                number: 0,
+            });
         });
     });
 });

--- a/scanomatic/ui_server_data/js/src/qc/reducers/plate.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/plate.spec.js
@@ -1,0 +1,26 @@
+import plate from './plate';
+
+describe('qc/reducers/plate', () => {
+    it('returns the initial state', () => {
+        expect(plate(undefined, {})).toEqual({ number: 1 });
+    });
+
+    it('resets to initial state on PROJECT_SET', () => {
+        const action = { type: 'PROJECT_SET', project: 'test.a.test' };
+        expect(plate({ number: 4 }, action)).toEqual({ number: 1 });
+    });
+
+    it('sets raw curve data on CURVE_RAW_SET', () => {
+        const action = {
+            type: 'CURVE_RAW_SET', plate: 1, row: 2, col: 3, data: [4, 5],
+        };
+        expect(plate(undefined, action)).toEqual({
+            number: 1,
+            raw: [
+                [null, null, null, null],
+                [null, null, null, null],
+                [null, null, null, [4, 5]],
+            ],
+        });
+    });
+});

--- a/scanomatic/ui_server_data/js/src/qc/reducers/settings.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/settings.js
@@ -1,0 +1,14 @@
+// @flow
+import type { Action } from '../actions';
+import type { Settings as State } from '../state';
+
+const initialState : State = {};
+
+export default function settings(state: State = initialState, action: Action) {
+    switch (action.type) {
+    case 'PROJECT_SET':
+        return { project: action.project };
+    default:
+        return state;
+    }
+}

--- a/scanomatic/ui_server_data/js/src/qc/reducers/settings.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/settings.spec.js
@@ -1,0 +1,13 @@
+import settings from './settings';
+
+describe('/qc/reducers/settings', () => {
+    it('returns the initial state', () => {
+        const action = {};
+        expect(settings(undefined, action)).toEqual({});
+    });
+
+    it('handles PROJECT_SET', () => {
+        const action = { type: 'PROJECT_SET', project: 'my/path/to/somewhere' };
+        expect(settings(undefined, action)).toEqual({ project: action.project });
+    });
+});

--- a/scanomatic/ui_server_data/js/src/qc/selectors.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.js
@@ -2,7 +2,7 @@
 
 import type { State, TimeSeries, Pinning } from './state';
 
-export function getProject(state: State): string {
+export function getProject(state: State): ?string {
     return state.settings.project;
 }
 
@@ -10,21 +10,23 @@ export function getPlate(state: State): number {
     return state.plate.number;
 }
 
-export function getPinning(state: State): Pinning {
-    return state.plate.pinning;
+export function getPinning(state: State, plate: number): ?Pinning {
+    if (plate === state.plate.number) return state.plate.pinning;
+    return null;
 }
 
-export function getTimes(state: State): TimeSeries {
-    return state.plate.times;
+export function getTimes(state: State, plate: number): ?TimeSeries {
+    if (plate === state.plate.number) return state.plate.times;
+    return null;
 }
 
-export function getRawCurve(state: State, plate: number, row: number, col: number): TimeSeries {
+export function getRawCurve(state: State, plate: number, row: number, col: number): ?TimeSeries {
     const { raw, number: plateNumber } = state.plate;
     if (!raw || plate !== plateNumber) return null;
     return raw[row][col];
 }
 
-export function getSmoothCurve(state: State, plate: number, row: number, col: number): TimeSeries {
+export function getSmoothCurve(state: State, plate: number, row: number, col: number): ?TimeSeries {
     const { smooth, number: plateNumber } = state.plate;
     if (!smooth || plate !== plateNumber) return null;
     return smooth[row][col];

--- a/scanomatic/ui_server_data/js/src/qc/selectors.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.js
@@ -1,18 +1,30 @@
 // @flow
 
-import type { State, TimeSeries } from './state';
+import type { State, TimeSeries, Pinning } from './state';
 
-export function getPlate(state: State): Number {
+export function getProject(state: State): string {
+    return state.settings.project;
+}
+
+export function getPlate(state: State): number {
     return state.plate.number;
 }
 
-export function getRawCurve(state: State, plate: Number, row: Number, col: Number): TimeSeries {
+export function getPinning(state: State): Pinning {
+    return state.plate.pinning;
+}
+
+export function getTimes(state: State): TimeSeries {
+    return state.plate.times;
+}
+
+export function getRawCurve(state: State, plate: number, row: number, col: number): TimeSeries {
     const { raw, number: plateNumber } = state.plate;
     if (!raw || plate !== plateNumber) return null;
     return raw[row][col];
 }
 
-export function getSmoothCurve(state: State, plate: Number, row: Number, col: Number): TimeSeries {
+export function getSmoothCurve(state: State, plate: number, row: number, col: number): TimeSeries {
     const { smooth, number: plateNumber } = state.plate;
     if (!smooth || plate !== plateNumber) return null;
     return smooth[row][col];

--- a/scanomatic/ui_server_data/js/src/qc/selectors.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.js
@@ -1,0 +1,19 @@
+// @flow
+
+import type { State, TimeSeries } from './state';
+
+export function getPlate(state: State): Number {
+    return state.plate.number;
+}
+
+export function getRawCurve(state: State, plate: Number, row: Number, col: Number): TimeSeries {
+    const { raw, number: plateNumber } = this.state.plate;
+    if (!raw || plate !== plateNumber) return null;
+    return raw[row][col];
+}
+
+export function getSmoothCurve(state: State, plate: Number, row: Number, col: Number): TimeSeries {
+    const { smooth, number: plateNumber } = this.state.plate;
+    if (!smooth || plate !== plateNumber) return null;
+    return smooth[row][col];
+}

--- a/scanomatic/ui_server_data/js/src/qc/selectors.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.js
@@ -7,13 +7,13 @@ export function getPlate(state: State): Number {
 }
 
 export function getRawCurve(state: State, plate: Number, row: Number, col: Number): TimeSeries {
-    const { raw, number: plateNumber } = this.state.plate;
+    const { raw, number: plateNumber } = state.plate;
     if (!raw || plate !== plateNumber) return null;
     return raw[row][col];
 }
 
 export function getSmoothCurve(state: State, plate: Number, row: Number, col: Number): TimeSeries {
-    const { smooth, number: plateNumber } = this.state.plate;
+    const { smooth, number: plateNumber } = state.plate;
     if (!smooth || plate !== plateNumber) return null;
     return smooth[row][col];
 }

--- a/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
@@ -12,9 +12,16 @@ describe('/qc/selectors', () => {
         expect(selectors.getPlate(state)).toEqual(2);
     });
 
-    it('should get the pinning', () => {
-        const state = new StateBuilder().setPinning(2, 1).build();
-        expect(selectors.getPinning(state)).toEqual({ rows: 2, cols: 1 });
+    describe('pinning', () => {
+        it('should get the pinning if plate is right', () => {
+            const state = new StateBuilder().setPinning(2, 1).build();
+            expect(selectors.getPinning(state, 0)).toEqual({ rows: 2, cols: 1 });
+        });
+
+        it('should return null if plate is wrong', () => {
+            const state = new StateBuilder().setPinning(2, 1).build();
+            expect(selectors.getPinning(state, 1)).toEqual(null);
+        });
     });
 
     describe('raw data', () => {
@@ -60,9 +67,14 @@ describe('/qc/selectors', () => {
     });
 
     describe('times', () => {
-        it('should get the times of the growth curve', () => {
+        it('should get the times of the growth curve if plate is right', () => {
             const state = new StateBuilder().setTimes(0, [1, 2, 3]);
-            expect(selectors.getTimes(state)).toEqual([1, 2, 3]);
+            expect(selectors.getTimes(state, 0)).toEqual([1, 2, 3]);
+        });
+
+        it('should return null if plate is wrong', () => {
+            const state = new StateBuilder().setTimes(0, [1, 2, 3]);
+            expect(selectors.getTimes(state, 1)).toEqual(null);
         });
     });
 });

--- a/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
@@ -2,9 +2,19 @@ import * as selectors from './selectors';
 import StateBuilder from './StateBuilder';
 
 describe('/qc/selectors', () => {
+    it('should get the project path', () => {
+        const state = new StateBuilder().setProject('/my/path').build();
+        expect(selectors.getProject(state)).toEqual('/my/path');
+    });
+
     it('should get the plate number', () => {
         const state = new StateBuilder().setPlate(2).build();
         expect(selectors.getPlate(state)).toEqual(2);
+    });
+
+    it('should get the pinning', () => {
+        const state = new StateBuilder().setPinning(2, 1).build();
+        expect(selectors.getPinning(state)).toEqual({ rows: 2, cols: 1 });
     });
 
     describe('raw data', () => {
@@ -15,12 +25,15 @@ describe('/qc/selectors', () => {
 
         it('should return null if curve not yet loaded', () => {
             const state = new StateBuilder().build();
-            expect(selectors.getRawCurve(state, 1, 4, 4)).toBe(null);
+            expect(selectors.getRawCurve(state, 0, 4, 4)).toBe(null);
         });
 
         it('should return the growth data', () => {
             const data = [1, 2, 3];
-            const state = new StateBuilder().setRawCurveData(1, 4, 5, data).build();
+            const state = new StateBuilder()
+                .setPlate(1)
+                .setRawCurveData(1, 4, 5, data)
+                .build();
             expect(selectors.getRawCurve(state, 1, 4, 5)).toEqual(data);
         });
     });
@@ -33,13 +46,23 @@ describe('/qc/selectors', () => {
 
         it('should return null if curve not yet loaded', () => {
             const state = new StateBuilder().build();
-            expect(selectors.getSmoothCurve(state, 1, 4, 4)).toBe(null);
+            expect(selectors.getSmoothCurve(state, 0, 4, 4)).toBe(null);
         });
 
         it('should return the growth data', () => {
             const data = [1, 2, 3];
-            const state = new StateBuilder().setSmoothCurveData(1, 4, 5, data).build();
+            const state = new StateBuilder()
+                .setPlate(1)
+                .setSmoothCurveData(1, 4, 5, data)
+                .build();
             expect(selectors.getSmoothCurve(state, 1, 4, 5)).toEqual(data);
+        });
+    });
+
+    describe('times', () => {
+        it('should get the times of the growth curve', () => {
+            const state = new StateBuilder().setTimes(0, [1, 2, 3]);
+            expect(selectors.getTimes(state)).toEqual([1, 2, 3]);
         });
     });
 });

--- a/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
@@ -1,0 +1,45 @@
+import * as selectors from './selectors';
+import StateBuilder from './StateBuilder';
+
+describe('/qc/selectors', () => {
+    it('should get the plate number', () => {
+        const state = new StateBuilder().setPlate(2).build();
+        expect(selectors.getPlate(state)).toEqual(2);
+    });
+
+    describe('raw data', () => {
+        it('should return null if curve is on wrong plate', () => {
+            const state = new StateBuilder().build();
+            expect(selectors.getRawCurve(state, 2, 4, 4)).toBe(null);
+        });
+
+        it('should return null if curve not yet loaded', () => {
+            const state = new StateBuilder().build();
+            expect(selectors.getRawCurve(state, 1, 4, 4)).toBe(null);
+        });
+
+        it('should return the growth data', () => {
+            const data = [1, 2, 3];
+            const state = new StateBuilder().setRawCurveData(1, 4, 5, data).build();
+            expect(selectors.getRawCurve(state, 1, 4, 5)).toEqual(data);
+        });
+    });
+
+    describe('smooth data', () => {
+        it('should return null if curve is on wrong plate', () => {
+            const state = new StateBuilder().build();
+            expect(selectors.getSmoothCurve(state, 2, 4, 4)).toBe(null);
+        });
+
+        it('should return null if curve not yet loaded', () => {
+            const state = new StateBuilder().build();
+            expect(selectors.getSmoothCurve(state, 1, 4, 4)).toBe(null);
+        });
+
+        it('should return the growth data', () => {
+            const data = [1, 2, 3];
+            const state = new StateBuilder().setSmoothCurveData(1, 4, 5, data).build();
+            expect(selectors.getSmoothCurve(state, 1, 4, 5)).toEqual(data);
+        });
+    });
+});

--- a/scanomatic/ui_server_data/js/src/qc/state.js
+++ b/scanomatic/ui_server_data/js/src/qc/state.js
@@ -1,0 +1,17 @@
+// @flow
+export type TimeSeries = Array<Number>;
+
+export type Settings = {
+    +project: string,
+}
+
+export type Plate = {
+    +number: Number,
+    +raw: Array<Array<TimeSeries>>,
+    +smooth: Array<Array<TimeSeries>>,
+}
+
+export type State = {
+    +settings: Settings,
+    +plate: Plate,
+};

--- a/scanomatic/ui_server_data/js/src/qc/state.js
+++ b/scanomatic/ui_server_data/js/src/qc/state.js
@@ -7,10 +7,16 @@ export type Settings = {
     +project: string,
 }
 
+export type Pinning = {
+    +rows: number,
+    +cols: number,
+}
+
 export type Plate = {
     +number: Number,
     +raw: PlateOfTimeSeries,
     +smooth: PlateOfTimeSeries,
+    +pinning: Pinning,
 }
 
 export type State = {

--- a/scanomatic/ui_server_data/js/src/qc/state.js
+++ b/scanomatic/ui_server_data/js/src/qc/state.js
@@ -4,7 +4,7 @@ export type TimeSeries = Array<number>;
 export type PlateOfTimeSeries = Array<Array<TimeSeries>>;
 
 export type Settings = {
-    +project: string,
+    +project?: string,
 }
 
 export type Pinning = {
@@ -13,10 +13,11 @@ export type Pinning = {
 }
 
 export type Plate = {
-    +number: Number,
-    +raw: PlateOfTimeSeries,
-    +smooth: PlateOfTimeSeries,
-    +pinning: Pinning,
+    +number: number,
+    +raw?: PlateOfTimeSeries,
+    +smooth?: PlateOfTimeSeries,
+    +pinning?: Pinning,
+    +times?: TimeSeries,
 }
 
 export type State = {

--- a/scanomatic/ui_server_data/js/src/qc/state.js
+++ b/scanomatic/ui_server_data/js/src/qc/state.js
@@ -1,5 +1,7 @@
 // @flow
-export type TimeSeries = Array<Number>;
+export type TimeSeries = Array<number>;
+
+export type PlateOfTimeSeries = Array<Array<TimeSeries>>;
 
 export type Settings = {
     +project: string,
@@ -7,8 +9,8 @@ export type Settings = {
 
 export type Plate = {
     +number: Number,
-    +raw: Array<Array<TimeSeries>>,
-    +smooth: Array<Array<TimeSeries>>,
+    +raw: PlateOfTimeSeries,
+    +smooth: PlateOfTimeSeries,
 }
 
 export type State = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
         scanning: ['./scanomatic/ui_server_data/js/src/scanning.jsx'],
         projects: ['./scanomatic/ui_server_data/js/src/projects'],
         statuspage: ['./scanomatic/ui_server_data/js/src/statuspage'],
+        qc: ['./scanomatic/ui_server_data/js/src/qc'],
     },
     output: {
         filename: 'scanomatic/ui_server_data/js/[name].js',


### PR DESCRIPTION
![screenshot from 2018-05-29 12-16-56](https://user-images.githubusercontent.com/8041100/40659487-ae7b6c64-634e-11e8-999f-a0608121eb51.png)

## Notes
* I skipped implementing tests for the thunk action since I will write a new endpoint and after that update the thunk action.

## Features
### `qc.subscribe`
Adds a callback that will be called without arguments each time the store changes.
### `qc.actions`
The store actions that are exposed. This encapsulates the redux store so the outer legacy code only needs to know what function to call.
* Retrieving curves terminates if plate is changed.
### `qc.selectors`
Useful functions encapsulating the store, typically for whatever has added itself as a subscriber to changes in the store.