### PR TITLE
Fixed left/right arrow buttons in QC

### DIFF
--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -344,10 +344,10 @@
                           <button id="btnMarkBad" class="markButton vcenter" title="Mark all phenotypes as Bad [hotkey: w]"></button>
                           <button id="btnMarkEmpty" class="markButton vcenter" title="Mark all phenotypes as Empty [hotkey: e]"></button>
                           <button id="btnMarkNoGrowth" class="markButton vcenter" title="Mark all phenotypes as NoGrowth [hotkey: r]"></button>
-                          <button id="btnQidxNext" style="margin-left:10px" class="btn btn-default btn-xs" title="Next in Qidx position [hotkey: <right>/<up>]">
+                          <button id="btnQidxPrev" class="btn btn-default btn-xs" title="Back in Qidx position [hotkey: <left>/<down>]">
                               <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
                           </button>
-                          <button id="btnQidxPrev" class="btn btn-default btn-xs" title="Back in Qidx position [hotkey: <left>/<down>]">
+                          <button id="btnQidxNext" style="margin-left:10px" class="btn btn-default btn-xs" title="Next in Qidx position [hotkey: <right>/<up>]">
                               <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span>
                           </button>
                         </span>

--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -344,12 +344,13 @@
                           <button id="btnMarkBad" class="markButton vcenter" title="Mark all phenotypes as Bad [hotkey: w]"></button>
                           <button id="btnMarkEmpty" class="markButton vcenter" title="Mark all phenotypes as Empty [hotkey: e]"></button>
                           <button id="btnMarkNoGrowth" class="markButton vcenter" title="Mark all phenotypes as NoGrowth [hotkey: r]"></button>
-                          <button id="btnQidxPrev" style="margin-left:10px" class="btn btn-default btn-xs" title="Back in Qidx position [hotkey: <left>/<down>]">
-                              <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
-                          </button>
-                          <button id="btnQidxZero" class="btn btn-default btn-xs" title="Go to first Qidx [hotkey: 0]">
+                          <button id="btnQidxZero" style="margin-left:10px" class="btn btn-default btn-xs" title="Go to first Qidx [hotkey: 0]">
                               <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                           </button>
+                          <button id="btnQidxPrev" class="btn btn-default btn-xs" title="Back in Qidx position [hotkey: <left>/<down>]">
+                              <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
+                          </button>
+                          <span id="qIndexCurrent"></span>
                           <button id="btnQidxNext" class="btn btn-default btn-xs" title="Next in Qidx position [hotkey: <right>/<up>]">
                               <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span>
                           </button>

--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -344,10 +344,10 @@
                           <button id="btnMarkBad" class="markButton vcenter" title="Mark all phenotypes as Bad [hotkey: w]"></button>
                           <button id="btnMarkEmpty" class="markButton vcenter" title="Mark all phenotypes as Empty [hotkey: e]"></button>
                           <button id="btnMarkNoGrowth" class="markButton vcenter" title="Mark all phenotypes as NoGrowth [hotkey: r]"></button>
-                          <button id="btnQidxPrev" class="btn btn-default btn-xs" title="Back in Qidx position [hotkey: <left>/<down>]">
+                          <button id="btnQidxPrev" style="margin-left:10px" class="btn btn-default btn-xs" title="Back in Qidx position [hotkey: <left>/<down>]">
                               <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
                           </button>
-                          <button id="btnQidxNext" style="margin-left:10px" class="btn btn-default btn-xs" title="Next in Qidx position [hotkey: <right>/<up>]">
+                          <button id="btnQidxNext" class="btn btn-default btn-xs" title="Next in Qidx position [hotkey: <right>/<up>]">
                               <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span>
                           </button>
                         </span>

--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -150,10 +150,10 @@
                   markExperiemnt(plateMetaDataType.NoGrowth, true);
               });
               $("#btnQidxNext").click(function () {
-                  setExperimentByQidx(qIdxOperations.Prev);
+                  setExperimentByQidx(qIdxOperations.Next);
               });
               $("#btnQidxPrev").click(function () {
-                  setExperimentByQidx(qIdxOperations.Next);
+                  setExperimentByQidx(qIdxOperations.Prev);
               });
               $(document).keypress(function (event) {
                   var char = getChar(event).toLowerCase();
@@ -346,6 +346,9 @@
                           <button id="btnMarkNoGrowth" class="markButton vcenter" title="Mark all phenotypes as NoGrowth [hotkey: r]"></button>
                           <button id="btnQidxPrev" style="margin-left:10px" class="btn btn-default btn-xs" title="Back in Qidx position [hotkey: <left>/<down>]">
                               <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
+                          </button>
+                          <button id="btnQidxZero" class="btn btn-default btn-xs" title="Go to first Qidx [hotkey: 0]">
+                              <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                           </button>
                           <button id="btnQidxNext" class="btn btn-default btn-xs" title="Next in Qidx position [hotkey: <right>/<up>]">
                               <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span>

--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -149,6 +149,9 @@
               $("#btnMarkNoGrowth").click(function () {
                   markExperiemnt(plateMetaDataType.NoGrowth, true);
               });
+              $("#btnQidxReset").click(function () {
+                  setExperimentByQidx(qIdxOperations.Reset);
+              });
               $("#btnQidxNext").click(function () {
                   setExperimentByQidx(qIdxOperations.Next);
               });
@@ -194,6 +197,9 @@
               $(document).keydown(function (e) {
                   if (!isQualityControlOn()) return;
                   switch (e.which) {
+                      case 36: // home
+                          setExperimentByQidx(qIdxOperations.Reset);
+                          break;
                       case 37: // left
                       case 40: // down
                           setExperimentByQidx(qIdxOperations.Prev);
@@ -344,7 +350,7 @@
                           <button id="btnMarkBad" class="markButton vcenter" title="Mark all phenotypes as Bad [hotkey: w]"></button>
                           <button id="btnMarkEmpty" class="markButton vcenter" title="Mark all phenotypes as Empty [hotkey: e]"></button>
                           <button id="btnMarkNoGrowth" class="markButton vcenter" title="Mark all phenotypes as NoGrowth [hotkey: r]"></button>
-                          <button id="btnQidxZero" style="margin-left:10px" class="btn btn-default btn-xs" title="Go to first Qidx [hotkey: 0]">
+                          <button id="btnQidxReset" style="margin-left:10px" class="btn btn-default btn-xs" title="Go to first Qidx [hotkey: <home>]">
                               <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                           </button>
                           <button id="btnQidxPrev" class="btn btn-default btn-xs" title="Back in Qidx position [hotkey: <left>/<down>]">

--- a/scanomatic/ui_server_data/js/qc_normHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normHelper.js
@@ -157,7 +157,6 @@ function fillProjectDetails(projectDetails) {
         drawRunPhenotypeSelection(projectDetails.phenotype_names);
         drawRunNormalizedPhenotypeSelection(projectDetails.phenotype_normalized_names);
         drawReferenceOffsetSelecton();
-        updateQIndexLabel(qIndexCurrent);
     });
 }
 
@@ -473,6 +472,7 @@ function renderPlate(phenotypePlates) {
     $('#currentSelection').data('plateIdx', plateIdx);
     $('#currentSelection').data('project', project);
     $('#spnPlateIdx').text((plateIdx + 1));
+    updateQIndexLabel(qIndexCurrent);
     wait();
     // e.g. /api/results/phenotype/GenerationTimeWhen/1/by4742_h/analysis
     const isNormalized = $('#ckNormalized').is(':checked');

--- a/scanomatic/ui_server_data/js/qc_normHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normHelper.js
@@ -156,6 +156,7 @@ function fillProjectDetails(projectDetails) {
         drawRunPhenotypeSelection(projectDetails.phenotype_names);
         drawRunNormalizedPhenotypeSelection(projectDetails.phenotype_normalized_names);
         drawReferenceOffsetSelecton();
+        updateQIndexLabel(qIndexCurrent);
     });
 }
 
@@ -174,12 +175,20 @@ function isQualityControlOn() {
     return $('#ckMarkExperiments').is(':checked');
 }
 
+function updateQIndexLabel(qIndex) {
+    $("#qIndexCurrent").text(qIndex + 1);
+}
+
 function getQIndexCoord(operation) {
     qIndexCurrent += operation;
-    const maxQueueSize = qIndexQueue.length - 1;
-    if (qIndexCurrent < 0) { qIndexCurrent = maxQueueSize; }
-    if (qIndexCurrent > maxQueueSize) { qIndexCurrent = 0; }
+    const qIndexMax = qIndexQueue.length - 1;
+    if (qIndexCurrent < 0) {
+        qIndexCurrent = qIndexMax;
+    } else if (qIndexCurrent > qIndexMax) {
+        qIndexCurrent = 0;
+    };
     const item = qIndexQueue[qIndexCurrent];
+    updateQIndexLabel(qIndexCurrent);
     return item;
 }
 

--- a/scanomatic/ui_server_data/js/qc_normHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normHelper.js
@@ -25,7 +25,7 @@ function initSpinner() {
         className: 'spinner', // The CSS class to assign to the spinner
     }).spin(spinTarget);
 }
-﻿
+
 function getUrlParameter(sParam) {
     var sPageUrl = decodeURIComponent(window.location.search.substring(1));
     var sUrlVariables = sPageUrl.split('&');

--- a/scanomatic/ui_server_data/js/qc_normHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normHelper.js
@@ -10,6 +10,7 @@ const qIdxOperations = {
     Current: 0,
     Prev: -1,
     Next: 1,
+    Reset: '',
 };
 
 function initSpinner() {
@@ -161,9 +162,9 @@ function fillProjectDetails(projectDetails) {
 }
 
 function setExperimentByQidx(operation) {
-    var queue = getQIndexCoord(operation);
-    var row = queue.row;
-    var col = queue.col;
+    const queueCurrent = getQIndexCoord(operation);
+    const row = queueCurrent.row;
+    const col = queueCurrent.col;
     dispatch.setExp("id" + row + "_" + col);
 }
 
@@ -180,16 +181,21 @@ function updateQIndexLabel(qIndex) {
 }
 
 function getQIndexCoord(operation) {
-    qIndexCurrent += operation;
-    const qIndexMax = qIndexQueue.length - 1;
-    if (qIndexCurrent < 0) {
-        qIndexCurrent = qIndexMax;
-    } else if (qIndexCurrent > qIndexMax) {
+    if (operation === qIdxOperations.Reset) {
         qIndexCurrent = 0;
+    } else {
+        qIndexCurrent += operation;
+
+        const qIndexMax = qIndexQueue.length - 1;
+        if (qIndexCurrent < 0) {
+            qIndexCurrent = qIndexMax;
+        } else if (qIndexCurrent > qIndexMax) {
+            qIndexCurrent = 0;
+        };
     };
-    const item = qIndexQueue[qIndexCurrent];
+
     updateQIndexLabel(qIndexCurrent);
-    return item;
+    return qIndexQueue[qIndexCurrent];
 }
 
 function getChar(event) {
@@ -289,7 +295,11 @@ function markExperiemnt(mark, all) {
         if (gData.success === true) {
             dispatch.reDrawExp(`id${row}_${col}`, mark);
             const queueCurrent = getQIndexCoord(qIdxOperations.Current);
-            if (queueCurrent.row == row && queueCurrent.col == col) { setExperimentByQidx(qIdxOperations.Next); } else { setExperimentByQidx(qIdxOperations.Current); }
+            if (queueCurrent.row == row && queueCurrent.col == col) {
+                setExperimentByQidx(qIdxOperations.Next);
+            } else {
+                setExperimentByQidx(qIdxOperations.Current);
+            }
         } else { alert(`${gData.success} : ${gData.reason}`); }
         stopWait();
     });

--- a/scanomatic/ui_server_data/js/qc_normHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normHelper.js
@@ -10,7 +10,7 @@ const qIdxOperations = {
     Current: 0,
     Prev: -1,
     Next: 1,
-    Reset: '',
+    Reset: 'reset',
 };
 
 function initSpinner() {

--- a/tests/system/test_qcnorm.py
+++ b/tests/system/test_qcnorm.py
@@ -187,15 +187,15 @@ class PlateDisplayArea(object):
 
     def get_qindex(self):
         id = "#qIndexCurrent"
-        return self.elem.find_element(By.CSS_SELECTOR, id).text()
+        return self.elem.find_element(By.CSS_SELECTOR, id).text
 
     def update_qindex(self, operation):
         id = ''
-        if operation == CurveMark.NEXT:
+        if operation == Navigations.NEXT:
             id = '#btnQidxNext'
-        elif operation == CurveMark.PREV:
+        elif operation == Navigations.PREV:
             id = '#btnQidxPrev'
-        elif operation == CurveMark.RESET:
+        elif operation == Navigations.RESET:
             id = '#btnQidxReset'
         self.elem.find_element(By.CSS_SELECTOR, id).click()
 
@@ -322,37 +322,38 @@ class TestQCNormCurveMarking:
         assert position.mark == CurveMark.BAD
 
 
+@pytest.fixture(scope='function')
+def plate_page(browser, scanomatic, experiment_only_analysis):
+    page = QCNormPagePreloadedProject(
+        browser,
+        scanomatic,
+        experiment_only_analysis,
+        experiment_only_analysis[-2],
+    )
+    return page.get_plate_display_area()
+
+
 class TestQCNormNavigateQidx:
 
-    @classmethod
-    @pytest.fixture(scope='function')
-    def plate_page(browser, scanomatic, experiment_only_analysis):
-        page = QCNormPagePreloadedProject(
-            browser,
-            scanomatic,
-            experiment_only_analysis,
-            experiment_only_analysis[-2],
-        )
-        return page
+    def test_qindex_navigation(self, plate_page):
+        # Page starts at first Qindex:
+        assert plate_page.get_qindex() == "1"
 
-    def test_page_starts_on_lowest_qindex(self, plate_page):
-        assert plate_page.get_qindex == "1"
-
-    def test_pressing_btns_changes_qindex(self, plate_page):
+        # Pressing buttons works as expected:
         plate_page.update_qindex(Navigations.NEXT)
-        assert plate_page.get_qindex == "2"
+        assert plate_page.get_qindex() == "2"
         plate_page.update_qindex(Navigations.PREV)
-        assert plate_page.get_qindex == "1"
+        assert plate_page.get_qindex() == "1"
 
-    def test_qindex_overflow_wraps(self, plate_page):
+        # Qindex wraps as expexted:
         plate_page.update_qindex(Navigations.PREV)
-        assert plate_page.get_qindex == "1536"
+        assert plate_page.get_qindex() == "1536"
         plate_page.update_qindex(Navigations.NEXT)
-        assert plate_page.get_qindex == "1"
+        assert plate_page.get_qindex() == "1"
 
-    def test_pressing_reset_goes_to_first_qindex(self, plate_page):
+        # Pressing reset goes back to first index:
         plate_page.update_qindex(Navigations.NEXT)
         plate_page.update_qindex(Navigations.NEXT)
-        assert plate_page.get_qindex == "3"
+        assert plate_page.get_qindex() == "3"
         plate_page.update_qindex(Navigations.RESET)
-        assert plate_page.get_qindex == "1"
+        assert plate_page.get_qindex() == "1"


### PR DESCRIPTION
- Left/right buttons now behave as expected.
- Q-index is shown in the UI
- Added button to go to first Q-index

![som_arrows](https://user-images.githubusercontent.com/358614/40829396-9f28a632-6583-11e8-9fc6-626a5b3f52c9.png)
