### PR TITLE
Integrate QC store quality index.

### DIFF
--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -80,7 +80,7 @@
                   if (this.checked) {
                       $("#divMarkStates").show();
                       $("#qidxHint").show();
-                      setExperimentByQidx(qIdxOperations.Current);
+                      showCurrentQIndex();
                   } else {
                       $("#divMarkStates").hide();
                       $("#qidxHint").hide();
@@ -151,13 +151,13 @@
                   markExperiment(plateMetaDataType.NoGrowth, true);
               });
               $("#btnQidxReset").click(function () {
-                  setExperimentByQidx(qIdxOperations.Reset);
+                  window.qc.actions.setQualityIndex(window.qc.selectors.getPlate(), 0);
               });
               $("#btnQidxNext").click(function () {
-                  setExperimentByQidx(qIdxOperations.Next);
+                  window.qc.actions.nextQualityIndex(window.qc.selectors.getPlate());
               });
               $("#btnQidxPrev").click(function () {
-                  setExperimentByQidx(qIdxOperations.Prev);
+                  window.qc.actions.previousQualityIndex(window.qc.selectors.getPlate());
               });
               $(document).keypress(function (event) {
                   var char = getChar(event).toLowerCase();
@@ -199,15 +199,15 @@
                   if (!isQualityControlOn()) return;
                   switch (e.which) {
                       case 36: // home
-                          setExperimentByQidx(qIdxOperations.Reset);
+                          window.qc.actions.setQualityIndex(window.qc.selectors.getPlate(), 0);
                           break;
                       case 37: // left
                       case 40: // down
-                          setExperimentByQidx(qIdxOperations.Prev);
+                          window.qc.actions.previousQualityIndex(window.qc.selectors.getPlate());
                           break;
                       case 38: // up
                       case 39: // right
-                          setExperimentByQidx(qIdxOperations.Next);
+                          window.qc.actions.nextQualityIndex(window.qc.selectors.getPlate());
                           break;
                       default: return;
                   }

--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -76,16 +76,6 @@
                 });
 
               $("#divLockRemoving").hide();
-              $("#ckMarkExperiments").change(function () {
-                  if (this.checked) {
-                      $("#divMarkStates").show();
-                      $("#qidxHint").show();
-                      showCurrentQIndex();
-                  } else {
-                      $("#divMarkStates").hide();
-                      $("#qidxHint").hide();
-                  }
-              });
               $("#ckNormalized").change(function () {
                   $("#" + selRunNormPhenotypesName).toggle();
                   $("#" + selRunPhenotypesName).toggle();
@@ -151,13 +141,13 @@
                   markExperiment(plateMetaDataType.NoGrowth, true);
               });
               $("#btnQidxReset").click(function () {
-                  window.qc.actions.setQualityIndex(window.qc.selectors.getPlate(), 0);
+                  window.qc.actions.setQualityIndex(0);
               });
               $("#btnQidxNext").click(function () {
-                  window.qc.actions.nextQualityIndex(window.qc.selectors.getPlate());
+                  window.qc.actions.nextQualityIndex();
               });
               $("#btnQidxPrev").click(function () {
-                  window.qc.actions.previousQualityIndex(window.qc.selectors.getPlate());
+                  window.qc.actions.previousQualityIndex();
               });
               $(document).keypress(function (event) {
                   var char = getChar(event).toLowerCase();
@@ -196,18 +186,17 @@
                   }
               });
               $(document).keydown(function (e) {
-                  if (!isQualityControlOn()) return;
                   switch (e.which) {
                       case 36: // home
-                          window.qc.actions.setQualityIndex(window.qc.selectors.getPlate(), 0);
+                          window.qc.actions.setQualityIndex(0);
                           break;
                       case 37: // left
                       case 40: // down
-                          window.qc.actions.previousQualityIndex(window.qc.selectors.getPlate());
+                          window.qc.actions.previousQualityIndex();
                           break;
                       case 38: // up
                       case 39: // right
-                          window.qc.actions.nextQualityIndex(window.qc.selectors.getPlate());
+                          window.qc.actions.nextQualityIndex();
                           break;
                       default: return;
                   }
@@ -340,10 +329,6 @@
                   </div>
                   <div class="row">
                       <div class="col-md-12">
-                        <span class="mark-experiments-toggle">
-                          Mark experiments
-                          <input id="ckMarkExperiments" type="checkbox" data-toggle="toggle" data-size="mini"/>
-                        </span>
                         <span id="divMarkStates" class="mark-experiments-action-group">
                           <div id="currentSelection"></div>
                           <button id="btnMarkOK" class="markButton vcenter" title="Mark all phenotypes as OK [hotkey: q]"></button>

--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -330,7 +330,6 @@
                   <div class="row">
                       <div class="col-md-12">
                         <span id="divMarkStates" class="mark-experiments-action-group">
-                          <div id="currentSelection"></div>
                           <button id="btnMarkOK" class="markButton vcenter" title="Mark all phenotypes as OK [hotkey: q]"></button>
                           <button id="btnMarkOKOne" class="markButton vcenter" title="Mark this phenotype as OK [hotkey: a]"></button>
                           <button id="btnMarkBad" class="markButton vcenter" title="Mark all phenotypes as Bad [hotkey: w]"></button>

--- a/scanomatic/ui_server_data/js/qc_normAPIHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normAPIHelper.js
@@ -204,8 +204,7 @@ function GetPlateData(url, isNormalized, metaDataPath, phenotypePlaceholderMetaD
                                     qIdxSort.push({ idx: idx, row: qIdxRows[i], col: qIdxCols[i] });
                                     idx = idx + 1;
                                 }
-                                const plateIdx = $('#currentSelection').data('plateIdx');
-                                window.qc.actions.setQualityIndexQueue(qIdxSort, parseInt(plateIdx, 10));
+                                window.qc.actions.setQualityIndexQueue(qIdxSort, window.qc.selectors.getPlate());
                             }
                             var plate = {
                                 plate_data: json.data,

--- a/scanomatic/ui_server_data/js/qc_normAPIHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normAPIHelper.js
@@ -204,6 +204,7 @@ function GetPlateData(url, isNormalized, metaDataPath, phenotypePlaceholderMetaD
                                     qIdxSort.push({ idx: idx, row: qIdxRows[i], col: qIdxCols[i] });
                                     idx = idx + 1;
                                 }
+                                window.qc.actions.setQualityIndexQueue(qIdxSort);
                             }
                             var plate = {
                                 plate_data: json.data,

--- a/scanomatic/ui_server_data/js/qc_normAPIHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normAPIHelper.js
@@ -204,7 +204,8 @@ function GetPlateData(url, isNormalized, metaDataPath, phenotypePlaceholderMetaD
                                     qIdxSort.push({ idx: idx, row: qIdxRows[i], col: qIdxCols[i] });
                                     idx = idx + 1;
                                 }
-                                window.qc.actions.setQualityIndexQueue(qIdxSort);
+                                const plateIdx = $('#currentSelection').data('plateIdx');
+                                window.qc.actions.setQualityIndexQueue(qIdxSort, parseInt(plateIdx, 10));
                             }
                             var plate = {
                                 plate_data: json.data,

--- a/scanomatic/ui_server_data/js/qc_normDrawCurves.js
+++ b/scanomatic/ui_server_data/js/qc_normDrawCurves.js
@@ -233,9 +233,6 @@ d3.scanomatic.growthChart = function (time, serRaw, serSmooth) {
             })
             .text("GT");
         //Py=m (Px-x) + Py
-        console.log("GT:" + generationTime);
-        console.log("GTTimeWhen:" + generationTimeWhen);
-        console.log("GTTimeWhenValue:" + smoothGtValue);
         var windowSize = 4;
         var gtSlope = 1 / generationTime;
         var l = parseFloat(smoothGtTime) - windowSize;
@@ -289,8 +286,6 @@ d3.scanomatic.growthChart = function (time, serRaw, serSmooth) {
         var gtY = yScale(smoothYieldValue);
         var baseX = gtX;
         var baseY = yScale(smoothData[0].value);
-        console.log("Yield time:" + smoothYieldTime);
-        console.log("Yield value:" + smoothYieldValue);
 
         var gMetaYeild = g.append("g")
           .classed("meta yield", true);

--- a/scanomatic/ui_server_data/js/qc_normDrawPlate.js
+++ b/scanomatic/ui_server_data/js/qc_normDrawPlate.js
@@ -41,7 +41,7 @@ function DrawPlate(container, data, growthMetaData, plateMetaData, phenotypeName
     //heatmap legend
     var legendWidth = 25;
     var legendMargin = 5;
-    
+
     //SetDebugText(data, cols, rows);
 
     var grid = d3.select(container)
@@ -55,7 +55,7 @@ function DrawPlate(container, data, growthMetaData, plateMetaData, phenotypeName
 
     addSelectionHanddling(grid);
     addSymbolsToSGV(grid);
-   
+
     var plateGroup = grid.append("g").classed("gHeatmap", true);
 
     //heatmap
@@ -303,7 +303,7 @@ d3.scanomatic.plateHeatmap = function () {
     var heatMapCelHeight;
     var dispatch = d3.dispatch(dispatcherSelectedExperiment);
     var numberFormat = "0.3n";
-    
+
     function heatmap(container) {
         g = container;
         update();
@@ -448,8 +448,8 @@ d3.scanomatic.plateHeatmap = function () {
         }
 
         function addShapes(nodes) {
-            
-            //ok metadata 
+
+            //ok metadata
             nodes
             .filter(function (d) { return d.metaType == plateMetaDataType.OK; })
             .append("circle")
@@ -496,7 +496,7 @@ d3.scanomatic.plateHeatmap = function () {
         }
 
         function setShapes(node) {
-            //ok metadata 
+            //ok metadata
             node
             .filter(function(d) {
                      return d.metaType == plateMetaDataType.OK;
@@ -633,8 +633,6 @@ d3.scanomatic.plateHeatmap = function () {
             });
             //trigger click and send coordinate
             toolTipDiv.transition().duration(0).style("opacity", 0);
-            d3.select("#sel").selectAll("*").remove();
-            d3.select("#sel").text("Experiment " + coordinate + ", Value " + phenotype);
             dispatch[dispatcherSelectedExperiment](exp);
         };
 
@@ -666,9 +664,10 @@ d3.scanomatic.plateHeatmap = function () {
             });
             //trigger click and send coordinate
             toolTipDiv.transition().duration(0).style("opacity", 0);
-            d3.select("#sel").selectAll("*").remove();
-            d3.select("#sel").text("Experiment " + coordinate + ", Value " + phenotype);
-            dispatch[dispatcherSelectedExperiment](exp);
+            window.qc.actions.setQualityIndex(window.qc.selectors.getQIndexFromPosition(
+                parseInt(row, 10),
+                parseInt(col, 10),
+            ));
         }
 
         function onMouseOut(node) {
@@ -703,7 +702,7 @@ d3.scanomatic.plateHeatmap = function () {
                 });
 
             addSymbolsToSGV(toolTipIcon);
-            
+
             node.select(".plateWell")
                 .attr("fill", "black")
                 .attr("", function (d) {
@@ -867,7 +866,7 @@ d3.scanomatic.plateHeatmap = function () {
     }
 
     heatmap.setColorScale = function(value) {
-        
+
         if (typeof value === "undefined" || value === null) {
             throw "colorSchema isundefined";
         }
@@ -914,5 +913,3 @@ d3.scanomatic.plateHeatmap = function () {
 
     return d3.rebind(heatmap, dispatch, "on");
 }
-
-

--- a/scanomatic/ui_server_data/js/qc_normHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normHelper.js
@@ -457,7 +457,7 @@ function renderPlate(phenotypePlates) {
             $('#currentSelection').data('phenotype', datah.phenotype);
             $('#currentSelection').data('project', $('#spProject').text());
             window.qc.actions.setQualityIndex(window.qc.selectors
-                .getQIndexFromCoord(parseInt(row, 10), parseInt(col, 10)));
+                .getQIndexFromPosition(parseInt(row, 10), parseInt(col, 10)));
         });
     });
 }

--- a/scanomatic/ui_server_data/js/qc_normHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normHelper.js
@@ -4,15 +4,6 @@ const selRunNormPhenotypesName = 'selRunNormPhenotypes';
 const selRunPhenotypesName = 'selRunPhenotypes';
 const dispatch = d3.dispatch('setExp', 'reDrawExp');
 const branchSymbol = '¤';
-let qIndexQueue = [];
-let qIndexCurrent = 0;
-const qIdxOperations = {
-    Current: 0,
-    Prev: -1,
-    Next: 1,
-    Reset: 'reset',
-    Goto: 'goto',
-};
 
 function initSpinner() {
     spinTarget = document.getElementById('divLoading');
@@ -198,11 +189,10 @@ function updateQIndexCoord(operation, index) {
     return qIndexQueue[qIndexCurrent];
 }
 
-function setExperimentByQidx(operation) {
-    const queueCurrent = updateQIndexCoord(operation);
-    const row = queueCurrent.row;
-    const col = queueCurrent.col;
-    dispatch.setExp(`id${row}_${col}`);
+function showCurrentQIndex() {
+    const current = window.qc.selectors
+        .getCurrrentQIndexInfo(window.qc.selectors.getPlate());
+    dispatch.setExp(`id${current.row}_${current.col}`);
 }
 
 function getChar(event) {
@@ -301,12 +291,7 @@ function markExperiment(mark, all) {
     GetMarkExperiment(path, lockKey, (gData) => {
         if (gData.success === true) {
             dispatch.reDrawExp(`id${row}_${col}`, mark);
-            const queueCurrent = updateQIndexCoord(qIdxOperations.Current);
-            if (queueCurrent.row == row && queueCurrent.col == col) {
-                setExperimentByQidx(qIdxOperations.Next);
-            } else {
-                setExperimentByQidx(qIdxOperations.Current);
-            }
+            window.qc.actions.nextQualityIndex(window.qc.selectors.getPlate());
         } else { alert(`${gData.success} : ${gData.reason}`); }
         stopWait();
     });
@@ -521,6 +506,6 @@ function renderPlate(phenotypePlates) {
                 parseInt(col, 10),
             );
         });
-        setExperimentByQidx(qIdxOperations.Reset);
+        showCurrentQIndex();
     });
 }

--- a/scanomatic/ui_server_data/js/qc_normHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normHelper.js
@@ -153,48 +153,6 @@ function fillProjectDetails(projectDetails) {
     });
 }
 
-function getQIndexFromCoord(row, col) {
-    return qIndexQueue.filter(e => e.row == row && e.col == col)[0].idx;
-}
-
-function setExperimentByCoord(row, col) {
-    dispatch.setExp(`id${row}_${col}`);
-}
-
-function isQualityControlOn() {
-    return $('#ckMarkExperiments').is(':checked');
-}
-
-function updateQIndexLabel(qIndex) {
-    $('#qIndexCurrent').text(qIndex + 1);
-}
-
-function updateQIndexCoord(operation, index) {
-    if (operation === qIdxOperations.Reset) {
-        qIndexCurrent = 0;
-    } else if (operation === qIdxOperations.Goto) {
-        qIndexCurrent = index;
-    } else {
-        qIndexCurrent += operation;
-
-        const qIndexMax = qIndexQueue.length - 1;
-        if (qIndexCurrent < 0) {
-            qIndexCurrent = qIndexMax;
-        } else if (qIndexCurrent > qIndexMax) {
-            qIndexCurrent = 0;
-        }
-    }
-
-    updateQIndexLabel(qIndexCurrent);
-    return qIndexQueue[qIndexCurrent];
-}
-
-function showCurrentQIndex() {
-    const current = window.qc.selectors
-        .getCurrrentQIndexInfo(window.qc.selectors.getPlate());
-    dispatch.setExp(`id${current.row}_${current.col}`);
-}
-
 function getChar(event) {
     if (event.which == null) {
         return String.fromCharCode(event.keyCode); // IE
@@ -277,7 +235,6 @@ function projectSelectionStage(level) {
 
 // Mark Selected Experiment
 function markExperiment(mark, all) {
-    if (!isQualityControlOn()) return;
     const plateIdx = $('#currentSelection').data('plateIdx');
     const row = $('#currentSelection').data('row');
     const col = $('#currentSelection').data('col');
@@ -291,7 +248,7 @@ function markExperiment(mark, all) {
     GetMarkExperiment(path, lockKey, (gData) => {
         if (gData.success === true) {
             dispatch.reDrawExp(`id${row}_${col}`, mark);
-            window.qc.actions.nextQualityIndex(window.qc.selectors.getPlate());
+            window.qc.actions.nextQualityIndex();
         } else { alert(`${gData.success} : ${gData.reason}`); }
         stopWait();
     });
@@ -499,13 +456,8 @@ function renderPlate(phenotypePlates) {
             $('#currentSelection').data('col', col);
             $('#currentSelection').data('phenotype', datah.phenotype);
             $('#currentSelection').data('project', $('#spProject').text());
-            updateQIndexCoord(qIdxOperations.Goto, getQIndexFromCoord(row, col));
-            window.qc.actions.setFocus(
-                parseInt(plateIdx, 10),
-                parseInt(row, 10),
-                parseInt(col, 10),
-            );
+            window.qc.actions.setQualityIndex(window.qc.selectors
+                .getQIndexFromCoord(parseInt(row, 10), parseInt(col, 10));
         });
-        showCurrentQIndex();
     });
 }

--- a/scanomatic/ui_server_data/js/qc_normHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normHelper.js
@@ -457,7 +457,7 @@ function renderPlate(phenotypePlates) {
             $('#currentSelection').data('phenotype', datah.phenotype);
             $('#currentSelection').data('project', $('#spProject').text());
             window.qc.actions.setQualityIndex(window.qc.selectors
-                .getQIndexFromCoord(parseInt(row, 10), parseInt(col, 10));
+                .getQIndexFromCoord(parseInt(row, 10), parseInt(col, 10)));
         });
     });
 }

--- a/scanomatic/ui_server_data/js/qc_normHelper.js
+++ b/scanomatic/ui_server_data/js/qc_normHelper.js
@@ -439,12 +439,14 @@ function renderPlate(phenotypePlates) {
         const plateMetaData = data.Plate_metadata;
         const growthMetaData = data.Growth_metaData;
         const phenotypeName = data.plate_phenotype;
-        qIndexQueue = data.plate_qIdxSort;
         window.qc.actions.retrievePlateCurves(parseInt(plateIdx, 10));
         const plate = DrawPlate('#plate', plateData, growthMetaData, plateMetaData, phenotypeName, dispatch);
         const row = $('#currentSelection').data('row');
         const col = $('#currentSelection').data('col');
-        if (row && col) { setExperimentByCoord(row, col); }
+        if (row && col) {
+            window.qc.actions.setQualityIndex(window.qc.selectors
+                .getQIndexFromPosition(parseInt(row, 10), parseInt(col, 10)));
+        }
         stopWait();
         plate.on('SelectedExperiment', (datah) => {
             const arr = datah.coord.split(',');

--- a/scanomatic/ui_server_data/js/src/qc/DrawCurvesIntegration.js
+++ b/scanomatic/ui_server_data/js/src/qc/DrawCurvesIntegration.js
@@ -25,6 +25,15 @@ export default class DrawCurvesIntegration {
             $(selector).hide();
             return;
         }
+        // This is horrible, but seems only way to access all needed data
+        // in  the legacy code.
+
+        const well = $(`#id${focus.row}_${focus.col}`)[0]
+        if (!well) return;
+        
+        const data = well.__data__;
+        $('#sel').text(`Experiment [${focus.row},${focus.col}], Value ${data.phenotype.toPrecision(3)}`);
+
         if (!this.shouldDraw({ plate, ...focus })) return;
 
         const raw = window.qc.selectors.getRawCurve(plate, focus.row, focus.col);
@@ -36,10 +45,6 @@ export default class DrawCurvesIntegration {
             return;
         }
 
-        const well = `#id${focus.row}_${focus.col}`;
-        // This is horrible, but seems only way to access all needed data
-        // in  the legacy code.
-        const data = $(well)[0].__data__;
         window.DrawCurves(
             selector,
             time,

--- a/scanomatic/ui_server_data/js/src/qc/DrawCurvesIntegration.js
+++ b/scanomatic/ui_server_data/js/src/qc/DrawCurvesIntegration.js
@@ -25,12 +25,12 @@ export default class DrawCurvesIntegration {
             $(selector).hide();
             return;
         }
-        // This is horrible, but seems only way to access all needed data
-        // in  the legacy code.
 
         const well = $(`#id${focus.row}_${focus.col}`)[0];
         if (!well) return;
 
+        // This is horrible, but seems only way to access all needed data
+        // in the legacy code.
         const data = well.__data__;
         $('#sel').text(`Experiment [${focus.row},${focus.col}], Value ${data.phenotype.toPrecision(3)}`);
 

--- a/scanomatic/ui_server_data/js/src/qc/DrawCurvesIntegration.js
+++ b/scanomatic/ui_server_data/js/src/qc/DrawCurvesIntegration.js
@@ -28,9 +28,9 @@ export default class DrawCurvesIntegration {
         // This is horrible, but seems only way to access all needed data
         // in  the legacy code.
 
-        const well = $(`#id${focus.row}_${focus.col}`)[0]
+        const well = $(`#id${focus.row}_${focus.col}`)[0];
         if (!well) return;
-        
+
         const data = well.__data__;
         $('#sel').text(`Experiment [${focus.row},${focus.col}], Value ${data.phenotype.toPrecision(3)}`);
 

--- a/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
+++ b/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
@@ -26,7 +26,7 @@ export default class QIndexAndSelectionIntegration {
     handleUpdate() {
         const focus = Object.assign(
             {},
-            this.bridge.selectors.getCurrrentQIndexInfo(),
+            this.bridge.selectors.getFocus(),
             { plate: this.bridge.selectos.getPlate() },
         );
         updateQIndexLabel(focus);

--- a/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
+++ b/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
@@ -27,7 +27,7 @@ export default class QIndexAndSelectionIntegration {
         const focus = Object.assign(
             {},
             this.bridge.selectors.getFocus(),
-            { plate: this.bridge.selectos.getPlate() },
+            { plate: this.bridge.selectors.getPlate() },
         );
         updateQIndexLabel(focus);
         if (!this.shouldSync(focus)) return;

--- a/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
+++ b/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
@@ -5,18 +5,11 @@ import Bridge from './bridge';
 
 export default class QIndexAndSelectionIntegration {
     bridge: Bridge;
-    plate: number;
-    row: number;
-    col: number;
     handleUpdate: () => void;
 
     constructor(bridge: Bridge) {
         this.bridge = bridge;
         this.handleUpdate = this.handleUpdate.bind(this);
-    }
-
-    shouldSync({ plate, row, col } : { plate: number, row: number, col: number }) : boolean {
-        return this.plate !== plate || this.row !== row || this.col !== col;
     }
 
     handleUpdate() {
@@ -25,15 +18,12 @@ export default class QIndexAndSelectionIntegration {
             this.bridge.selectors.getFocus(),
             { plate: this.bridge.selectors.getPlate() },
         );
-        $('#qIndexCurrent').text(focus.idx + 1);
-        if (!this.shouldSync(focus)) return;
-        this.plate = focus.plate;
-        this.row = focus.row;
-        this.col = focus.col;
 
-        // I don't know exactly how and where this function ends up in the
-        // global scope, but there it is. It's not a property of window or
-        // document so I don't know how I should deal with the lint error.
-        dispatch.setExp(`id${focus.row}_${focus.col}`);
+        const well = $(`#id${focus.row}_${focus.col}`)[0];
+        if (!well) return;
+
+        $('.selected-experiment').removeClass('selected-experiment');
+        $(`#id${focus.row}_${focus.col}`).addClass('selected-experiment');
+        $('#qIndexCurrent').text(focus.idx + 1);
     }
 }

--- a/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
+++ b/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
@@ -2,10 +2,6 @@
 import $ from 'jquery';
 import Bridge from './bridge';
 
-function updateQIndexLabel({ idx }) {
-    $('#qIndexCurrent').text(idx + 1);
-}
-
 
 export default class QIndexAndSelectionIntegration {
     bridge: Bridge;
@@ -29,11 +25,15 @@ export default class QIndexAndSelectionIntegration {
             this.bridge.selectors.getFocus(),
             { plate: this.bridge.selectors.getPlate() },
         );
-        updateQIndexLabel(focus);
+        $('#qIndexCurrent').text(focus.idx + 1);
         if (!this.shouldSync(focus)) return;
         this.plate = focus.plate;
         this.row = focus.row;
         this.col = focus.col;
+
+        // I don't know exactly how and where this function ends up in the
+        // global scope, but there it is. It's not a property of window or
+        // document so I don't know how I should deal with the lint error.
         dispatch.setExp(`id${focus.row}_${focus.col}`);
     }
 }

--- a/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
+++ b/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
@@ -1,0 +1,36 @@
+// @flow
+import $ from 'jquery';
+import Bridge from './bridge';
+
+function updateQIndexLabel({ idx }) {
+    $('#qIndexCurrent').text(idx + 1);
+}
+
+
+export default class QIndexAndSelectionIntegration {
+    bridge: Bridge;
+    plate: number;
+    row: number;
+    col: number;
+    handleUpdate: () => void;
+
+    constructor(bridge: Bridge) {
+        this.bridge = bridge;
+        this.handleUpdate = this.handleUpdate.bind(this);
+    }
+
+    shouldSync({ plate, row, col } : { plate: number, row: number, col: number }) : boolean {
+        return this.plate !== plate || this.row !== row || this.col !== col;
+    }
+
+    handleUpdate() {
+        const focus = Object.assign(
+            {},
+            this.bridge.selectors.getCurrrentQIndexInfo(),
+            { plate: this.bridge.selectos.getPlate() },
+        );
+        updateQIndexLabel(focus);
+        if (!this.shouldSync(focus)) return;
+        window.dispatch.setExp(`id${focus.row}_${focus.col}`);
+    }
+}

--- a/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
+++ b/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
@@ -31,6 +31,9 @@ export default class QIndexAndSelectionIntegration {
         );
         updateQIndexLabel(focus);
         if (!this.shouldSync(focus)) return;
-        window.dispatch.setExp(`id${focus.row}_${focus.col}`);
+        this.plate = focus.plate;
+        this.row = focus.row;
+        this.col = focus.col;
+        dispatch.setExp(`id${focus.row}_${focus.col}`);
     }
 }

--- a/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
+++ b/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
@@ -24,12 +24,6 @@ export default class StateBuilder {
         return this;
     }
 
-    setFocus(plate: number, row: number, col: number) {
-        if (plate !== this.plate.number) return this;
-        this.plate = Object.assign({}, this.plate, { focus: { row, col } });
-        return this;
-    }
-
     setPlateGrowthData(
         plate: number,
         times: TimeSeries,

--- a/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
+++ b/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
@@ -19,6 +19,12 @@ export default class StateBuilder {
         return this;
     }
 
+    setPhenotype(phenotype: string) {
+        if (!this.settings.project) return this;
+        this.settings = Object.assign({}, this.settings, { phenotype });
+        return this;
+    }
+
     setPlate(plate: number) {
         this.plate = { number: plate, qIndex: 0 };
         return this;

--- a/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
+++ b/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
@@ -1,24 +1,26 @@
 // @flow
 
-import type { State, TimeSeries, PlateOfTimeSeries, Plate, Settings } from './state';
+import type {
+    State, TimeSeries, PlateOfTimeSeries, Plate, Settings, QualityIndexQueue,
+} from './state';
 
 export default class StateBuilder {
     plate: Plate;
     settings: Settings;
 
     constructor() {
-        this.plate = { number: 0 };
+        this.plate = { number: 0, qIndex: 0 };
         this.settings = {};
     }
 
     setProject(project: string) {
         this.settings = { project };
-        this.plate = { number: 0 };
+        this.plate = { number: 0, qIndex: 0 };
         return this;
     }
 
     setPlate(plate: number) {
-        this.plate = { number: plate };
+        this.plate = { number: plate, qIndex: 0 };
         return this;
     }
 
@@ -36,6 +38,19 @@ export default class StateBuilder {
     ) {
         if (plate !== this.plate.number) return this;
         this.plate = Object.assign({}, this.plate, { times, raw, smooth });
+        return this;
+    }
+
+    setQualityIndexQueue(plate: number, queue: QualityIndexQueue) {
+        if (plate !== this.plate.number) return this;
+        this.plate = Object.assign({}, this.plate, { qIndexQueue: queue });
+        return this;
+    }
+
+    setQualityIndex(plate: number, index: number) {
+        if (plate !== this.plate.number) return this;
+        if (!this.plate.qIndexQueue) return this;
+        this.plate = Object.assign({}, this.plate, { qIndex: index });
         return this;
     }
 

--- a/scanomatic/ui_server_data/js/src/qc/actions.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.js
@@ -1,6 +1,6 @@
 // @flow
 import { getProject, getPlate } from './selectors';
-import type { State, TimeSeries, PlateOfTimeSeries } from './state';
+import type { State, TimeSeries, PlateOfTimeSeries, QualityIndexQueue } from './state';
 import { getPlateGrowthData } from '../api';
 
 export type Action
@@ -14,6 +14,10 @@ export type Action
         smooth: PlateOfTimeSeries,
         raw: PlateOfTimeSeries,
     |}
+    | {| type: 'QUALITYINDEX_QUEUE_SET', queue: QualityIndexQueue |}
+    | {| type: 'QUALITYINDEX_SET', index: number, plate: number |}
+    | {| type: 'QUALITYINDEX_NEXT', plate: number |}
+    | {| type: 'QUALITYINDEX_PREVIOUS', plate: number |}
 
 export function setPlate(plate : number) : Action {
     return { type: 'PLATE_SET', plate };
@@ -46,6 +50,30 @@ export function focusCurve(
     return {
         type: 'CURVE_FOCUS', plate, row, col,
     };
+}
+
+export function setQualityIndexQueue(plate: number, queue: QualityIndexQueue) : Action {
+    return {
+        type: 'QUALITYINDEX_QUEUE_SET',
+        queue,
+        plate,
+    };
+}
+
+export function setQualityIndex(plate: number, index: number): Action {
+    return {
+        type: 'QUALITYINDEX_SET',
+        index,
+        plate,
+    };
+}
+
+export function nextQualityIndex(plate: number) : Action {
+    return { type: 'QUALITYINDEX_NEXT', plate };
+}
+
+export function previousQualityIndex(plate: number) : Action {
+    return { type: 'QUALITYINDEX_PREVIOUS', plate };
 }
 
 export type ThunkAction = (dispatch: Action => any, getState: () => State) => any;

--- a/scanomatic/ui_server_data/js/src/qc/actions.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.js
@@ -18,6 +18,7 @@ export type Action
     | {| type: 'QUALITYINDEX_SET', index: number |}
     | {| type: 'QUALITYINDEX_NEXT' |}
     | {| type: 'QUALITYINDEX_PREVIOUS' |}
+    | {| type: 'PHENOTYPE_SET', phenotype: string |}
 
 export function setPlate(plate : number) : Action {
     return { type: 'PLATE_SET', plate };
@@ -25,6 +26,10 @@ export function setPlate(plate : number) : Action {
 
 export function setProject(project : string) : Action {
     return { type: 'PROJECT_SET', project };
+}
+
+export function setPhenotype(phenotype: string) : Action {
+    return { type: 'PHENOTYPE_SET', phenotype };
 }
 
 export function setPlateGrowthData(

--- a/scanomatic/ui_server_data/js/src/qc/actions.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.js
@@ -14,7 +14,7 @@ export type Action
         smooth: PlateOfTimeSeries,
         raw: PlateOfTimeSeries,
     |}
-    | {| type: 'QUALITYINDEX_QUEUE_SET', queue: QualityIndexQueue |}
+    | {| type: 'QUALITYINDEX_QUEUE_SET', plate: number, queue: QualityIndexQueue |}
     | {| type: 'QUALITYINDEX_SET', index: number, plate: number |}
     | {| type: 'QUALITYINDEX_NEXT', plate: number |}
     | {| type: 'QUALITYINDEX_PREVIOUS', plate: number |}

--- a/scanomatic/ui_server_data/js/src/qc/actions.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.spec.js
@@ -22,6 +22,15 @@ describe('/qc/actions', () => {
         });
     });
 
+    describe('setPhenotype', () => {
+        it('should return a PHENOTYPE_SET action', () => {
+            expect(actions.setProject('death rate')).toEqual({
+                type: 'PHENOTYPE_SET',
+                project: 'death rate',
+            });
+        });
+    });
+
     describe('focusCurve', () => {
         it('should return a CURVE_FOCUS action', () => {
             expect(actions.focusCurve(0, 1, 2)).toEqual({

--- a/scanomatic/ui_server_data/js/src/qc/actions.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.spec.js
@@ -24,9 +24,9 @@ describe('/qc/actions', () => {
 
     describe('setPhenotype', () => {
         it('should return a PHENOTYPE_SET action', () => {
-            expect(actions.setProject('death rate')).toEqual({
+            expect(actions.setPhenotype('death rate')).toEqual({
                 type: 'PHENOTYPE_SET',
-                project: 'death rate',
+                phenotype: 'death rate',
             });
         });
     });

--- a/scanomatic/ui_server_data/js/src/qc/actions.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.spec.js
@@ -111,4 +111,42 @@ describe('/qc/actions', () => {
             });
         });
     });
+
+    describe('quality index', () => {
+        it('setQualityIndexQueue should return a QUALITYINDEX_QUEUE_SET acation', () => {
+            const queue = [{ idx: 0, col: 4, row: 10 }, { idx: 1, col: 2, row: 55 }];
+            const plate = 1;
+            expect(actions.setQualityIndexQueue(plate, queue)).toEqual({
+                type: 'QUALITYINDEX_QUEUE_SET',
+                queue,
+                plate,
+            });
+        });
+
+        it('setQualityIndex should return a QUALITYINDEX_SET action', () => {
+            const index = 42;
+            const plate = 1;
+            expect(actions.setQualityIndex(plate, index)).toEqual({
+                type: 'QUALITYINDEX_SET',
+                index,
+                plate,
+            });
+        });
+
+        it('nextQualityIndex should return a QUALITYINDEX_NEXT action', () => {
+            const plate = 1;
+            expect(actions.nextQualityIndex(plate)).toEqual({
+                type: 'QUALITYINDEX_NEXT',
+                plate,
+            });
+        });
+
+        it('previousQualityIndex should return a QUALITYINDEX_PREVIOUS action', () => {
+            const plate = 1;
+            expect(actions.previousQualityIndex(plate)).toEqual({
+                type: 'QUALITYINDEX_PREVIOUS',
+                plate,
+            });
+        });
+    });
 });

--- a/scanomatic/ui_server_data/js/src/qc/bridge.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.js
@@ -51,9 +51,9 @@ class Selectors {
         return getFocus(state);
     }
 
-    getCurrrentQIndexInfo() : ?QualityIndexInfo {
+    getCurrrentQIndexInfo(plate: number) : ?QualityIndexInfo {
         const state = this.store.getState();
-        return getCurrrentQIndexInfo(state);
+        return getCurrrentQIndexInfo(state, plate);
     }
 }
 

--- a/scanomatic/ui_server_data/js/src/qc/bridge.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.js
@@ -1,12 +1,12 @@
 // @flow
 
 import {
-    retrievePlateCurves, setProject, setPlate,
+    retrievePlateCurves, setProject, setPlate, setPhenotype,
     setQualityIndexQueue, nextQualityIndex, previousQualityIndex, setQualityIndex,
 } from './actions';
 import {
-    getRawCurve, getSmoothCurve, getTimes, getPlate,
-    getFocus, getQIndexFromPosition,
+    getRawCurve, getSmoothCurve, getTimes, getPlate, getProject,
+    getFocus, getQIndexFromPosition, getPhenotype,
 } from './selectors';
 
 import type { Action, ThunkAction } from './actions';
@@ -25,6 +25,16 @@ class Selectors {
 
     constructor(store : Store) {
         this.store = store;
+    }
+
+    getProject() : ?string {
+        const state = this.store.getState();
+        return getProject(state);
+    }
+
+    getPhenotype() : ?string {
+        const state = this.store.getState();
+        return getPhenotype(state);
     }
 
     getRawCurve(plate: number, row : number, col : number) : ?TimeSeries {
@@ -67,6 +77,10 @@ class Actions {
 
     setProject(project: string) {
         this.store.dispatch(setProject(project));
+    }
+
+    setPhenotype(phenotype: string) {
+        this.store.dispatch(setPhenotype(phenotype));
     }
 
     setPlate(plate: number) {

--- a/scanomatic/ui_server_data/js/src/qc/bridge.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.js
@@ -73,7 +73,8 @@ class Actions {
         this.store.dispatch(setPlate(plate));
     }
 
-    setQualityIndexQueue(queue: QualityIndexQueue) {
+    setQualityIndexQueue(queue: QualityIndexQueue, plate: ?number) {
+        if (plate != null) this.setPlate(plate);
         this.store.dispatch(setQualityIndexQueue(queue));
     }
 

--- a/scanomatic/ui_server_data/js/src/qc/bridge.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.js
@@ -2,13 +2,16 @@
 
 import {
     retrievePlateCurves, setProject, setPlate, focusCurve,
+    setQualityIndexQueue, nextQualityIndex, previousQualityIndex, setQualityIndex,
 } from './actions';
 import {
-    getRawCurve, getSmoothCurve, getTimes, getPlate, getFocus,
+    getRawCurve, getSmoothCurve, getTimes, getPlate, getFocus, getCurrrentQIndexInfo,
 } from './selectors';
 
 import type { Action, ThunkAction } from './actions';
-import type { State, TimeSeries, PlatePosition } from './state';
+import type {
+    State, TimeSeries, PlatePosition, QualityIndexInfo, QualityIndexQueue,
+} from './state';
 
 type Store = {
     +dispatch: (Action | ThunkAction) => any,
@@ -47,6 +50,11 @@ class Selectors {
         const state = this.store.getState();
         return getFocus(state);
     }
+
+    getCurrrentQIndexInfo() : ?QualityIndexInfo {
+        const state = this.store.getState();
+        return getCurrrentQIndexInfo(state);
+    }
 }
 
 class Actions {
@@ -66,6 +74,22 @@ class Actions {
 
     setFocus(plate: number, row: number, col: number) {
         this.store.dispatch(focusCurve(plate, row, col));
+    }
+
+    setQualityIndexQueue(plate: number, queue: QualityIndexQueue) {
+        this.store.dispatch(setQualityIndexQueue(plate, queue));
+    }
+
+    setQualityIndex(plate: number, index: number) {
+        this.store.dispatch(setQualityIndex(plate, index));
+    }
+
+    nextQualityIndex(plate: number) {
+        this.store.dispatch(nextQualityIndex(plate));
+    }
+
+    previousQualityIndex(plate: number) {
+        this.store.dispatch(previousQualityIndex(plate));
     }
 
     retrievePlateCurves(plate: ?number = null) {

--- a/scanomatic/ui_server_data/js/src/qc/bridge.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.js
@@ -112,14 +112,18 @@ class Actions {
     }
 }
 
-export default function Bridge(store: Store) :
-{actions: Actions, selectors: Selectors, subscribe:(() => void) => void} {
-    const actions = new Actions(store);
-    const selectors = new Selectors(store);
-    const subscribe: (() => void) => void = callback => store.subscribe(callback);
-    return {
-        actions,
-        selectors,
-        subscribe,
-    };
+export default class Bridge {
+    actions: Actions;
+    selectors: Selectors;
+    store: Store;
+
+    constructor(store: Store) {
+        this.store = store;
+        this.actions = new Actions(store);
+        this.selectors = new Selectors(store);
+    }
+
+    subscribe(callback: () => void) {
+        this.store.subscribe(callback);
+    }
 }

--- a/scanomatic/ui_server_data/js/src/qc/bridge.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.js
@@ -1,17 +1,17 @@
 // @flow
 
 import {
-    retrievePlateCurves, setProject, setPlate, focusCurve,
+    retrievePlateCurves, setProject, setPlate,
     setQualityIndexQueue, nextQualityIndex, previousQualityIndex, setQualityIndex,
 } from './actions';
 import {
-    getRawCurve, getSmoothCurve, getTimes, getPlate, getFocus,
-    getCurrrentQIndexInfo, getQIndexFromPosition,
+    getRawCurve, getSmoothCurve, getTimes, getPlate,
+    getFocus, getQIndexFromPosition,
 } from './selectors';
 
 import type { Action, ThunkAction } from './actions';
 import type {
-    State, TimeSeries, PlatePosition, QualityIndexInfo, QualityIndexQueue,
+    State, TimeSeries, QualityIndexInfo, QualityIndexQueue,
 } from './state';
 
 type Store = {
@@ -47,14 +47,9 @@ class Selectors {
         return getPlate(state);
     }
 
-    getFocus() : ?PlatePosition {
+    getFocus() : ?QualityIndexInfo {
         const state = this.store.getState();
         return getFocus(state);
-    }
-
-    getCurrrentQIndexInfo() : ?QualityIndexInfo {
-        const state = this.store.getState();
-        return getCurrrentQIndexInfo(state);
     }
 
     getQIndexFromPosition(row: number, col: number) : ?number {
@@ -76,10 +71,6 @@ class Actions {
 
     setPlate(plate: number) {
         this.store.dispatch(setPlate(plate));
-    }
-
-    setFocus(plate: number, row: number, col: number) {
-        this.store.dispatch(focusCurve(plate, row, col));
     }
 
     setQualityIndexQueue(queue: QualityIndexQueue) {

--- a/scanomatic/ui_server_data/js/src/qc/bridge.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.js
@@ -97,7 +97,8 @@ class Actions {
     }
 }
 
-export default function Bridge(store: Store) {
+export default function Bridge(store: Store) :
+{actions: Actions, selectors: Selectors, subscribe:(() => void) => void} {
     const actions = new Actions(store);
     const selectors = new Selectors(store);
     const subscribe: (() => void) => void = callback => store.subscribe(callback);

--- a/scanomatic/ui_server_data/js/src/qc/bridge.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.spec.js
@@ -57,6 +57,40 @@ describe('/qc/bridge', () => {
                 plate: 2,
             });
         });
+
+        it('dispatches a QUALITYINDEX_QUEUE_SET on setQualityIndexQueue', () => {
+            bridge.actions.setQualityIndexQueue(0, [{ idx: 0, row: 0, col: 0 }]);
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'QUALITYINDEX_QUEUE_SET',
+                plate: 0,
+                queue: [{ idx: 0, row: 0, col: 0 }],
+            });
+        });
+
+        it('dispatches a QUALITYINDEX_SET on setQualityIndex', () => {
+            bridge.actions.setQualityIndex(0, 10);
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'QUALITYINDEX_SET',
+                plate: 0,
+                index: 10,
+            });
+        });
+
+        it('dispatches a QUALITYINDEX_NEXT on nextQualityIndex', () => {
+            bridge.actions.nextQualityIndex(0);
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'QUALITYINDEX_NEXT',
+                plate: 0,
+            });
+        });
+
+        it('dispatches a QUALITYINDEX_PREVIOUS on previousQualityIndex', () => {
+            bridge.actions.previousQualityIndex(0);
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'QUALITYINDEX_PREVIOUS',
+                plate: 0,
+            });
+        });
     });
 
     describe('selectors', () => {

--- a/scanomatic/ui_server_data/js/src/qc/bridge.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.spec.js
@@ -11,7 +11,7 @@ describe('/qc/bridge', () => {
         getState: jasmine.createSpy('getState').and.returnValue(state),
     };
 
-    const bridge = Bridge(store);
+    const bridge = new Bridge(store);
     let retrievePlateCurves;
 
     beforeEach(() => {
@@ -44,6 +44,14 @@ describe('/qc/bridge', () => {
             });
         });
 
+        it('dispatches a PHENOTYPE_SET on setPhenotype', () => {
+            bridge.actions.setPhenotype('test');
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'PHENOTYPE_SET',
+                phenotype: 'test',
+            });
+        });
+
         it('dispatches a retrievePlateCurves ThunkAction on retrievePlateCurves', () => {
             bridge.actions.retrievePlateCurves();
             expect(store.dispatch).toHaveBeenCalled();
@@ -72,7 +80,7 @@ describe('/qc/bridge', () => {
                 type: 'PLATE_SET',
                 plate: 2,
             });
-        })
+        });
 
         it('dispatches a QUALITYINDEX_SET on setQualityIndex', () => {
             bridge.actions.setQualityIndex(10);

--- a/scanomatic/ui_server_data/js/src/qc/bridge.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.spec.js
@@ -66,6 +66,14 @@ describe('/qc/bridge', () => {
             });
         });
 
+        it('dispatches a PLATE_SET on setQualityIndexQueue if plate supplied', () => {
+            bridge.actions.setQualityIndexQueue([{ idx: 0, row: 0, col: 0 }], 2);
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'PLATE_SET',
+                plate: 2,
+            });
+        })
+
         it('dispatches a QUALITYINDEX_SET on setQualityIndex', () => {
             bridge.actions.setQualityIndex(10);
             expect(store.dispatch).toHaveBeenCalledWith({

--- a/scanomatic/ui_server_data/js/src/qc/bridge.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/bridge.spec.js
@@ -124,18 +124,18 @@ describe('/qc/bridge', () => {
 
         it('calls getFocus on getFocus', () => {
             const getFocus = spyOn(selectors, 'getFocus')
-                .and.returnValue({ row: 41, col: 43 });
-            expect(bridge.selectors.getFocus()).toEqual({ row: 41, col: 43 });
+                .and.returnValue({ row: 41, col: 43, idx: 0 });
+            expect(bridge.selectors.getFocus()).toEqual({ row: 41, col: 43, idx: 0 });
             expect(store.getState).toHaveBeenCalled();
             expect(getFocus).toHaveBeenCalledWith(state);
         });
 
-        it('calls getCurrrentQIndexInfo on getCurrrentQIndexInfo', () => {
-            const getCurrrentQIndexInfo = spyOn(selectors, 'getCurrrentQIndexInfo')
+        it('calls getFocus on getFocus', () => {
+            const getFocus = spyOn(selectors, 'getFocus')
                 .and.returnValue({ idx: 42, row: 7, col: 8 });
-            expect(bridge.selectors.getCurrrentQIndexInfo()).toEqual({ idx: 42, row: 7, col: 8 });
+            expect(bridge.selectors.getFocus()).toEqual({ idx: 42, row: 7, col: 8 });
             expect(store.getState).toHaveBeenCalled();
-            expect(getCurrrentQIndexInfo).toHaveBeenCalledWith(state);
+            expect(getFocus).toHaveBeenCalledWith(state);
         });
 
         it('calls getQIndexFromPosition on getQIndexFromPosition', () => {

--- a/scanomatic/ui_server_data/js/src/qc/index.js
+++ b/scanomatic/ui_server_data/js/src/qc/index.js
@@ -13,6 +13,6 @@ const store = createStore(
     applyMiddleware(thunk),
 );
 
-window.qc = Bridge(store);
+window.qc = new Bridge(store);
 window.qc.subscribe(new DrawCurvesIntegration().handleUpdate);
 window.qc.subscribe(new QIndexAndSelectionIntegration(window.qc).handleUpdate);

--- a/scanomatic/ui_server_data/js/src/qc/index.js
+++ b/scanomatic/ui_server_data/js/src/qc/index.js
@@ -5,6 +5,7 @@ import reducer from './reducers';
 
 import Bridge from './bridge';
 import DrawCurvesIntegration from './DrawCurvesIntegration';
+import QIndexAndSelectionIntegration from './QIndexAndSelectionIntegration';
 
 const store = createStore(
     reducer,
@@ -14,3 +15,4 @@ const store = createStore(
 
 window.qc = Bridge(store);
 window.qc.subscribe(new DrawCurvesIntegration().handleUpdate);
+window.qc.subscribe(new QIndexAndSelectionIntegration(window.qc).handleUpdate);

--- a/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
@@ -2,7 +2,7 @@
 import type { Action } from '../actions';
 import type { Plate as State } from '../state';
 
-const initialState : State = { number: 0 };
+const initialState : State = { number: 0, qIndex: 0 };
 
 export default function plate(state: State = initialState, action: Action) {
     switch (action.type) {
@@ -10,7 +10,7 @@ export default function plate(state: State = initialState, action: Action) {
         return initialState;
     case 'PLATE_SET':
         if (action.plate === state.number) return state;
-        return { number: action.plate };
+        return { number: action.plate, qIndex: 0 };
     case 'PLATE_GROWTHDATA_SET':
         if (action.plate !== state.number) return state;
         return Object.assign(
@@ -21,6 +21,33 @@ export default function plate(state: State = initialState, action: Action) {
     case 'CURVE_FOCUS':
         if (action.plate !== state.number) return state;
         return Object.assign({}, state, { focus: { row: action.row, col: action.col } });
+    case 'QUALITYINDEX_QUEUE_SET':
+        if (action.plate !== state.number) return state;
+        return Object.assign(
+            {},
+            state,
+            { qIndexQueue: action.queue.sort((a, b) => a.idx - b.idx) },
+        );
+    case 'QUALITYINDEX_SET':
+        if (action.plate !== state.number || !state.qIndexQueue) return state;
+        return Object.assign(
+            {},
+            state,
+            { qIndex: Math.max(Math.min(action.index, state.qIndexQueue.length - 1), 0) },
+        );
+    case 'QUALITYINDEX_NEXT':
+        if (action.plate !== state.number || !state.qIndexQueue) return state;
+        return Object.assign(
+            {},
+            state,
+            { qIndex: (state.qIndex + 1) % state.qIndexQueue.length },
+        );
+    case 'QUALITYINDEX_PREVIOUS': {
+        if (action.plate !== state.number || !state.qIndexQueue) return state;
+        let next = state.qIndex - 1;
+        if (next < 0) next += state.qIndexQueue.length;
+        return Object.assign({}, state, { qIndex: next });
+    }
     default:
         return state;
     }

--- a/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/plate.js
@@ -18,9 +18,6 @@ export default function plate(state: State = initialState, action: Action) {
             state,
             { times: action.times, raw: action.raw, smooth: action.smooth },
         );
-    case 'CURVE_FOCUS':
-        if (action.plate !== state.number) return state;
-        return Object.assign({}, state, { focus: { row: action.row, col: action.col } });
     case 'QUALITYINDEX_QUEUE_SET':
         return Object.assign(
             {},

--- a/scanomatic/ui_server_data/js/src/qc/reducers/plate.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/plate.spec.js
@@ -24,32 +24,6 @@ describe('/qc/reducers/plate', () => {
         });
     });
 
-    describe('CURVE_FOCUS', () => {
-        it('sets curve focus', () => {
-            const action = {
-                type: 'CURVE_FOCUS', plate: 0, row: 1, col: 2,
-            };
-            expect(plate(undefined, action)).toEqual({
-                number: 0,
-                focus: {
-                    row: 1,
-                    col: 2,
-                },
-                qIndex: 0,
-            });
-        });
-
-        it('doesnt do a thing if wrong plate', () => {
-            const action = {
-                type: 'CURVE_FOCUS', plate: 2, row: 1, col: 2,
-            };
-            expect(plate(undefined, action)).toEqual({
-                number: 0,
-                qIndex: 0,
-            });
-        });
-    });
-
     describe('PLATE_GROWTHDATA_SET', () => {
         it('sets the plate growth data', () => {
             const times = [1, 2, 3];

--- a/scanomatic/ui_server_data/js/src/qc/reducers/plate.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/plate.spec.js
@@ -2,24 +2,25 @@ import plate from './plate';
 
 describe('/qc/reducers/plate', () => {
     it('returns the initial state', () => {
-        expect(plate(undefined, {})).toEqual({ number: 0 });
+        expect(plate(undefined, {})).toEqual({ number: 0, qIndex: 0 });
     });
 
     it('resets to initial state on PROJECT_SET', () => {
         const action = { type: 'PROJECT_SET', project: 'test.a.test' };
-        expect(plate({ number: 4 }, action)).toEqual({ number: 0 });
+        expect(plate({ number: 4 }, action)).toEqual({ number: 0, qIndex: 0 });
     });
 
     describe('PLATE_SET', () => {
         it('sets the plate number and removes curves', () => {
             const action = { type: 'PLATE_SET', plate: 3 };
-            expect(plate({ number: 2, raw: [[[1, 2]]] }, action)).toEqual({ number: 3 });
+            expect(plate({ number: 2, raw: [[[1, 2]]], qIndex: 0 }, action))
+                .toEqual({ number: 3, qIndex: 0 });
         });
 
         it('doesnt do a thing if trying to set current plate', () => {
             const action = { type: 'PLATE_SET', plate: 3 };
-            expect(plate({ number: 3, raw: [[[1, 2]]] }, action))
-                .toEqual({ number: 3, raw: [[[1, 2]]] });
+            expect(plate({ number: 3, raw: [[[1, 2]]], qIndex: 1 }, action))
+                .toEqual({ number: 3, raw: [[[1, 2]]], qIndex: 1 });
         });
     });
 
@@ -34,6 +35,7 @@ describe('/qc/reducers/plate', () => {
                     row: 1,
                     col: 2,
                 },
+                qIndex: 0,
             });
         });
 
@@ -43,6 +45,7 @@ describe('/qc/reducers/plate', () => {
             };
             expect(plate(undefined, action)).toEqual({
                 number: 0,
+                qIndex: 0,
             });
         });
     });
@@ -64,6 +67,7 @@ describe('/qc/reducers/plate', () => {
                 times,
                 raw,
                 smooth,
+                qIndex: 0,
             });
         });
 
@@ -78,8 +82,120 @@ describe('/qc/reducers/plate', () => {
                 smooth,
                 plate: 0,
             };
-            expect(plate({ number: 3 }, action)).toEqual({
+            expect(plate({ number: 3, qIndex: 2 }, action)).toEqual({
                 number: 3,
+                qIndex: 2,
+            });
+        });
+    });
+
+    describe('QUALITYINDEX_QUEUE_SET', () => {
+        const queue = [{ idx: 1, col: 4, row: 10 }, { idx: 0, col: 2, row: 55 }];
+
+        it('doesnt set for wrong plate', () => {
+            const action = { type: 'QUALITYINDEX_QUEUE_SET', queue, plate: 42 };
+            expect(plate(undefined, action)).toEqual({
+                number: 0,
+                qIndex: 0,
+            });
+        });
+
+        it('sets an index-sorted queue', () => {
+            const action = { type: 'QUALITYINDEX_QUEUE_SET', queue, plate: 2 };
+            expect(plate({ number: 2, qIndex: 0 }, action)).toEqual({
+                number: 2,
+                qIndex: 0,
+                qIndexQueue: [
+                    { idx: 0, col: 2, row: 55 },
+                    { idx: 1, col: 4, row: 10 },
+                ],
+            });
+        });
+    });
+
+    describe('qIndex', () => {
+        const state = {
+            number: 0,
+            qIndex: 1,
+            qIndexQueue: [
+                { idx: 0, col: 1, row: 1 },
+                { idx: 1, col: 0, row: 1 },
+                { idx: 2, col: 1, row: 0 },
+                { idx: 3, col: 0, row: 0 },
+            ],
+        };
+
+        describe('QUALITYINDEX_SET', () => {
+            it('doesnt set for wrong plate', () => {
+                const action = { type: 'QUALITYINDEX_SET', plate: 2, index: 42 };
+                expect(plate(state, action)).toEqual(state);
+            });
+
+            it('doesnt set when missing queue', () => {
+                const action = { type: 'QUALITYINDEX_SET', plate: 0, index: 42 };
+                expect(plate(Object.assign({}, state, { qIndexQueue: null }).qIndex, action))
+                    .toEqual(1);
+            });
+
+            it('sets new index', () => {
+                const action = { type: 'QUALITYINDEX_SET', plate: 0, index: 2 };
+                expect(plate(state, action).qIndex).toEqual(2);
+            });
+
+            it('limits max to last in queue', () => {
+                const action = { type: 'QUALITYINDEX_SET', plate: 0, index: 42 };
+                expect(plate(state, action).qIndex).toEqual(3);
+            });
+
+            it('limits min to first in queue', () => {
+                const action = { type: 'QUALITYINDEX_SET', plate: 0, index: -42 };
+                expect(plate(state, action).qIndex).toEqual(0);
+            });
+        });
+
+        describe('QUALITYINDEX_NEXT', () => {
+            it('doesnt set for wrong plate', () => {
+                const action = { type: 'QUALITYINDEX_NEXT', plate: 2 };
+                expect(plate(state, action)).toEqual(state);
+            });
+
+            it('doesnt set when missing queue', () => {
+                const action = { type: 'QUALITYINDEX_NEXT', plate: 0 };
+                expect(plate(Object.assign({}, state, { qIndexQueue: null }).qIndex, action))
+                    .toEqual(1);
+            });
+
+            it('sets next index', () => {
+                const action = { type: 'QUALITYINDEX_NEXT', plate: 0 };
+                expect(plate(state, action).qIndex).toEqual(2);
+            });
+
+            it('wraps around to first', () => {
+                const action = { type: 'QUALITYINDEX_NEXT', plate: 0 };
+                expect(plate(Object.assign({}, state, { qIndex: 3 }), action).qIndex).toEqual(0);
+            });
+        });
+
+        describe('QUALITYINDEX_PREVIOUS', () => {
+            it('doesnt set for wrong plate', () => {
+                const action = { type: 'QUALITYINDEX_PREVIOUS', plate: 2 };
+                expect(plate(state, action)).toEqual(state);
+            });
+
+            it('doesnt set when missing queue', () => {
+                const action = { type: 'QUALITYINDEX_PREVIOUS', plate: 0 };
+                expect(plate(Object.assign({}, state, { qIndexQueue: null }).qIndex, action))
+                    .toEqual(1);
+            });
+
+            it('sets previous index', () => {
+                const action = { type: 'QUALITYINDEX_PREVIOUS', plate: 0 };
+                expect(plate(state, action).qIndex).toEqual(0);
+            });
+
+            it('wraps around to last', () => {
+                const action = { type: 'QUALITYINDEX_PREVIOUS', plate: 0 };
+                expect(plate(Object.assign({}, state, { qIndex: 0 }), action).qIndex).toEqual(3);
             });
         });
     });

--- a/scanomatic/ui_server_data/js/src/qc/reducers/settings.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/settings.js
@@ -8,6 +8,8 @@ export default function settings(state: State = initialState, action: Action) {
     switch (action.type) {
     case 'PROJECT_SET':
         return { project: action.project };
+    case 'PHENOTYPE_SET':
+        return Object.assign({}, state, { phenotype: action.phenotype });
     default:
         return state;
     }

--- a/scanomatic/ui_server_data/js/src/qc/reducers/settings.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/settings.spec.js
@@ -10,4 +10,12 @@ describe('/qc/reducers/settings', () => {
         const action = { type: 'PROJECT_SET', project: 'my/path/to/somewhere' };
         expect(settings(undefined, action)).toEqual({ project: action.project });
     });
+
+    it('handles PHENOTYPE_SET', () => {
+        const action = { type: 'PHENOTYPE_SET', phenotype: 'yield' };
+        expect(settings({ project: '/my/proj' }, action)).toEqual({
+            project: '/my/proj',
+            phenotype: 'yield',
+        });
+    });
 });

--- a/scanomatic/ui_server_data/js/src/qc/selectors.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.js
@@ -4,11 +4,9 @@ import type {
     State,
     QualityIndexInfo,
     TimeSeries as _TimeSeries,
-    PlatePosition as _PlatePosition,
 } from './state';
 
 export type TimeSeries = _TimeSeries;
-export type PlatePosition = _PlatePosition;
 
 export function getProject(state: State): ?string {
     if (!state.settings) return null;
@@ -40,12 +38,7 @@ export function getSmoothCurve(state: State, plate: number, row: number, col: nu
     return smooth[row][col];
 }
 
-export function getFocus(state: State) : ?PlatePosition {
-    if (!state.plate || !state.plate.focus) return null;
-    return state.plate.focus;
-}
-
-export function getCurrrentQIndexInfo(state: State) : ?QualityIndexInfo {
+export function getFocus(state: State) : ?QualityIndexInfo {
     if (!state.plate || !state.plate.qIndexQueue) return null;
     return state.plate.qIndexQueue[state.plate.qIndex];
 }

--- a/scanomatic/ui_server_data/js/src/qc/selectors.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.js
@@ -2,6 +2,7 @@
 
 import type {
     State,
+    QualityIndexInfo,
     TimeSeries as _TimeSeries,
     PlatePosition as _PlatePosition,
 } from './state';
@@ -42,4 +43,9 @@ export function getSmoothCurve(state: State, plate: number, row: number, col: nu
 export function getFocus(state: State) : ?PlatePosition {
     if (!state.plate || !state.plate.focus) return null;
     return state.plate.focus;
+}
+
+export function getCurrrentQIndexInfo(state: State, plate: number) : ?QualityIndexInfo {
+    if (!state.plate || state.plate.number !== plate || !state.plate.qIndexQueue) return null;
+    return state.plate.qIndexQueue[state.plate.qIndex];
 }

--- a/scanomatic/ui_server_data/js/src/qc/selectors.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.js
@@ -13,6 +13,11 @@ export function getProject(state: State): ?string {
     return state.settings.project;
 }
 
+export function getPhenotype(state: State): ?string {
+    if (!state.settings) return null;
+    return state.settings.phenotype;
+}
+
 export function getPlate(state: State): ?number {
     if (!state.plate) return null;
     return state.plate.number;

--- a/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
@@ -12,18 +12,6 @@ describe('/qc/selectors', () => {
         expect(selectors.getPlate(state)).toEqual(2);
     });
 
-    describe('focus', () => {
-        it('should return null if no focus', () => {
-            const state = new StateBuilder().build();
-            expect(selectors.getFocus(state)).toEqual(null);
-        });
-
-        it('should return the focused curve', () => {
-            const state = new StateBuilder().setFocus(0, 2, 1).build();
-            expect(selectors.getFocus(state)).toEqual({ row: 2, col: 1 });
-        });
-    });
-
     describe('raw data', () => {
         it('should return null if curve is on wrong plate', () => {
             const state = new StateBuilder().build();
@@ -100,7 +88,7 @@ describe('/qc/selectors', () => {
         });
     });
 
-    describe('getCurrrentQIndexInfo', () => {
+    describe('getFocus', () => {
         const queue = [
             { idx: 0, col: 1, row: 1 },
             { idx: 1, col: 0, row: 1 },
@@ -110,7 +98,7 @@ describe('/qc/selectors', () => {
 
         it('should return null if no queue', () => {
             const state = new StateBuilder().build();
-            expect(selectors.getCurrrentQIndexInfo(state)).toBe(null);
+            expect(selectors.getFocus(state)).toBe(null);
         });
 
         it('should return current index info', () => {
@@ -118,7 +106,7 @@ describe('/qc/selectors', () => {
                 .setQualityIndexQueue(queue)
                 .setQualityIndex(1)
                 .build();
-            expect(selectors.getCurrrentQIndexInfo(state)).toEqual({
+            expect(selectors.getFocus(state)).toEqual({
                 idx: 1,
                 col: 0,
                 row: 1,

--- a/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
@@ -99,4 +99,37 @@ describe('/qc/selectors', () => {
             expect(selectors.getTimes(state, 1)).toEqual(null);
         });
     });
+
+    describe('getCurrrentQIndexInfo', () => {
+        const queue = [
+            { idx: 0, col: 1, row: 1 },
+            { idx: 1, col: 0, row: 1 },
+            { idx: 2, col: 1, row: 0 },
+            { idx: 3, col: 0, row: 0 },
+        ];
+
+        it('should return null if no queue', () => {
+            const state = new StateBuilder().build();
+            expect(selectors.getCurrrentQIndexInfo(state, 0)).toBe(null);
+        });
+
+        it('should return null if requesting for wrong plate', () => {
+            const state = new StateBuilder()
+                .setQualityIndexQueue(0, queue)
+                .build();
+            expect(selectors.getCurrrentQIndexInfo(state, 1)).toBe(null);
+        });
+
+        it('should return current index info', () => {
+            const state = new StateBuilder()
+                .setQualityIndexQueue(0, queue)
+                .setQualityIndex(0, 1)
+                .build();
+            expect(selectors.getCurrrentQIndexInfo(state, 0)).toEqual({
+                idx: 1,
+                col: 0,
+                row: 1,
+            });
+        });
+    });
 });

--- a/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
@@ -7,6 +7,14 @@ describe('/qc/selectors', () => {
         expect(selectors.getProject(state)).toEqual('/my/path');
     });
 
+    it('should get phenotype', () => {
+        const state = new StateBuilder()
+            .setProject('/my/path')
+            .setPhenotype('test')
+            .build();
+        expect(selectors.getPhenotype(state)).toEqual('test');
+    });
+
     it('should get the plate number', () => {
         const state = new StateBuilder().setPlate(2).build();
         expect(selectors.getPlate(state)).toEqual(2);

--- a/scanomatic/ui_server_data/js/src/qc/state.js
+++ b/scanomatic/ui_server_data/js/src/qc/state.js
@@ -13,7 +13,8 @@ export type QualityIndexQueue = Array<QualityIndexInfo>;
 
 export type Settings = {
     +project?: string,
-}
+    +phenotype?: string,
+};
 
 export type Plate = {
     +number: number,
@@ -22,7 +23,7 @@ export type Plate = {
     +raw?: PlateOfTimeSeries,
     +smooth?: PlateOfTimeSeries,
     +times?: TimeSeries,
-}
+};
 
 export type State = {
     +settings: Settings,

--- a/scanomatic/ui_server_data/js/src/qc/state.js
+++ b/scanomatic/ui_server_data/js/src/qc/state.js
@@ -3,6 +3,14 @@ export type TimeSeries = Array<number>;
 
 export type PlateOfTimeSeries = Array<Array<TimeSeries>>;
 
+export type QualityIndexInfo = {
+    +idx: number,
+    +col: number,
+    +row: number,
+};
+
+export type QualityIndexQueue = Array<QualityIndexInfo>;
+
 export type Settings = {
     +project?: string,
 }
@@ -14,6 +22,8 @@ export type PlatePosition = {
 
 export type Plate = {
     +number: number,
+    +qIndex: number,
+    +qIndexQueue?: QualityIndexQueue,
     +raw?: PlateOfTimeSeries,
     +smooth?: PlateOfTimeSeries,
     +times?: TimeSeries,

--- a/scanomatic/ui_server_data/js/src/qc/state.js
+++ b/scanomatic/ui_server_data/js/src/qc/state.js
@@ -15,11 +15,6 @@ export type Settings = {
     +project?: string,
 }
 
-export type PlatePosition = {
-    +row: number,
-    +col: number,
-}
-
 export type Plate = {
     +number: number,
     +qIndex: number,
@@ -27,7 +22,6 @@ export type Plate = {
     +raw?: PlateOfTimeSeries,
     +smooth?: PlateOfTimeSeries,
     +times?: TimeSeries,
-    +focus?: PlatePosition,
 }
 
 export type State = {

--- a/scanomatic/ui_server_data/style/qc_norm.css
+++ b/scanomatic/ui_server_data/style/qc_norm.css
@@ -1,7 +1,7 @@
 /* Data Selection*/
-.SelectedExperiment {
+.selected-experiment {
     stroke: black;
-    stroke-width:2
+    stroke-width: 3;
 }
 
 .loProjectSelection,

--- a/tests/system/test_qcnorm.py
+++ b/tests/system/test_qcnorm.py
@@ -134,9 +134,6 @@ class ProjectDetails(object):
 
 
 class PlateDisplayArea(object):
-    mark_experiments_toggle_selector = (
-        By.CSS_SELECTOR, '.mark-experiments-toggle',
-    )
     mark_states_action_group_selector = (
         By.CSS_SELECTOR, '.mark-experiments-action-group',
     )
@@ -155,15 +152,6 @@ class PlateDisplayArea(object):
     def has_marking_enabled(self):
         return self.elem.find_element(
             *self.mark_states_action_group_selector).is_displayed()
-
-    def toggle_mark_experiments(self):
-        span = self.elem.find_element(*self.mark_experiments_toggle_selector)
-        span.find_element(By.CSS_SELECTOR, '.toggle').click()
-
-    def show_mark_experiments(self):
-        self.toggle_mark_experiments()
-        while not self.has_marking_enabled:
-            self.toggle_mark_experiments()
 
     def mark_selected_curve(self, mark):
         id = ''
@@ -435,7 +423,6 @@ class TestQCNormCurveMarking:
     def test_marking_ok_this_only_ok_current_phenotype(self, page_with_plate):
         pos = (5, 10)
         plate = page_with_plate.get_plate_display_area()
-        plate.show_mark_experiments()
         position = plate.get_plate_position(*pos)
         assert position.mark == CurveMark.OK
 


### PR DESCRIPTION
This moves the control over what position/curve is focused/shown entirely into the redux store. In there it is entirely driven by the selected quality index.

I've mostly relied on the unit-tests of the store and bridge code and the system tests that existed. They cover the vast majority of functionality that is touched by this PR. There are some details like validating which position on the heatmap gets that circle mark at each time as well as the grid images thing. I opted to not extend them for this PR as it is rather huge. I can add them though, but it might be better to add them in their own PR in that case?