### PR TITLE
Qc, Show Normalized state [builds upone #416]

### DIFF
--- a/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
+++ b/scanomatic/ui_server_data/js/src/qc/StateBuilder.js
@@ -11,12 +11,17 @@ export default class StateBuilder {
 
     constructor() {
         this.plate = { number: 0, qIndex: 0 };
-        this.settings = {};
+        this.settings = { showNormalized: false };
     }
 
     setProject(project: string) {
-        this.settings = { project };
+        this.settings = { project, showNormalized: false };
         this.plate = { number: 0, qIndex: 0 };
+        return this;
+    }
+
+    setShowNormalized(value: bool) {
+        this.settings = Object.assign({}, this.settings, { showNormalized: value });
         return this;
     }
 

--- a/scanomatic/ui_server_data/js/src/qc/actions.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.js
@@ -48,6 +48,10 @@ export type Action
         row: number,
         col: number,
     |}
+    | {|
+        +type: 'SHOWNORMALIZED_SET',
+        +value: bool,
+    |}
 
 export function setPlate(plate : number) : Action {
     return { type: 'PLATE_SET', plate };
@@ -59,6 +63,10 @@ export function setProject(project : string) : Action {
 
 export function setPhenotype(phenotype: Phenotype) : Action {
     return { type: 'PHENOTYPE_SET', phenotype };
+}
+
+export function setShowNormalized(value: bool) : Action {
+    return { type: 'SHOWNORMALIZED_SET', value };
 }
 
 export function setPlateGrowthData(

--- a/scanomatic/ui_server_data/js/src/qc/actions.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/actions.spec.js
@@ -31,6 +31,10 @@ describe('/qc/actions', () => {
         });
     });
 
+    describe('setShowNormalized', () => {
+
+    });
+
     describe('setPlatePhenotypeData', () => {
         it('should return a PLATE_PHENOTYPEDATA_SET action', () => {
             expect(actions.setPlatePhenotypeData(

--- a/scanomatic/ui_server_data/js/src/qc/reducers/settings.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/settings.js
@@ -2,7 +2,7 @@
 import type { Action } from '../actions';
 import type { Settings as State } from '../state';
 
-const initialState : State = {};
+const initialState : State = { showNormalized: false };
 
 export default function settings(state: State = initialState, action: Action) {
     switch (action.type) {
@@ -10,6 +10,8 @@ export default function settings(state: State = initialState, action: Action) {
         return { project: action.project };
     case 'PHENOTYPE_SET':
         return Object.assign({}, state, { phenotype: action.phenotype });
+    case 'SHOWNORMALIZED_SET':
+        return Object.assign({}, state, { showNormalized: action.value });
     default:
         return state;
     }

--- a/scanomatic/ui_server_data/js/src/qc/reducers/settings.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/settings.js
@@ -7,7 +7,7 @@ const initialState : State = { showNormalized: false };
 export default function settings(state: State = initialState, action: Action) {
     switch (action.type) {
     case 'PROJECT_SET':
-        return { project: action.project };
+        return { project: action.project, showNormalized: false };
     case 'PHENOTYPE_SET':
         return Object.assign({}, state, { phenotype: action.phenotype });
     case 'SHOWNORMALIZED_SET':

--- a/scanomatic/ui_server_data/js/src/qc/reducers/settings.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/reducers/settings.spec.js
@@ -3,12 +3,21 @@ import settings from './settings';
 describe('/qc/reducers/settings', () => {
     it('returns the initial state', () => {
         const action = {};
-        expect(settings(undefined, action)).toEqual({});
+        expect(settings(undefined, action)).toEqual({ showNormalized: false });
     });
 
-    it('handles PROJECT_SET', () => {
-        const action = { type: 'PROJECT_SET', project: 'my/path/to/somewhere' };
-        expect(settings(undefined, action)).toEqual({ project: action.project });
+    describe('PROJECT_SET', () => {
+        it('handles PROJECT_SET', () => {
+            const action = { type: 'PROJECT_SET', project: 'my/path/to/somewhere' };
+            expect(settings(undefined, action))
+                .toEqual({ project: action.project, showNormalized: false });
+        });
+
+        it('sets showNormalized to false', () => {
+            const action = { type: 'PROJECT_SET', project: 'my/path/to/somewhere' };
+            expect(settings({ project: 'my/other/project', showNormalized: true }, action))
+                .toEqual({ project: action.project, showNormalized: false });
+        });
     });
 
     it('handles PHENOTYPE_SET', () => {
@@ -17,5 +26,11 @@ describe('/qc/reducers/settings', () => {
             project: '/my/proj',
             phenotype: 'yield',
         });
+    });
+
+    it('handles SHOWNORMALIZED_SET', () => {
+        const action = { type: 'SHOWNORMALIZED_SET', value: true };
+        expect(settings({ showNormalized: false }, action))
+            .toEqual({ showNormalized: true });
     });
 });

--- a/scanomatic/ui_server_data/js/src/qc/selectors.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.js
@@ -120,3 +120,8 @@ export function isDirty(state: State, plate: number, row: number, col: number) :
     return state.plate.dirty
         .some(([dirtyRow, dirtyCol]) => dirtyRow === row && dirtyCol === col);
 }
+
+export function getShowNormalized(state: State) : bool {
+    if (!state.settings) return false;
+    return state.settings.showNormalized;
+}

--- a/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
+++ b/scanomatic/ui_server_data/js/src/qc/selectors.spec.js
@@ -378,4 +378,20 @@ describe('/qc/selectors', () => {
             expect(selectors.isDirty(state, 0, 0, 10)).toBe(false);
         });
     });
+
+    describe('getShowNormalized', () => {
+        it('returns default status false', () => {
+            const state = new StateBuilder()
+                .build();
+            expect(selectors.getShowNormalized(state)).toBe(false);
+        });
+
+        it('returns current value', () => {
+            const state = new StateBuilder()
+                .setProject('my/experiment')
+                .setShowNormalized(true)
+                .build();
+            expect(selectors.getShowNormalized(state)).toBe(true);
+        });
+    });
 });

--- a/scanomatic/ui_server_data/js/src/qc/state.js
+++ b/scanomatic/ui_server_data/js/src/qc/state.js
@@ -30,6 +30,7 @@ export type Phenotype = "GenerationTime"
 
 
 export type Settings = {
+    +showNormalized: bool,
     +project?: string,
     +phenotype?: Phenotype,
 };


### PR DESCRIPTION
This introduces the toggle state between showing phenotypes and normalized phenotypes into the store. To keep merge small, that's it.

Coming soon is storing retrieving normalized phenotypes from the API and extending the store to deal with both types of phenotypes.

It builds upon #416