### PR TITLE
Qindex input box

### DIFF
--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -141,7 +141,7 @@
                   markExperiment(plateMetaDataType.NoGrowth, true);
               });
               $("#btnQidxReset").click(function () {
-                  window.qc.actions.setQualityIndex(0);
+                  window.qc.actions.setQualityIndex($("#qIndexCurrent").val() - 1);
               });
               $("#btnQidxNext").click(function () {
                   window.qc.actions.nextQualityIndex();
@@ -167,28 +167,12 @@
                       case 'r':
                           markExperiment(plateMetaDataType.NoGrowth, true);
                           break;
-                      case '1':
-                          $("#btnPlate0").focus();
-                          document.getElementById("btnPlate0").click();
-                          break;
-                      case '2':
-                          $("#btnPlate1").focus();
-                          document.getElementById("btnPlate1").click();
-                          break;
-                      case '3':
-                          $("#btnPlate2").focus();
-                          document.getElementById("btnPlate2").click();
-                          break;
-                      case '4':
-                          $("#btnPlate3").focus();
-                          document.getElementById("btnPlate3").click();
-                          break;
                   }
               });
               $(document).keydown(function (e) {
                   switch (e.which) {
-                      case 36: // home
-                          window.qc.actions.setQualityIndex(0);
+                      case 13: // enter
+                          window.qc.actions.setQualityIndex($("#qIndexCurrent").val() - 1);
                           break;
                       case 37: // left
                       case 40: // down
@@ -335,13 +319,13 @@
                           <button id="btnMarkBad" class="markButton vcenter" title="Mark all phenotypes as Bad [hotkey: w]"></button>
                           <button id="btnMarkEmpty" class="markButton vcenter" title="Mark all phenotypes as Empty [hotkey: e]"></button>
                           <button id="btnMarkNoGrowth" class="markButton vcenter" title="Mark all phenotypes as NoGrowth [hotkey: r]"></button>
-                          <button id="btnQidxReset" style="margin-left:10px" class="btn btn-default btn-xs" title="Go to first Qidx [hotkey: <home>]">
-                              <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
-                          </button>
                           <button id="btnQidxPrev" class="btn btn-default btn-xs" title="Back in Qidx position [hotkey: <left>/<down>]">
                               <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
                           </button>
-                          <span id="qIndexCurrent"></span>
+                          <input type="number" id="qIndexCurrent" name="qIndexCurrent" value=1 />
+                          <button id="btnQidxReset" class="btn btn-default btn-xs" title="Go to specified Qidx [hotkey: <enter>]">
+                              Go
+                          </button>
                           <button id="btnQidxNext" class="btn btn-default btn-xs" title="Next in Qidx position [hotkey: <right>/<up>]">
                               <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span>
                           </button>

--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -140,7 +140,7 @@
               $("#btnMarkNoGrowth").click(function () {
                   markExperiment(plateMetaDataType.NoGrowth, true);
               });
-              $("#btnQidxReset").click(function () {
+              $("#btnQidxSet").click(function () {
                   window.qc.actions.setQualityIndex($("#qIndexCurrent").val() - 1);
               });
               $("#btnQidxNext").click(function () {
@@ -323,8 +323,8 @@
                               <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
                           </button>
                           <input type="number" id="qIndexCurrent" name="qIndexCurrent" value=1 />
-                          <button id="btnQidxReset" class="btn btn-default btn-xs" title="Go to specified Qidx [hotkey: <enter>]">
-                              Go
+                          <button id="btnQidxSet" class="btn btn-default btn-xs" title="Go to specified Qidx [hotkey: <enter>]">
+                              Set
                           </button>
                           <button id="btnQidxNext" class="btn btn-default btn-xs" title="Next in Qidx position [hotkey: <right>/<up>]">
                               <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span>

--- a/scanomatic/ui_server/templates/qc_norm.html
+++ b/scanomatic/ui_server/templates/qc_norm.html
@@ -322,7 +322,7 @@
                           <button id="btnQidxPrev" class="btn btn-default btn-xs" title="Back in Qidx position [hotkey: <left>/<down>]">
                               <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
                           </button>
-                          <input type="number" id="qIndexCurrent" name="qIndexCurrent" value=1 />
+                          <input type="number" class="no-spin" id="qIndexCurrent" name="qIndexCurrent" value=1 />
                           <button id="btnQidxSet" class="btn btn-default btn-xs" title="Go to specified Qidx [hotkey: <enter>]">
                               Set
                           </button>

--- a/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
+++ b/scanomatic/ui_server_data/js/src/qc/QIndexAndSelectionIntegration.js
@@ -24,6 +24,6 @@ export default class QIndexAndSelectionIntegration {
 
         $('.selected-experiment').removeClass('selected-experiment');
         $(`#id${focus.row}_${focus.col}`).addClass('selected-experiment');
-        $('#qIndexCurrent').text(focus.idx + 1);
+        $('#qIndexCurrent').val(focus.idx + 1);
     }
 }

--- a/scanomatic/ui_server_data/style/qc_norm.css
+++ b/scanomatic/ui_server_data/style/qc_norm.css
@@ -223,9 +223,9 @@ body > .modal {
 }
 
 .no-spin, .no-spin:hover, no-spin:focus {
-    -webkit-appearance: none !important;
-    margin: 0 !important;
-    -moz-appearance:textfield !important;
+    -webkit-appearance: none;
+    margin: 0;
+    -moz-appearance:textfield;
 }
 
 #qIndexCurrent {

--- a/scanomatic/ui_server_data/style/qc_norm.css
+++ b/scanomatic/ui_server_data/style/qc_norm.css
@@ -225,7 +225,7 @@ body > .modal {
 #qIndexCurrent {
     width: 5em;
     display: inline-block;
-    border: 0px;
+    border: 0;
     text-align: center;
     font-size: 12px;
     color: #000;

--- a/scanomatic/ui_server_data/style/qc_norm.css
+++ b/scanomatic/ui_server_data/style/qc_norm.css
@@ -222,6 +222,12 @@ body > .modal {
     right: 0px;
 }
 
+.no-spin, .no-spin:hover, no-spin:focus {
+    -webkit-appearance: none !important;
+    margin: 0 !important;
+    -moz-appearance:textfield !important;
+}
+
 #qIndexCurrent {
     width: 5em;
     display: inline-block;

--- a/scanomatic/ui_server_data/style/qc_norm.css
+++ b/scanomatic/ui_server_data/style/qc_norm.css
@@ -223,8 +223,10 @@ body > .modal {
 }
 
 #qIndexCurrent {
-    width: 4em;
+    width: 5em;
     display: inline-block;
-    border: 1px solid;
+    border: 0px;
     text-align: center;
+    font-size: 12px;
+    color: #000;
 }

--- a/tests/system/test_qcnorm.py
+++ b/tests/system/test_qcnorm.py
@@ -506,3 +506,8 @@ class TestQCNormNavigateQidx:
         plate.set_qindex_input("1764")
         plate.update_qindex(Navigations.SET)
         assert plate.get_qindex() == "1536"
+
+        # Trying to set to non-number defaults to first index:
+        plate.set_qindex_input("foo")
+        plate.update_qindex(Navigations.SET)
+        assert plate.get_qindex() == "1"

--- a/tests/system/test_qcnorm.py
+++ b/tests/system/test_qcnorm.py
@@ -12,7 +12,7 @@ from selenium.webdriver.support.ui import Select, WebDriverWait
 UI_DEFAULT_WAIT = 20
 
 CurveMark = Enum('CurveMark', ['OK', 'OK_THIS', 'BAD', 'EMPTY', 'NO_GROWTH'])
-Navigations = Enum('Navigations', ['NEXT', 'PREV', 'RESET'])
+Navigations = Enum('Navigations', ['NEXT', 'PREV', 'SET'])
 
 
 class AnalysisNotFoundError(Exception):
@@ -183,7 +183,9 @@ class PlateDisplayArea(object):
 
     def get_qindex(self):
         id = "#qIndexCurrent"
-        return self.elem.find_element(By.CSS_SELECTOR, id).text
+        return (
+            self.elem.find_element(By.CSS_SELECTOR, id).get_attribute("value")
+        )
 
     def update_qindex(self, operation):
         id = ''
@@ -191,12 +193,19 @@ class PlateDisplayArea(object):
             id = '#btnQidxNext'
         elif operation == Navigations.PREV:
             id = '#btnQidxPrev'
-        elif operation == Navigations.RESET:
-            id = '#btnQidxReset'
+        elif operation == Navigations.SET:
+            id = '#btnQidxSet'
 
         graph = self.get_graph()
         self.elem.find_element(By.CSS_SELECTOR, id).click()
         graph.wait_until_graph_is_updated()
+
+    def set_qindex_input(self, keystrokes):
+        id = '#qIndexCurrent'
+        graph = self.get_graph()
+        elem = self.elem.find_element(By.CSS_SELECTOR, id)
+        elem.clear()
+        elem.send_keys(keystrokes)
 
     def get_graph(self):
         return Graph(self)
@@ -467,13 +476,6 @@ class TestQCNormNavigateQidx:
         assert plate.get_qindex() == "1"
         assert plate.get_graph() == graph_for_qindex1
 
-        # Pressing reset goes back to first index:
-        plate.update_qindex(Navigations.NEXT)
-        plate.update_qindex(Navigations.NEXT)
-        assert plate.get_qindex() == "3"
-        plate.update_qindex(Navigations.RESET)
-        assert plate.get_qindex() == "1"
-
         # Changing plate resets index:
         plate.update_qindex(Navigations.NEXT)
         assert plate.get_qindex() == "2"
@@ -489,3 +491,19 @@ class TestQCNormNavigateQidx:
         plate_position.click()
         assert plate.get_qindex() == "42"
         assert graph_plate_3 != plate.get_graph()
+
+        # Pressing set goes back to specified index:
+        plate.set_qindex_input("1")
+        plate.update_qindex(Navigations.SET)
+        assert plate.get_qindex() == "1"
+        plate.update_qindex(Navigations.NEXT)
+        assert plate.get_qindex() == "2"
+
+        # Pressing set outside bounds goes to max or min:
+        plate.set_qindex_input("-42")
+        plate.update_qindex(Navigations.SET)
+        assert plate.get_qindex() == "1"
+
+        plate.set_qindex_input("1764")
+        plate.update_qindex(Navigations.SET)
+        assert plate.get_qindex() == "1536"

--- a/tests/system/test_qcnorm.py
+++ b/tests/system/test_qcnorm.py
@@ -202,7 +202,6 @@ class PlateDisplayArea(object):
 
     def set_qindex_input(self, keystrokes):
         id = '#qIndexCurrent'
-        graph = self.get_graph()
         elem = self.elem.find_element(By.CSS_SELECTOR, id)
         elem.clear()
         elem.send_keys(keystrokes)


### PR DESCRIPTION
Replaced panel showing current qindex with an input box, and re-purposed the reset-button as a set-button.

Since the "hot keys" for switching plates interfered with using the input in a natural way, I removed those.

![qindex_input](https://user-images.githubusercontent.com/358614/42379985-ad19ff9c-812c-11e8-8339-039b1e868c80.png)
